### PR TITLE
Harry TVT76 Island Rumble - Arland

### DIFF
--- a/Missions/CRF_TVT76_IslandRumble.conf
+++ b/Missions/CRF_TVT76_IslandRumble.conf
@@ -1,0 +1,13 @@
+SCR_MissionHeader {
+ World "{35C845DB6F7E69C3}Worlds/Lobby/Arland/Harry_TVT_IslandRumble.ent"
+ m_sName "CRF TVT76 Island Rumble"
+ m_sAuthor "Harry"
+ m_sDescription "A minimalist TVT mission on Arland."
+ m_sIcon "{B7385DA4504BD4D5}CRF Images/crflogo.edds"
+ m_sLoadingScreen "{B7385DA4504BD4D5}CRF Images/crflogo.edds"
+ m_sPreviewImage "{B7385DA4504BD4D5}CRF Images/crflogo.edds"
+ m_sGameMode "TVT"
+ m_iPlayerCount 76
+ m_iStartingHours 12
+ m_iMapMarkerLimitPerPlayer 120
+}

--- a/Missions/CRF_TVT76_IslandRumble.conf.meta
+++ b/Missions/CRF_TVT76_IslandRumble.conf.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{72C578F638BEC40F}Missions/CRF_TVT76_IslandRumble.conf"
+ Configurations {
+  CONFResourceClass PC {
+  }
+  CONFResourceClass XBOX_ONE : PC {
+  }
+  CONFResourceClass XBOX_SERIES : PC {
+  }
+  CONFResourceClass PS4 : PC {
+  }
+  CONFResourceClass PS5 : PC {
+  }
+  CONFResourceClass HEADLESS : PC {
+  }
+  CONFResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Worlds/Lobby/Arland/Harry_TVT_IslandRumble.ent
+++ b/Worlds/Lobby/Arland/Harry_TVT_IslandRumble.ent
@@ -1,0 +1,3 @@
+SubScene {
+ Parent "{A9806AF617972E97}worlds/Arland/Arland.ent"
+}

--- a/Worlds/Lobby/Arland/Harry_TVT_IslandRumble.ent.meta
+++ b/Worlds/Lobby/Arland/Harry_TVT_IslandRumble.ent.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{35C845DB6F7E69C3}Worlds/Lobby/Arland/Harry_TVT_IslandRumble.ent"
+ Configurations {
+  ENTResourceClass PC {
+  }
+  ENTResourceClass XBOX_ONE : PC {
+  }
+  ENTResourceClass XBOX_SERIES : PC {
+  }
+  ENTResourceClass PS4 : PC {
+  }
+  ENTResourceClass PS5 : PC {
+  }
+  ENTResourceClass HEADLESS : PC {
+  }
+  ENTResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Worlds/Lobby/Arland/Harry_TVT_IslandRumble_Layers/aaInit.layer
+++ b/Worlds/Lobby/Arland/Harry_TVT_IslandRumble_Layers/aaInit.layer
@@ -1,0 +1,33 @@
+SCR_AIWorld : "{01DC74137CFDDB6A}Prefabs/AI/SCR_AIWorld_Arland.et" {
+ coords 2591.366 123.062 2320.689
+}
+PS_GameModeCoop CRF_GameMode_Lobby_1 : "{70D51A019CC9AA3F}Prefabs/MP/Modes/Lobby/CRF_GameMode_Lobby-12.et" {
+ components {
+  CRF_SafestartGameModeComponent "{61BCFEC3FE6731AB}" {
+   m_iTimeLimitMinutes 60
+  }
+  SCR_InitWeatherComponent "{61BCFEC02D389EB2}" {
+   m_sInitialStartingWeatherId "Rainy"
+  }
+ }
+ coords 2577.146 142.956 2301.469
+ {
+  SCR_FactionManager "631B17F232983D10" {
+   ID "61BCFEC02D38B83E"
+   Factions {
+    SCR_Faction "{628C2D2BFC8C6447}" {
+     m_CallsignInfo SCR_FactionCallsignInfo "{5DA0F2A67DFB8809}" {
+      m_aSquadNames {
+       SCR_CallsignInfo "{631B065D52998440}" {
+        m_sCallsign "1-4"
+       }
+       SCR_CallsignInfo "{631B065D579A3EAE}" {
+        m_sCallsign "1-5"
+       }
+      }
+     }
+    }
+   }
+  }
+ }
+}

--- a/Worlds/Lobby/Arland/Harry_TVT_IslandRumble_Layers/briefings.layer
+++ b/Worlds/Lobby/Arland/Harry_TVT_IslandRumble_Layers/briefings.layer
@@ -3,34 +3,38 @@ $grp PS_MissionDescription : "{79EBB4201309B9F3}PrefabsEditable/MissionDescripti
   coords 2446.902 248.877 2199.98
   m_sTextData "You've managed to land on Arland, and need to push quickly to Signal Hill. Once there, you can call for support in the form of two BTR-70s that will arrive at the predesignated spot. This will give you the support you need for the main objective, eliminating the FIA cell at Arleville."\
   ""\
-  "Note: Signal Hill must be held for 1 minute to receive the assets."
+  "Note: Signal Hill must be held for 2 minutes to receive the assets."
   m_aVisibleForFactions {
    "OPFOR"
   }
+  m_iOrder 4
  }
  indBrief {
   coords 2455.247 252.282 2193.842
   m_sTitle "INDFOR Brief"
   m_sTextData "OPFOR has managed a surprise landing on the sandbank near Beauregard. We have intelligence that they are going to cut off our communications at Signal Hill, and direct asset drops to support their push. We can try to take Signal Hill, and redirect those assets for ourselves, but the primary objective is to hold Arleville until help can arrive. "\
   ""\
-  "Note: Signal Hill must be held for 1 minute to receive the assets."
+  "Note: Signal Hill must be held for 2 minutes to receive the assets."
   m_aVisibleForFactions {
    "INDFOR"
   }
+  m_iOrder 4
  }
 }
