### PR TITLE
Add Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest a feature for the Coalition Reforger Framework
+title: "[CRF Feature]"
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/genberal-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/genberal-bug-report.md
@@ -1,0 +1,30 @@
+---
+name: Genberal Bug report
+about: Report a general bug in the Coalition Reforger Framework
+title: "[CRF General Bug]"
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Device (please complete the following information):**
+- Type: [e.g. PC, Console, etc.]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/loadout-problem.md
+++ b/.github/ISSUE_TEMPLATE/loadout-problem.md
@@ -1,0 +1,23 @@
+---
+name: Loadout Problem
+about: Report a problem in one of our Loadouts
+title: "[Loadout Bug]"
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**What Faction**
+US/USSR/BW/etc.
+
+**What Loadout/Role**
+SL/TL/Rifleman/etc.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/mission-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/mission-bug-report.md
@@ -1,0 +1,23 @@
+---
+name: Mission bug report
+about: Report a bug/problem in one of our missions
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**What mission**
+e.g. CRF_Pie_TVT130_Container_Search or just 'The Container Search mission from last friday', or any alternative information pointing to the mission
+
+**Experienced Problem**
+A clear and concise description of the problem you experienced.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
This PR adds the following issue templates:
- General Bug Report
-> For any general problems or bugs that arent covered by other templates
-Feature request
->A template for people to request features
-Loadout Problem
-> A template to be used to report problems with loadouts/factions/groups/etc.
-Mission bug report
-> A template to be used to report problems with missions