### PR TITLE
Re-enable working vehicles in Misty Mudflats mission

### DIFF
--- a/Worlds/Lobby/Mussalo/MistyMudflats_Layers/BLUFOR.layer
+++ b/Worlds/Lobby/Mussalo/MistyMudflats_Layers/BLUFOR.layer
@@ -7,17 +7,14 @@ $grp Vehicle : "{3EA6F47D95867114}Prefabs/Vehicles/Wheeled/M998/M1025_armed_M2HB
  M1025_M2HB_1A {
   coords 893.805 3.063 6413.614
   angleY -90
-  Flags 2097155
  }
  M1025_M2HB_3A {
   coords 893.805 3.063 6433.612
   angleY -90
-  Flags 2097155
  }
  M1025_M2HB_2A {
   coords 893.805 3.063 6423.612
   angleY -90
-  Flags 2097155
  }
 }
 $grp SCR_AIGroup : "{3EDD55795C91213A}Prefabs/Groups/BLUFOR/RHS_USAF_USMC/Infantry/CRF_USMC_RifleSquad2020.et" {
@@ -69,40 +66,60 @@ SCR_AIGroup USMC_PlatoonHQ_0 : "{62990CF36C70D69A}Prefabs/Groups/BLUFOR/RHS_USAF
  angleY -90
  m_sCustomNameSet "Platoon HQ (Mot.)"
 }
