### PR TITLE
Added check to see if replicated members are run on clients.

### DIFF
--- a/Worlds/Lobby/Arland/testworld_Layers/default.layer
+++ b/Worlds/Lobby/Arland/testworld_Layers/default.layer
@@ -39,6 +39,20 @@ $grp BaseGameTriggerEntity {
  respawn3 {
   coords 1496.212 43.443 3185.285
  }
+ Test {
+  coords 2036.377 57.934 2135.297
+  TriggerShapeType Sphere
+  SphereRadius 50
+  PeriodicQueries 1
+  UpdatePeriod 1
+  OnQueryFinished ""\
+  "		CRF_RadioRespawnSystemComponent radioComponent = CRF_RadioRespawnSystemComponent.Cast(GetGame().GetGameMode().FindComponent(CRF_RadioRespawnSystemComponent));"\
+  "		if(Replication.IsClient())"\
+  "		{"\
+  "			radioComponent.AddRespawnWaves(\"FIA\", 1);"\
+  "		}"\
+  "	"
+ }
 }
 SCR_AIGroup : "{17C7309FFE4775B1}Prefabs/Groups/INDFOR/FIA 1980s/Infantry/Group_FIA_RifleSquad_P.et" {
  coords 2023.435 53.576 2127.13

--- a/scripts/Game/Systems/Respawns/RadioRespawnGameComponent.c
+++ b/scripts/Game/Systems/Respawns/RadioRespawnGameComponent.c
@@ -155,6 +155,11 @@ class CRF_RadioRespawnSystemComponent: SCR_BaseGameModeComponent
 	
 	void AddRespawnWaves(string factionKey, int amount)
 	{
+		if(Replication.IsClient())
+		{
+			Print("RUN AddRespawnWaves ONLY ON THE SERVER");
+			return;
+		}
 		if(factionKey == m_bluforFactionKey)
 		{
 			m_bluforRespawnWaves = m_bluforRespawnWaves + amount;
@@ -177,6 +182,11 @@ class CRF_RadioRespawnSystemComponent: SCR_BaseGameModeComponent
 	
 	void RemoveRespawnWaves(string factionKey, int amount)
 	{
+		if(Replication.IsClient())
+		{
+			Print("RUN RemoveRespawnWaves ONLY ON THE SERVER");
+			return;
+		}
 		if(factionKey == m_bluforFactionKey)
 		{
 			m_bluforRespawnWaves = m_bluforRespawnWaves - amount;
@@ -199,6 +209,11 @@ class CRF_RadioRespawnSystemComponent: SCR_BaseGameModeComponent
 	
 	void SetCanFactionRespawn(string factionKey, bool canRespawn)
 	{
+		if(Replication.IsClient())
+		{
+			Print("RUN SetCanFactionRespawn ONLY ON THE SERVER");
+			return;
+		}
 		if(factionKey == m_bluforFactionKey)
 		{
 			m_canBluforRespawn = canRespawn;


### PR DESCRIPTION
Another small bug picked up in testing, members for adding respawn waves, setting if a faction can respawn or removing respawn waves are already built in with replication so theres no need to run on the clients, no clue what chaos it'd cause but now it just yells at the client it can't do this.