-PS_MissionDescription : "{7D0DD3460BE3D185}PrefabsEditable/MissionDescription/Assets.et" {
+PS_MissionDescription c_assets : "{7D0DD3460BE3D185}PrefabsEditable/MissionDescription/Assets.et" {
  coords 2456.353 251.463 2202.714
  m_sTextData "Both sides have the potential to have 2x BTR-70. "
+ m_iOrder 2
 }
-PS_MissionDescription : "{8204C07A1B25066F}PrefabsEditable/MissionDescription/WelcomeDescription.et" {
+PS_MissionDescription a_welcome : "{8204C07A1B25066F}PrefabsEditable/MissionDescription/WelcomeDescription.et" {
  coords 2450.316 250.287 2204.12
 }
-PS_MissionDescription : "{AE37B19A0B021679}PrefabsEditable/MissionDescription/WinCondition.et" {
+PS_MissionDescription d_wincon : "{AE37B19A0B021679}PrefabsEditable/MissionDescription/WinCondition.et" {
  coords 2450.492 249.974 2200.096
  m_sTextData "The game will end once Arleville has been held by Opfor for 8 minutes uncontested, if FIA is eliminated, or Opfor has unsufficient numbers to take Arleville. "
+ m_iOrder 3
 }
-PS_MissionDescription : "{E600EB659F551D8E}PrefabsEditable/MissionDescription/Situation.et" {
+PS_MissionDescription b_situation : "{E600EB659F551D8E}PrefabsEditable/MissionDescription/Situation.et" {
  coords 2456.494 252.566 2194.172
  m_sTextData "Opfor has mounted an assault on Arland with the intent to eliminate the FIA cell at Arleville. Opfor has inserted infantry with the goal to quietly take Signal Hill, cut off communications, receive asset support, and then wipe out the FIA cells at Arleville."
 }

--- a/Worlds/Lobby/Arland/Harry_TVT_IslandRumble_Layers/briefings.layer
+++ b/Worlds/Lobby/Arland/Harry_TVT_IslandRumble_Layers/briefings.layer
@@ -1,0 +1,36 @@
+$grp PS_MissionDescription : "{79EBB4201309B9F3}PrefabsEditable/MissionDescription/OPF_Brief.et" {
+ {
+  coords 2446.902 248.877 2199.98
+  m_sTextData "You've managed to land on Arland, and need to push quickly to Signal Hill. Once there, you can call for support in the form of two BTR-70s that will arrive at the predesignated spot. This will give you the support you need for the main objective, eliminating the FIA cell at Arleville."\
+  ""\
+  "Note: Signal Hill must be held for 1 minute to receive the assets."
+  m_aVisibleForFactions {
+   "OPFOR"
+  }
+ }
+ indBrief {
+  coords 2455.247 252.282 2193.842
+  m_sTitle "INDFOR Brief"
+  m_sTextData "OPFOR has managed a surprise landing on the sandbank near Beauregard. We have intelligence that they are going to cut off our communications at Signal Hill, and direct asset drops to support their push. We can try to take Signal Hill, and redirect those assets for ourselves, but the primary objective is to hold Arleville until help can arrive. "\
+  ""\
+  "Note: Signal Hill must be held for 1 minute to receive the assets."
+  m_aVisibleForFactions {
+   "INDFOR"
+  }
+ }
+}
+PS_MissionDescription : "{7D0DD3460BE3D185}PrefabsEditable/MissionDescription/Assets.et" {
+ coords 2456.353 251.463 2202.714
+ m_sTextData "Both sides have the potential to have 2x BTR-70. "
+}
+PS_MissionDescription : "{8204C07A1B25066F}PrefabsEditable/MissionDescription/WelcomeDescription.et" {
+ coords 2450.316 250.287 2204.12
+}
+PS_MissionDescription : "{AE37B19A0B021679}PrefabsEditable/MissionDescription/WinCondition.et" {
+ coords 2450.492 249.974 2200.096
+ m_sTextData "The game will end once Arleville has been held by Opfor for 8 minutes uncontested, if FIA is eliminated, or Opfor has unsufficient numbers to take Arleville. "
+}
+PS_MissionDescription : "{E600EB659F551D8E}PrefabsEditable/MissionDescription/Situation.et" {
+ coords 2456.494 252.566 2194.172
+ m_sTextData "Opfor has mounted an assault on Arland with the intent to eliminate the FIA cell at Arleville. Opfor has inserted infantry with the goal to quietly take Signal Hill, cut off communications, receive asset support, and then wipe out the FIA cells at Arleville."
+}

--- a/Worlds/Lobby/Arland/Harry_TVT_IslandRumble_Layers/indfor.layer
+++ b/Worlds/Lobby/Arland/Harry_TVT_IslandRumble_Layers/indfor.layer
@@ -1,3 +1,6 @@
+SCR_AIGroup a : "{8B4D1DC201B68BB9}Prefabs/Groups/INDFOR/Standard/Command/CRF_INDFOR_Company_p.et" {
+ coords 2502.236 147.059 2301.162
+}
 SCR_AIGroup : "{96DB67CD45DC5F85}Prefabs/Groups/INDFOR/Standard/Command/CRF_INDFOR_Platoon_p.et" {
  coords 2721.714 57.242 1471.721
  m_sCustomNameSet "Platoon"
@@ -17,7 +20,7 @@ SCR_AIGroup : "{96DB67CD45DC5F85}Prefabs/Groups/INDFOR/Standard/Command/CRF_INDF
      m_sCustomNameSet "Cell 2"
      {
       SCR_AIGroup : "{ADF09DD7FCCA37C3}Prefabs/Groups/INDFOR/Standard/Infantry/CRF_INDFOR_Infantry_p.et" {
-       coords -10.042 -0 0
+       coords -10.042 0 0
        m_aUnitPrefabSlots {
         "{8949382562216B1E}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_SL_P.et" "{23546266D23BBE77}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_Medic_P.et" "{5BCF0823FB56CF1C}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_TL_P.et" "{350425E3D3FE2F85}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_MMG_P.et" "{85BCB18428923941}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_AMMG_P.et" "{5BCF0823FB56CF1C}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_TL_P.et" "{911CD22FC97CC36A}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_AT_P.et" "{5305749FAC432544}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_AAT_P.et" "{0C86D510A52DF210}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_Demo_P.et"
        }

--- a/Worlds/Lobby/Arland/Harry_TVT_IslandRumble_Layers/indfor.layer
+++ b/Worlds/Lobby/Arland/Harry_TVT_IslandRumble_Layers/indfor.layer
@@ -1,0 +1,31 @@
+SCR_AIGroup : "{96DB67CD45DC5F85}Prefabs/Groups/INDFOR/Standard/Command/CRF_INDFOR_Platoon_p.et" {
+ coords 2721.714 57.242 1471.721
+ m_sCustomNameSet "Platoon"
+ {
+  SCR_AIGroup : "{ADF09DD7FCCA37C3}Prefabs/Groups/INDFOR/Standard/Infantry/CRF_INDFOR_Infantry_p.et" {
+   coords -9.171 0.177 1.394
+   m_aUnitPrefabSlots {
+    "{8949382562216B1E}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_SL_P.et" "{23546266D23BBE77}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_Medic_P.et" "{5BCF0823FB56CF1C}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_TL_P.et" "{350425E3D3FE2F85}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_MMG_P.et" "{85BCB18428923941}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_AMMG_P.et" "{5BCF0823FB56CF1C}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_TL_P.et" "{911CD22FC97CC36A}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_AT_P.et" "{5305749FAC432544}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_AAT_P.et" "{0C86D510A52DF210}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_Demo_P.et"
+   }
+   m_sCustomNameSet "Cell 1"
+   {
+    SCR_AIGroup : "{ADF09DD7FCCA37C3}Prefabs/Groups/INDFOR/Standard/Infantry/CRF_INDFOR_Infantry_p.et" {
+     coords -9.342 -0.437 0
+     m_aUnitPrefabSlots {
+      "{8949382562216B1E}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_SL_P.et" "{23546266D23BBE77}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_Medic_P.et" "{5BCF0823FB56CF1C}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_TL_P.et" "{350425E3D3FE2F85}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_MMG_P.et" "{85BCB18428923941}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_AMMG_P.et" "{5BCF0823FB56CF1C}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_TL_P.et" "{911CD22FC97CC36A}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_AT_P.et" "{5305749FAC432544}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_AAT_P.et" "{0C86D510A52DF210}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_Demo_P.et"
+     }
+     m_sCustomNameSet "Cell 2"
+     {
+      SCR_AIGroup : "{ADF09DD7FCCA37C3}Prefabs/Groups/INDFOR/Standard/Infantry/CRF_INDFOR_Infantry_p.et" {
+       coords -10.042 -0 0
+       m_aUnitPrefabSlots {
+        "{8949382562216B1E}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_SL_P.et" "{23546266D23BBE77}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_Medic_P.et" "{5BCF0823FB56CF1C}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_TL_P.et" "{350425E3D3FE2F85}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_MMG_P.et" "{85BCB18428923941}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_AMMG_P.et" "{5BCF0823FB56CF1C}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_TL_P.et" "{911CD22FC97CC36A}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_AT_P.et" "{5305749FAC432544}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_AAT_P.et" "{0C86D510A52DF210}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_Demo_P.et"
+       }
+       m_sCustomNameSet "Cell 3"
+      }
+     }
+    }
+   }
+  }
+ }
+}

--- a/Worlds/Lobby/Arland/Harry_TVT_IslandRumble_Layers/mapMarkers.layer
+++ b/Worlds/Lobby/Arland/Harry_TVT_IslandRumble_Layers/mapMarkers.layer
@@ -1,0 +1,206 @@
+$grp PS_ManualMarker : "{10F92A3FD09DA1C5}PrefabsEditable/Markers/OPFORSpawnMarker.et" {
+ opAssetSpawn {
+  coords 2513.534 56.892 2853.515
+  m_sDescription "OPFOR Asset Spawn"
+ }
+ {
+  coords 2479.5 7.791 3176.365
+  angleY 0
+ }
+}
+PS_ManualMarker : "{36BD5DC9A80977F2}PrefabsEditable/Markers/INDFORSafeStartBorderMarker.et" {
+ coords 2515.482 92.098 1868.614
+ angleY 4.644
+ {
+  $grp PS_ManualMarker : "{36BD5DC9A80977F2}PrefabsEditable/Markers/INDFORSafeStartBorderMarker.et" {
+   {
+    coords 100 0 0
+    angleY 0
+   }
+   {
+    coords 200.001 0 0.001
+    angleY 0
+   }
+   {
+    coords 300.001 0 0.001
+    angleY 0
+   }
+   {
+    coords 400.001 0 0.001
+    angleY 0
+   }
+   {
+    coords 500.002 0 0.002
+    angleY 0
+   }
+   {
+    coords 500.002 0 -99.999
+    angleY 0
+   }
+   {
+    coords 500.002 0 -199.999
+    angleY 0
+   }
+   {
+    coords 500.002 0 -299.999
+    angleY 0
+   }
+   {
+    coords 500.002 0 -400
+    angleY 0
+   }
+   {
+    coords 500.001 0 -500
+    angleY 0
+   }
+   {
+    coords 400.001 0 -500
+    angleY 0
+   }
+   {
+    coords 300 0 -500.001
+    angleY 0
+   }
+   {
+    coords 200 0 -500.001
+    angleY 0
+   }
+   {
+    coords 100 0 -500.002
+    angleY 0
+   }
+   {
+    coords 0.001 0 -500.002
+    angleY 0
+   }
+   {
+    coords 0.001 0 -400.001
+    angleY 0
+   }
+   {
+    coords 0.001 0 -300.001
+    angleY 0
+   }
+   {
+    coords 0.001 0 -200.001
+    angleY 0
+   }
+   {
+    coords 0.001 0 -100
+    angleY 0
+   }
+  }
+ }
+}
+PS_ManualMarker : "{AE820D882CD0ACC4}PrefabsEditable/Markers/OPFORSafeStartBorderMarker.et" {
+ coords 2629.222 24.677 3069.695
+ {
+  $grp PS_ManualMarker : "{AE820D882CD0ACC4}PrefabsEditable/Markers/OPFORSafeStartBorderMarker.et" {
+   {
+    coords -100 0 0
+   }
+   {
+    coords -200 0 0
+   }
+   {
+    coords -300 0 0
+   }
+   {
+    coords -300 0 100
+   }
+   {
+    coords -300 0 200
+   }
+   {
+    coords -200 0 200
+   }
+   {
+    coords -100 0 200
+   }
+   {
+    coords 0 0 200
+   }
+   {
+    coords 0 0 100
+   }
+  }
+ }
+}
+PS_ManualMarker : "{BE9E1F90BFFBB48A}PrefabsEditable/Markers/GameZoneMarker.et" {
+ coords 2304.323 2.285 3277.141
+ angleY -61.974
+ {
+  $grp PS_ManualMarker : "{BE9E1F90BFFBB48A}PrefabsEditable/Markers/GameZoneMarker.et" {
+   {
+    coords -100 0 0
+    angleY 0
+   }
+   {
+    coords -200 0 0
+    angleY 0
+   }
+   {
+    coords -300 0 0
+    angleY 0
+   }
+   {
+    coords -400 0 0.001
+    angleY 0
+   }
+   {
+    coords -500 0 0.001
+    angleY 0
+   }
+   {
+    coords -600 0 0.001
+    angleY 0
+   }
+   {
+    coords -700 0 0.001
+    angleY 0
+   }
+   {
+    coords -800 0 0.002
+    angleY 0
+   }
+   {
+    coords -900 0 0.002
+    angleY 0
+   }
+   {
+    coords -1000 0 0.002
+    angleY 0
+   }
+   {
+    coords -1100 0 0.002
+    angleY 0
+   }
+   {
+    coords -1200 0 0.002
+    angleY 0
+   }
+   {
+    coords -1300 0 0.003
+    angleY 0
+   }
+   {
+    coords -1400 0 0.003
+    angleY 0
+   }
+   {
+    coords -1500 0 0.003
+    angleY 0
+   }
+  }
+ }
+}
+$grp PS_ManualMarker : "{C113055E29F43DAA}PrefabsEditable/Markers/INDFORSpawnMarker.et" {
+ indAssetSpawn {
+  coords 2092.773 58.525 2113.175
+  m_sDescription "INDFOR Asset Spawn"
+ }
+ {
+  coords 2675.826 52.271 1467.386
+  angleY 90
+ }
+}

--- a/Worlds/Lobby/Arland/Harry_TVT_IslandRumble_Layers/objectives.layer
+++ b/Worlds/Lobby/Arland/Harry_TVT_IslandRumble_Layers/objectives.layer
@@ -1,0 +1,68 @@
+SCR_FactionControlTriggerEntity objTrigger {
+ coords 2782.726 84.178 1643.364
+ TriggerShapeType Sphere
+ SphereRadius 150
+ DrawShape 1
+ PeriodicQueries 1
+ UpdatePeriod 15
+ OnQueryFinished ""\
+ "		super.OnQueryFinished(bIsEmpty);"\
+ "		"\
+ "		if (m_bResult)"\
+ "		{"\
+ "			SCR_PopUpNotification.GetInstance().PopupMsg(\"Opfor has captured Arleville, Indfor has 8 minutes to contest\", 10);"\
+ "			IEntity objTrigger = GetGame().GetWorld().FindEntityByName(\"objTrigger\");"\
+ "			delete objTrigger;"\
+ "		}"\
+ "		"\
+ "	"
+ m_sOwnerFactionKey "OPFOR"
+ m_iRatioMethod "More than"
+ m_fFriendlyRatioLimit 0.8
+}
+$grp PS_ManualMarker : "{7B677FB61E410D0D}PrefabsEditable/Markers/ObjectiveMarker.et" {
+ {
+  coords 2524.95 147.807 2269.974
+  m_MarkerColor 0 0 0 1
+  m_sDescription "Control Signal Hill"
+  m_bVisibleForEmptyFaction 1
+  m_bShowForAnyFaction 1
+ }
+ {
+  coords 2776.502 77.416 1632.88
+  m_MarkerColor 0 0 0 1
+  m_sDescription "Control Arleville"
+  m_bVisibleForEmptyFaction 1
+  m_bShowForAnyFaction 1
+ }
+}
+$grp PS_Objective : "{DC02A6E23541A99B}PrefabsEditable/MissionDescription/Objective.et" {
+ {
+  coords 2496.63 136.343 2185.143
+  m_sTitle "Capture Signal HIll"
+  m_sTextData ""
+  m_iScore 25
+  m_sFactionKey "OPFOR"
+ }
+ {
+  coords 2502.646 133.798 2179.428
+  m_sTitle "Defend Signal Hill"
+  m_sTextData ""
+  m_iScore 25
+  m_sFactionKey "INDFOR"
+ }
+ {
+  coords 2763.793 76.77 1635.844
+  m_sTitle "Capture Arleville"
+  m_sTextData ""
+  m_iScore 75
+  m_sFactionKey "OPFOR"
+ }
+ {
+  coords 2765.193 74.313 1648.59
+  m_sTitle "Defend Arleville"
+  m_sTextData ""
+  m_iScore 75
+  m_sFactionKey "INDFOR"
+ }
+}

--- a/Worlds/Lobby/Arland/Harry_TVT_IslandRumble_Layers/opfor.layer
+++ b/Worlds/Lobby/Arland/Harry_TVT_IslandRumble_Layers/opfor.layer
@@ -1,0 +1,54 @@
+SCR_AIGroup : "{6524B6A6C69BD3EE}Prefabs/Groups/OPFOR/Standard/Command/CRF_OPFOR_Platoon_p.et" {
+ coords 2560.884 9.871 3156.992
+ {
+  SCR_AIGroup : "{92F50F60726EB86D}Prefabs/Groups/OPFOR/Standard/Infantry/CRF_OPFOR_RifleSquad_p.et" {
+   coords -19.158 -1.094 -1.36
+   {
+    SCR_AIGroup : "{92F50F60726EB86D}Prefabs/Groups/OPFOR/Standard/Infantry/CRF_OPFOR_RifleSquad_p.et" {
+     coords -12.43 0.22 0
+     m_sCustomNameSet "2nd Squad"
+     {
+      SCR_AIGroup : "{92F50F60726EB86D}Prefabs/Groups/OPFOR/Standard/Infantry/CRF_OPFOR_RifleSquad_p.et" {
+       coords -11.512 0.16 0
+       m_sCustomNameSet "3rd Squad"
+       {
+        SCR_AIGroup : "{92F50F60726EB86D}Prefabs/Groups/OPFOR/Standard/Infantry/CRF_OPFOR_RifleSquad_p.et" {
+         coords -12.944 0.407 0
+         m_sCustomNameSet "4th Squad"
+         {
+          SCR_AIGroup : "{92F50F60726EB86D}Prefabs/Groups/OPFOR/Standard/Infantry/CRF_OPFOR_RifleSquad_p.et" {
+           coords -11.249 0.019 0
+           m_sCustomNameSet "5th Squad"
+          }
+         }
+        }
+       }
+      }
+     }
+    }
+   }
+  }
+ }
+}
+$grp Vehicle : "{D9B91FAB817A6033}Prefabs/Vehicles/Wheeled/Ural4320/Ural4320_transport_covered.et" {
+ Ural4320_transport_covered1 {
+  coords 2465.653 17.838 3089.72
+  angleY 92.302
+ }
+ Ural4320_transport_covered2 {
+  coords 2455.079 17.579 3089.964
+  angleY 92.302
+ }
+ Ural4320_transport_covered3 {
+  coords 2443.511 17.305 3090.188
+  angleY 92.302
+ }
+ Ural4320_transport_covered4 {
+  coords 2431.477 17.023 3090.606
+  angleY 92.302
+ }
+ Ural4320_transport_covered5 {
+  coords 2421.863 16.808 3091.017
+  angleY 92.302
+ }
+}

--- a/Worlds/Lobby/Arland/Harry_TVT_IslandRumble_Layers/props.layer
+++ b/Worlds/Lobby/Arland/Harry_TVT_IslandRumble_Layers/props.layer
@@ -1,0 +1,422 @@
+GenericEntity : "{1AC1F28A21804631}Prefabs/Compositions/Misc/SubCompositions/Fortifications/Sandbag_Wall_Sign_USSR_01.et" {
+ coords 2488.257 128.582 2382.492
+ angleY 0
+}
+$grp GenericEntity : "{20D02D188D3E883F}Prefabs/Compositions/Misc/SubCompositions/Sandbag_Camo_wall_high_USSR.et" {
+ {
+  coords 2503.055 145.938 2313.148
+  angleY 0
+  angleZ -16.267
+ }
+ {
+  coords 2500.413 145.167 2313.107
+  angleY 0
+  angleZ -16.267
+ }
+ {
+  coords 2505.733 145.567 2313.148
+  angleY 0
+  angleZ -16.267
+ }
+ {
+  coords 2492.898 142.989 2305.628
+  angleX -4.595
+  angleY -85.711
+  angleZ -1.226
+ }
+ {
+  coords 2493.262 143.104 2311.158
+  angleX -4.595
+  angleY -85.711
+  angleZ -1.226
+ }
+ {
+  coords 2493.058 143.045 2308.377
+  angleX -4.595
+  angleY -85.711
+  angleZ -1.226
+ }
+ {
+  coords 2524.438 143.921 2282.471
+  angleX 1.237
+  angleY 3.578
+  angleZ 1.464
+ }
+ {
+  coords 2529.971 143.781 2282.169
+  angleX 1.237
+  angleY 3.578
+  angleZ 1.464
+ }
+ {
+  coords 2527.189 143.852 2282.341
+  angleX 1.237
+  angleY 3.578
+  angleZ 1.464
+ }
+ {
+  coords 2498.354 146.782 2266.219
+  angleX -4.726
+  angleY -107.015
+  angleZ 0.525
+ }
+ {
+  coords 2496.778 145.733 2271.522
+  angleX -4.726
+  angleY -107.015
+  angleZ 0.525
+ }
+ {
+  coords 2497.51 146.754 2268.839
+  angleX -4.726
+  angleY -107.015
+  angleZ 0.525
+ }
+ {
+  coords 2495.006 146.672 2276.802
+  angleX -4.726
+  angleY -107.015
+  angleZ 0.525
+ }
+ {
+  coords 2495.85 146.7 2274.182
+  angleX -4.726
+  angleY -107.015
+  angleZ 0.525
+ }
+ {
+  coords 2511.942 145.743 2323.54
+  angleX -4.177
+  angleY -29.69
+  angleZ -7.28
+ }
+ {
+  coords 2531.49 143.109 2254.745
+  angleX 1.237
+  angleY 3.578
+  angleZ 1.464
+ }
+ {
+  coords 2528.708 143.18 2254.917
+  angleX 1.237
+  angleY 3.578
+  angleZ 1.464
+ }
+ {
+  coords 2508.537 147.068 2285.83
+  angleX 1.237
+  angleY 3.578
+  angleZ -0.834
+ }
+ {
+  coords 2505.755 147.027 2286.005
+  angleX 1.237
+  angleY 3.578
+  angleZ -0.834
+ }
+ {
+  coords 2502.762 146.027 2286.214
+  angleX 1.237
+  angleY 3.578
+  angleZ -0.834
+ }
+}
+$grp StaticModelEntity : "{605A7848CB4D361A}Prefabs/Compositions/Misc/SubCompositions/Fortifications/Sandbag_Bunker_Camouflaged_USSR_01.et" {
+ {
+  coords 2514.772 147.483 2251.793
+  angleY 121.841
+  {
+   GenericEntity {
+    ID "5A532DCEFF9667C8"
+    coords 0 0.1 0
+   }
+   StaticModelEntity {
+    ID "5CB0D9919CD637A8"
+    coords -0.112 -0.37 2.713
+    angleZ -3.382
+   }
+  }
+ }
+ {
+  coords 2534.413 143.908 2283.275
+  angleY 9.977
+ }
+ {
+  coords 2495.282 144.456 2314.258
+  {
+   StaticModelEntity {
+    ID "5CB0D9919CD637A8"
+    coords -0.068 -0.199 2.203
+   }
+   StaticModelEntity {
+    ID "5CB0D9919CD637A9"
+    coords -2.123 -0.526 0.893
+   }
+   StaticModelEntity {
+    ID "5CB0D9919CD6F6B4"
+    coords -2.704 -0.237 -1.256
+   }
+   StaticModelEntity : "{B03F9691E961C4CA}Prefabs/Structures/Military/Fortifications/DirtCover_01/DirtCover_01_long_v3.et" {
+    components {
+     Hierarchy "{5CB0D9919CD6D30C}" {
+      Enabled 1
+     }
+    }
+    coords -1.118 -0.526 1.185
+    angleY 90
+   }
+  }
+ }
+ {
+  coords 2496.525 147.721 2283.041
+  angleY -49.586
+  {
+   GenericEntity {
+    ID "5CB0D9919CD64028"
+    coords 1.663 0.524 2.341
+   }
+  }
+ }
+ {
+  coords 2499.435 148.077 2259.592
+  angleY -101.808
+  {
+   StaticModelEntity {
+    ID "5CB0D9919CD6021B"
+    coords 2.108 -0.052 0.654
+   }
+  }
+ }
+}
+$grp GenericEntity : "{78A930FB0825AA9F}Prefabs/Compositions/Misc/SubCompositions/Sandbag_Camo_long_high_USSR.et" {
+ {
+  coords 2545.548 143.517 2265.79
+  angleY -94.051
+ }
+ {
+  coords 2545.895 143.517 2262.573
+  angleY -94.051
+ }
+ {
+  coords 2520.239 146.668 2277.529
+  angleX 1.638
+  angleY -146.554
+  angleZ -2.478
+  {
+   GenericEntity {
+    ID "5706BA97DA88469A"
+    coords 0 0 0
+   }
+  }
+ }
+ {
+  coords 2517.465 146.812 2279.366
+  angleX 1.638
+  angleY -146.554
+  angleZ -2.478
+ }
+ {
+  coords 2511.505 147.075 2284.938
+  angleY -146.518
+ }
+ {
+  coords 2514.283 147.075 2283.1
+  angleY -146.518
+ }
+ {
+  coords 2507.209 147.172 2251.25
+  angleY -146.518
+ }
+ {
+  coords 2509.987 147.172 2249.413
+  angleY -146.518
+ }
+ {
+  coords 2500.815 147.358 2252.75
+  angleY -172.994
+  angleZ -9.533
+ }
+ {
+  coords 2504.08 147.172 2252.349
+  angleY -172.994
+ }
+ {
+  coords 2539.15 143.068 2283.569
+  angleX 0.006
+  angleY -179.89
+  angleZ -2.971
+ }
+ {
+  coords 2542.476 142.895 2283.563
+  angleX 0.006
+  angleY -179.89
+  angleZ -2.971
+ }
+ {
+  coords 2520.878 146.8 2257.44
+  angleX -2.353
+  angleY 127.652
+  angleZ -1.814
+ }
+ {
+  coords 2518.848 146.905 2254.801
+  angleX -2.353
+  angleY 127.652
+  angleZ -1.814
+ }
+}
+GenericEntity : "{78A930FB0825AAA0}Prefabs/Compositions/Misc/SubCompositions/Fortifications/Sandbag_Camo_long_high_USSR.et" {
+ coords 2521.931 147.164 2315.783
+ angleY 23.687
+}
+$grp StaticModelEntity : "{B03F9691E961C4CA}Prefabs/Structures/Military/Fortifications/DirtCover_01/DirtCover_01_long_v3.et" {
+ {
+  components {
+   Hierarchy "{5CB0D9919CD6D310}" {
+    Enabled 1
+   }
+  }
+  coords 2514.405 -0.268 2248.783
+  angleY 17.319
+ }
+ {
+  components {
+   Hierarchy "{5CB0D9919CD6D310}" {
+    Enabled 1
+   }
+  }
+  coords 2495.214 0.754 2316.644
+ }
+}
+$grp GenericEntity : "{C56ED190635B0129}Prefabs/Compositions/Misc/SubCompositions/Fortifications/Sandbag_Camo_wall_high_USSR.et" {
+ {
+  coords 2523.282 147.64 2313.423
+  angleY -66.477
+ }
+ {
+  coords 2519.147 147.64 2316.896
+  angleY 23.089
+ }
+}
+$grp GenericEntity : "{DDF59362051B28BC}Prefabs/Props/Military/Fortification/BarbedTape_KnifeRest.et" {
+ {
+  coords 2547.183 141.872 2252.659
+  angleX 6.083
+ }
+ {
+  coords 2547.089 141.564 2249.77
+  angleX 6.083
+ }
+ {
+  coords 2547.089 141.274 2247.042
+  angleX 6.083
+ }
+ {
+  coords 2524.755 140.028 2203.401
+  angleX 12.967
+  angleY 65.434
+  angleZ 5.623
+ }
+ {
+  coords 2521.922 139.311 2202.106
+  angleX 12.967
+  angleY 65.434
+  angleZ 5.623
+ }
+ {
+  coords 2519.26 138.637 2200.889
+  angleX 12.967
+  angleY 65.434
+  angleZ 5.623
+ }
+ {
+  coords 2516.397 137.912 2199.58
+  angleX 12.967
+  angleY 65.434
+  angleZ 5.623
+ }
+ {
+  coords 2513.59 137.517 2198.263
+  angleX 4.809
+  angleY 64.631
+  angleZ 5.499
+ }
+ {
+  coords 2510.686 137.235 2196.886
+  angleX 5.254
+  angleY 64.674
+  angleZ 5.503
+ }
+ {
+  coords 2463.1 140.62 2183.78
+  angleX -12.434
+  angleY 92.407
+  angleZ 11.663
+ }
+ {
+  coords 2466.15 139.778 2183.687
+  angleX -16.737
+  angleY 91.48
+  angleZ 11.896
+ }
+ {
+  coords 2469.239 138.993 2183.577
+  angleX -15.468
+  angleY 91.757
+  angleZ 11.819
+ }
+ {
+  coords 2472.322 138.003 2183.51
+  angleX -14.981
+  angleY 91.862
+  angleZ 11.792
+ }
+ {
+  coords 2475.663 137.309 2183.361
+  angleX -7.972
+  angleY 93.336
+  angleZ 11.498
+ }
+ {
+  coords 2478.831 136.865 2183.177
+  angleX -7.972
+  angleY 93.336
+  angleZ 11.498
+ }
+ {
+  coords 2482.048 136.31 2183.011
+  angleX -5.968
+  angleY 93.745
+  angleZ 11.448
+ }
+ {
+  coords 2485.173 135.983 2182.807
+  angleX -5.968
+  angleY 93.745
+  angleZ 11.448
+ }
+ {
+  coords 2547.4 134.26 2335.896
+  angleX 18.499
+  angleY -65.558
+  angleZ 5.087
+ }
+ {
+  coords 2550.201 133.231 2334.624
+  angleX 18.499
+  angleY -65.558
+  angleZ 5.087
+ }
+ {
+  coords 2552.92 132.23 2333.388
+  angleX 18.499
+  angleY -65.558
+  angleZ 5.087
+ }
+ {
+  coords 2555.651 131.226 2332.147
+  angleX 18.499
+  angleY -65.558
+  angleZ 5.087
+ }
+}

--- a/Worlds/Lobby/Arland/Harry_TVT_IslandRumble_Layers/triggers.layer
+++ b/Worlds/Lobby/Arland/Harry_TVT_IslandRumble_Layers/triggers.layer
@@ -27,7 +27,6 @@ $grp SCR_FactionControlTriggerEntity {
   "	}"
   TriggerShapeType Sphere
   SphereRadius 60
-  DrawShape 1
   PeriodicQueries 1
   UpdatePeriod 15
   OnQueryFinished ""\
@@ -36,7 +35,7 @@ $grp SCR_FactionControlTriggerEntity {
   "		if (m_bResult && !m_captured)"\
   "		{"\
   "			m_captured = true;"\
-  "			GetGame().GetCallqueue().CallLater(captureCheck, 60000, false);"\
+  "			GetGame().GetCallqueue().CallLater(captureCheck, 120000, false);"\
   "			if (m_held)"\
   "			{"\
   "				spawnthings();"\
@@ -91,7 +90,6 @@ $grp SCR_FactionControlTriggerEntity {
   "	}"
   TriggerShapeType Sphere
   SphereRadius 60
-  DrawShape 1
   PeriodicQueries 1
   UpdatePeriod 15
   OnQueryFinished ""\
@@ -100,7 +98,7 @@ $grp SCR_FactionControlTriggerEntity {
   "		if (m_bResult && !m_captured)"\
   "		{"\
   "			m_captured = true;"\
-  "			GetGame().GetCallqueue().CallLater(captureCheck, 60000, false);"\
+  "			GetGame().GetCallqueue().CallLater(captureCheck, 120000, false);"\
   "			if (m_held)"\
   "			{"\
   "				spawnthings();"\

--- a/Worlds/Lobby/Arland/Harry_TVT_IslandRumble_Layers/triggers.layer
+++ b/Worlds/Lobby/Arland/Harry_TVT_IslandRumble_Layers/triggers.layer
@@ -1,0 +1,124 @@
+$grp SCR_FactionControlTriggerEntity {
+ indTrigger {
+  coords 2508.443 137.807 2268.293
+  userScript "  	string btr = \"{C012BB3488BEA0C2}Prefabs/Vehicles/Wheeled/BTR70/BTR70.et\";"\
+  "  	IEntity spawnIndBTR1, spawnIndBTR2;"\
+  "	bool m_captured = false;"\
+  "	bool m_held = false;"\
+  "  	"\
+  "  	void spawnthings()"\
+  "  	{"\
+  "  		spawnIndBTR1 = GetGame().GetWorld().FindEntityByName(\"spawnIndBTR1\");"\
+  "  		spawnIndBTR2 = GetGame().GetWorld().FindEntityByName(\"spawnIndBTR2\");"\
+  "  	"\
+  "  		EntitySpawnParams spawnParams = new EntitySpawnParams();"\
+  "  		spawnParams.TransformMode = ETransformMode.WORLD;"\
+  "  		"\
+  "  		spawnParams.Transform[3] = spawnIndBTR1.GetOrigin();"\
+  "  		GetGame().SpawnEntityPrefab(Resource.Load(btr),GetGame().GetWorld(),spawnParams);"\
+  "  		spawnParams.Transform[3] = spawnIndBTR2.GetOrigin();"\
+  "  		GetGame().SpawnEntityPrefab(Resource.Load(btr),GetGame().GetWorld(),spawnParams);"\
+  "  		"\
+  "  	}"\
+  "	"\
+  "	void captureCheck()"\
+  "	{"\
+  "		m_held = true;"\
+  "	}"
+  TriggerShapeType Sphere
+  SphereRadius 60
+  DrawShape 1
+  PeriodicQueries 1
+  UpdatePeriod 15
+  OnQueryFinished ""\
+  "		super.OnQueryFinished(bIsEmpty);"\
+  "		"\
+  "		if (m_bResult && !m_captured)"\
+  "		{"\
+  "			m_captured = true;"\
+  "			GetGame().GetCallqueue().CallLater(captureCheck, 60000, false);"\
+  "			if (m_held)"\
+  "			{"\
+  "				spawnthings();"\
+  "				SCR_PopUpNotification.GetInstance().PopupMsg(\"Indfor has captured the antenna and called in support\", 10);"\
+  "				IEntity indTrigger = GetGame().GetWorld().FindEntityByName(\"indTrigger\");"\
+  "				IEntity opTrigger = GetGame().GetWorld().FindEntityByName(\"opTrigger\");"\
+  "				delete indTrigger;"\
+  "				delete opTrigger;"\
+  "				"\
+  "			}"\
+  "			else"\
+  "			{"\
+  "				m_captured = false;"\
+  "				m_held = false;"\
+  "			}"\
+  "			"\
+  "			"\
+  "		}"\
+  "		"\
+  "		"\
+  "			 "\
+  "	"
+  m_sOwnerFactionKey "INDFOR"
+  m_iRatioMethod "More than"
+  m_fFriendlyRatioLimit 0.8
+ }
+ opTrigger {
+  coords 2508.443 137.807 2268.293
+  userScript "  	string btr = \"{C012BB3488BEA0C2}Prefabs/Vehicles/Wheeled/BTR70/BTR70.et\";"\
+  "  	IEntity spawnOpBTR1, spawnOpBTR2;"\
+  "	bool m_captured = false;"\
+  "	bool m_held = false;"\
+  "  	"\
+  "  	void spawnthings()"\
+  "  	{"\
+  "  		spawnOpBTR1 = GetGame().GetWorld().FindEntityByName(\"spawnOpBTR1\");"\
+  "  		spawnOpBTR2 = GetGame().GetWorld().FindEntityByName(\"spawnOpBTR2\");"\
+  "  	"\
+  "  		EntitySpawnParams spawnParams = new EntitySpawnParams();"\
+  "  		spawnParams.TransformMode = ETransformMode.WORLD;"\
+  "  		"\
+  "  		spawnParams.Transform[3] = spawnOpBTR1.GetOrigin();"\
+  "  		GetGame().SpawnEntityPrefab(Resource.Load(btr),GetGame().GetWorld(),spawnParams);"\
+  "  		spawnParams.Transform[3] = spawnOpBTR2.GetOrigin();"\
+  "  		GetGame().SpawnEntityPrefab(Resource.Load(btr),GetGame().GetWorld(),spawnParams);"\
+  "  		"\
+  "  	}"\
+  "	"\
+  "	void captureCheck()"\
+  "	{"\
+  "		m_held = true;"\
+  "	}"
+  TriggerShapeType Sphere
+  SphereRadius 60
+  DrawShape 1
+  PeriodicQueries 1
+  UpdatePeriod 15
+  OnQueryFinished ""\
+  "		super.OnQueryFinished(bIsEmpty);"\
+  "		"\
+  "		if (m_bResult && !m_captured)"\
+  "		{"\
+  "			m_captured = true;"\
+  "			GetGame().GetCallqueue().CallLater(captureCheck, 60000, false);"\
+  "			if (m_held)"\
+  "			{"\
+  "				spawnthings();"\
+  "				SCR_PopUpNotification.GetInstance().PopupMsg(\"Opfor has captured the antenna and called in support\", 10);"\
+  "				IEntity indTrigger = GetGame().GetWorld().FindEntityByName(\"indTrigger\");"\
+  "				IEntity opTrigger = GetGame().GetWorld().FindEntityByName(\"opTrigger\");"\
+  "				delete indTrigger;"\
+  "				delete opTrigger;"\
+  "			}"\
+  "			else"\
+  "			{"\
+  "				m_captured = false;"\
+  "				m_held = false;"\
+  "			}	"\
+  "		}"\
+  "	"
+  m_sOwnerFactionKey "OPFOR"
+  m_iRatioMethod "More than"
+  m_fFriendlyRatioLimit 0.8
+ }
+}

--- a/Worlds/Lobby/Arland/Harry_TVT_IslandRumble_Layers/vicSpawn.layer
+++ b/Worlds/Lobby/Arland/Harry_TVT_IslandRumble_Layers/vicSpawn.layer
@@ -1,0 +1,14 @@
+$grp SCR_BaseTriggerEntity {
+ spawnOpBTR1 {
+  coords 2548.294 60.669 2840.603
+ }
+ spawnOpBTR2 {
+  coords 2522.57 57.934 2849.534
+ }
+ spawnIndBTR1 {
+  coords 2131.06 57.452 2100.541
+ }
+ spawnIndBTR2 {
+  coords 2109.571 57.982 2107.222
+ }
+}


### PR DESCRIPTION
Mission Pull Request Template

This Pull Request will:

Add the mission Island Rumble made by Harry to the repository.

**Mission Creation Checklist:**
- [x] Mission File
- [x] Ingame Play Area Markers
- [x] Ingame Briefings to all players
- [x] Side-based briefings
- [x] Objective Entities
- [x] Mission .conf file

**Faction(s):**
BLUFOR - Attacking/Defending/NA
- [ ] US
- [ ] UK
- [ ] RHS_USAF 
- [ ] CDF

OPFOR - Attacking
- [x] USSR
- [ ] RHS_AFRF

INDFOR - Defending
- [x] FIA
- [ ] RHS_ION
- [ ] TALIBAN

**Objectives/Win Conditions:**

There is an optional objective to capture or defend Signal hill, which will give whoever captured it 2 BTRs. 

The main objective is to control Arleville.

**Terrain:**

Arland.

**Short mission description:**

Opfor has mounted an assault on Arland with the intent to eliminate the FIA cell at Arleville. Opfor has inserted infantry with the goal to quietly take Signal Hill, cut off communications, receive asset support, and then wipe out the FIA cells at Arleville.

**Slotting Ratio:**

<3:2>

**Time limit:**

<60min>

**Mission Briefing Screenshot:**

![image](https://github.com/user-attachments/assets/86e0f5f0-bb17-4424-816e-c6c62241bd0a)


**Design concept/thoughts:**

This is a simple mission I set up before the update to make sure we had a quick, easy mission to go Friday. There is some flavor to it in that sides can fight over control of asset spawning. 

**Other Notes:**

Neither side have vehicle crews for the BTR that spawn, because I couldn't find a not obnoxious way to do that. They'll have to figure it out crewing them in situ. 