-Vehicle M998_0A : "{9B1BF9644E0378D6}Prefabs/Vehicles/Wheeled/M998/M998_covered_long.et" {
- coords 893.805 3.063 6403.614
- angleY -90
- Flags 2097155
+$grp Vehicle : "{9B1BF9644E0378D6}Prefabs/Vehicles/Wheeled/M998/M998_covered_long.et" {
+ M998_0A {
+  coords 893.805 3.063 6403.614
+  angleY -90
+ }
+ M998_0B {
+  components {
+   SCR_UniversalInventoryStorageComponent "{5916C587FC993363}" {
+    MultiSlots {
+     MultiSlotConfiguration "{5A60CECB549327C1}" {
+      NumSlots 10
+     }
+     MultiSlotConfiguration "{61CAFD9B2EC37A7C}" {
+      SlotTemplate InventoryStorageSlot b {
+       Prefab "{0D9A5DCF89AE7AA9}Prefabs/Items/Medicine/MorphineInjection_01/MorphineInjection_01.et"
+      }
+      NumSlots 5
+     }
+     MultiSlotConfiguration "{61CAFD9B1214CE54}" {
+      SlotTemplate InventoryStorageSlot c {
+       Prefab "{00E36F41CA310E2A}Prefabs/Items/Medicine/SalineBag_01/SalineBag_US_01.et"
+      }
+      NumSlots 5
+     }
+    }
+   }
+  }
+  coords 903.805 3.063 6403.612
+  angleY -90
+ }
 }
 $grp Vehicle : "{B55C6990A6A9411B}Prefabs/Vehicles/Wheeled/M998/M998_covered.et" {
  M998_1B {
   coords 903.805 3.063 6413.613
   angleY -90
-  Flags 2097155
  }
  M998_1C {
   coords 913.805 3.063 6413.613
   angleY -90
-  Flags 2097155
  }
  M998_3B {
   coords 903.805 3.063 6433.612
   angleY -90
-  Flags 2097155
  }
  M998_3C {
   coords 913.805 3.031 6433.612
   angleY -90
-  Flags 2097155
  }
  M998_2B {
   coords 903.805 3.063 6423.612
   angleY -90
-  Flags 2097155
  }
  M998_2C {
   coords 913.805 3.063 6423.612
   angleY -90
-  Flags 2097155
  }
 }

--- a/Worlds/Lobby/Mussalo/MistyMudflats_Layers/OPFOR.layer
+++ b/Worlds/Lobby/Mussalo/MistyMudflats_Layers/OPFOR.layer
@@ -22,7 +22,6 @@ $grp Vehicle : "{447CFE8D73F95C3E}Prefabs/Vehicles/Wheeled/BTR70/BTR70_AFRF.et" 
   angleX -0.771
   angleY -7.514
   angleZ 1.004
-  Flags 2097155
  }
  BTR70_12 {
   components {
@@ -47,7 +46,6 @@ $grp Vehicle : "{447CFE8D73F95C3E}Prefabs/Vehicles/Wheeled/BTR70/BTR70_AFRF.et" 
   angleX -1.421
   angleY -7.572
   angleZ 2.895
-  Flags 2097155
  }
  BTR70_13 {
   components {
@@ -72,7 +70,6 @@ $grp Vehicle : "{447CFE8D73F95C3E}Prefabs/Vehicles/Wheeled/BTR70/BTR70_AFRF.et" 
   angleX -0.419
   angleY -7.527
   angleZ 3.662
-  Flags 2097155
  }
  BTR70_21 {
   components {
@@ -97,7 +94,6 @@ $grp Vehicle : "{447CFE8D73F95C3E}Prefabs/Vehicles/Wheeled/BTR70/BTR70_AFRF.et" 
   angleX -0.536
   angleY -7.526
   angleZ 2.778
-  Flags 2097155
  }
  BTR70_22 {
   components {
@@ -122,7 +118,6 @@ $grp Vehicle : "{447CFE8D73F95C3E}Prefabs/Vehicles/Wheeled/BTR70/BTR70_AFRF.et" 
   angleX -1.421
   angleY -7.572
   angleZ 2.895
-  Flags 2097155
  }
  BTR70_23 {
   components {
@@ -147,7 +142,6 @@ $grp Vehicle : "{447CFE8D73F95C3E}Prefabs/Vehicles/Wheeled/BTR70/BTR70_AFRF.et" 
   angleX -1.421
   angleY -7.572
   angleZ 2.895
-  Flags 2097155
  }
 }
 $grp SCR_AIGroup : "{844ED4C0DD333179}Prefabs/Groups/OPFOR/RHS_AFRF/MSV/VKPO_Demiseason/CRF_RF_MSV_PlatoonHQ.et" {

--- a/Worlds/Lobby/Mussalo/MistyMudflats_Layers/briefing_common.layer
+++ b/Worlds/Lobby/Mussalo/MistyMudflats_Layers/briefing_common.layer
@@ -23,6 +23,7 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   ""\
   "Russian Motor Rifles assault an airfield defended by a motorized USMC Rifle Platoon."\
   ""\
+  ""\
   "2:3 BLU:OP"
   m_bEmptyFactionVisibility 1
   m_iOrder 1
@@ -32,17 +33,13 @@ $grp PS_MissionDescription : "{3136BE42592F3B1B}PrefabsEditable/MissionDescripti
   m_sTitle "Assets"
   m_sTextData "BLUFOR:"\
   ""\
-  "1x M998 for HQ"\
-  "1x M997 for Medics"\
-  "1x M1025 and 2x M998 per squad (one for each fireteam)"\
+  "2x M998 for HQ and Medics"\
+  "1x M1025 (M2HB) and 2x M998 per squad, so one HMWVV for each fireteam"\
   ""\
   ""\
   "OPFOR:"\
   ""\
-  "1x BTR-70 (AFRF) per section"\
-  ""\
-  ""\
-  "Vehicle spawns are currently disabled due to a potential framework issue and will have to be spawned manually by a GM."
+  "1x BTR-70 (AFRF) per section"
   m_bEmptyFactionVisibility 1
   m_bShowForAnyFaction 1
   m_iOrder 4


### PR DESCRIPTION
Re-enable vehicles that don't cause JIP errors
Exchanged M997 Ambulance (which can cause JIP error) for M998
Adjusted briefing to reflect this change