### PR TITLE
Added "Get Them Out" HVT Mission to Kunar Province

### DIFF
--- a/Missions/CRF_HVT80_Get_Them_Out.conf
+++ b/Missions/CRF_HVT80_Get_Them_Out.conf
@@ -1,0 +1,13 @@
+SCR_MissionHeader {
+ World "{5413836B3CCD3177}Worlds/Lobby/Kunar/CRF_HVT_Get_Them_Out.ent"
+ m_sName "CRF HVT80 Get Them Out"
+ m_sAuthor "FanServ"
+ m_sDescription "Two forces on two sides of a valley must retrieve a HVT at the bottom of the valley."
+ m_sIcon "{B7385DA4504BD4D5}CRF Images/crflogo.edds"
+ m_sLoadingScreen "{B7385DA4504BD4D5}CRF Images/crflogo.edds"
+ m_sPreviewImage "{B7385DA4504BD4D5}CRF Images/crflogo.edds"
+ m_sGameMode "High Value Target"
+ m_iPlayerCount 80
+ m_iStartingHours 10
+ m_iMapMarkerLimitPerPlayer 120
+}

--- a/Missions/CRF_HVT80_Get_Them_Out.conf.meta
+++ b/Missions/CRF_HVT80_Get_Them_Out.conf.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{2B10C43115A03559}Missions/CRF_HVT80_Get_Them_Out.conf"
+ Configurations {
+  CONFResourceClass PC {
+  }
+  CONFResourceClass XBOX_ONE : PC {
+  }
+  CONFResourceClass XBOX_SERIES : PC {
+  }
+  CONFResourceClass PS4 : PC {
+  }
+  CONFResourceClass PS5 : PC {
+  }
+  CONFResourceClass HEADLESS : PC {
+  }
+  CONFResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Worlds/Lobby/Kunar/CRF_HVT_Get_Them_Out.ent
+++ b/Worlds/Lobby/Kunar/CRF_HVT_Get_Them_Out.ent
@@ -1,0 +1,3 @@
+SubScene {
+ Parent "{B264D601B4814028}worlds/KunarRagion/KunarRagion.ent"
+}

--- a/Worlds/Lobby/Kunar/CRF_HVT_Get_Them_Out.ent.meta
+++ b/Worlds/Lobby/Kunar/CRF_HVT_Get_Them_Out.ent.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{5413836B3CCD3177}Worlds/Lobby/Kunar/CRF_HVT_Get_Them_Out.ent"
+ Configurations {
+  ENTResourceClass PC {
+  }
+  ENTResourceClass XBOX_ONE : PC {
+  }
+  ENTResourceClass XBOX_SERIES : PC {
+  }
+  ENTResourceClass PS4 : PC {
+  }
+  ENTResourceClass PS5 : PC {
+  }
+  ENTResourceClass HEADLESS : PC {
+  }
+  ENTResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Worlds/Lobby/Kunar/CRF_HVT_Get_Them_Out_Layers/AAINIT.layer
+++ b/Worlds/Lobby/Kunar/CRF_HVT_Get_Them_Out_Layers/AAINIT.layer
@@ -1,0 +1,61 @@
+SCR_AIWorld : "{E0A05C76552E7F58}Prefabs/AI/SCR_AIWorld.et" {
+ coords 708.214 65.849 2903.259
+}
+PS_GameModeCoop CRF_GameMode_Lobby_1 : "{70D51A019CC9AA3F}Prefabs/MP/Modes/Lobby/CRF_GameMode_Lobby-12.et" {
+ components {
+  CRF_GearScriptGamemodeComponent "{628A6713CE1C127B}" {
+   m_BLUFORGearScriptSettings CRF_GearScriptContainer "{629E5222ADE13F54}" {
+    m_rGearScript "{3FCA1378C33401ED}Configs/Gearscripts/Standard/Modern/CRF_GS_RHSUSArmyMC.conf"
+   }
+   m_OPFORGearScriptSettings CRF_GearScriptContainer "{629E5222ACF12871}" {
+    m_rGearScript "{EC17EA82C390260C}Configs/Gearscripts/Standard/Modern/CRF_GS_RHSMSV.conf"
+   }
+  }
+  CRF_HighValueTargetGameModeComponent "{63282B5CAF0D50A4}" {
+   m_setUnconcious 1
+   m_transponderEntity "hostage"
+   m_searcherFactionKey ""
+  }
+  CRF_SafestartGameModeComponent "{61BCFEC3FE6731AB}" {
+   m_iTimeLimitMinutes 60
+  }
+  SCR_TimeAndWeatherHandlerComponent "{61BCFEC02D389E83}" {
+   m_iStartingHours 10
+  }
+ }
+ coords 702.276 93.326 2786.44
+ {
+  SCR_FactionManager "63284771CA860947" {
+   ID "61BCFEC02D38B83E"
+   Factions {
+    SCR_Faction "{628B22E9B4056C88}" {
+     m_CallsignInfo SCR_FactionCallsignInfo "{5DA0F2A6677ADA9E}" {
+      m_aSquadNames {
+       SCR_CallsignInfo "{63282B5C6C27DD16}" {
+        m_sCallsign "1-4"
+       }
+       SCR_CallsignInfo "{63282B5C6C7DA90F}" {
+        m_sCallsign "Sniper"
+       }
+      }
+     }
+    }
+    SCR_Faction "{628C2D2BFC8C6447}" {
+     m_CallsignInfo SCR_FactionCallsignInfo "{5DA0F2A67DFB8809}" {
+      m_aSquadNames {
+       SCR_CallsignInfo "{63282B5C768F9A4F}" {
+        m_sCallsign "1-4"
+       }
+       SCR_CallsignInfo "{63282B5C76F98B88}" {
+        m_sCallsign "Sniper"
+       }
+      }
+     }
+    }
+   }
+  }
+ }
+}
+SCR_BaseTriggerEntity hostage {
+ coords 725.055 101.388 2799.029
+}

--- a/Worlds/Lobby/Kunar/CRF_HVT_Get_Them_Out_Layers/AreaMarkers.layer
+++ b/Worlds/Lobby/Kunar/CRF_HVT_Get_Them_Out_Layers/AreaMarkers.layer
@@ -1,0 +1,228 @@
+$grp PS_ManualMarker : "{054125164E41BAB1}PrefabsEditable/Markers/BLUFORSafeStartBorderMarker.et" {
+ {
+  coords 983.97 163.786 2873.964
+ }
+ {
+  coords 949.22 171.765 2908.871
+ }
+ {
+  coords 965.876 159.94 2944.982
+ }
+ {
+  coords 991.202 146.696 2980.585
+ }
+ {
+  coords 1017.999 128.446 2994.706
+ }
+ {
+  coords 1056.232 96.333 3030.582
+ }
+ {
+  coords 1081.765 85.911 2972.432
+ }
+ {
+  coords 1037.297 110.089 2947.833
+ }
+ {
+  coords 1006.494 131.711 2919.572
+ }
+ {
+  coords 989.802 151.241 2900.614
+ }
+}
+$grp PS_ManualMarker : "{AE820D882CD0ACC4}PrefabsEditable/Markers/OPFORSafeStartBorderMarker.et" {
+ {
+  coords 263.577 173.038 2905.685
+ }
+ {
+  coords 227.991 165.451 2837.866
+ }
+ {
+  coords 177.911 121.083 2857.839
+ }
+ {
+  coords 143.849 96.438 2891.483
+ }
+ {
+  coords 162.473 100.865 2949.114
+ }
+ {
+  coords 195.985 100.349 2974.694
+ }
+ {
+  coords 218.16 128.74 2946.719
+ }
+ {
+  coords 232.923 147.81 2932.594
+ }
+}
+$grp PS_ManualMarker : "{BE9E1F90BFFBB48A}PrefabsEditable/Markers/GameZoneMarker.et" {
+ {
+  coords 995.888 29.116 3387.068
+  angleY 0
+ }
+ {
+  coords 1021.412 32.344 3301.061
+  angleY 0
+ }
+ {
+  coords 1044.631 40.461 3225.145
+  angleY 0
+ }
+ {
+  coords 1031.289 66.04 3148.502
+  angleY 0
+ }
+ {
+  coords 1046.301 71.707 3079.312
+  angleY 0
+ }
+ {
+  coords 1084.022 86.569 2982.145
+  angleY 0
+ }
+ {
+  coords 1088.383 97.933 2909.844
+  angleY 0
+ }
+ {
+  coords 1165.763 101.055 2867.622
+  angleY 0
+ }
+ {
+  coords 1217.235 102.537 2820.414
+  angleY 0
+ }
+ {
+  coords 1165.655 137.641 2722.054
+  angleY 0
+ }
+ {
+  coords 1139.169 190.213 2669.407
+  angleY 0
+ }
+ {
+  coords 1120.199 212.855 2618.632
+  angleY 0
+ }
+ {
+  coords 1099.327 198.454 2520.036
+  angleY 0
+ }
+ {
+  coords 1082.614 225.223 2469.013
+  angleY 0
+ }
+ {
+  coords 1026.983 166.707 2356.114
+  angleY 0
+ }
+ {
+  coords 990.313 146.664 2335.426
+  angleY 0
+ }
+ {
+  coords 941.972 129.289 2329.421
+  angleY 0
+ }
+ {
+  coords 883.545 114.822 2371.092
+  angleY 0
+ }
+ {
+  coords 822.593 113.182 2379.358
+  angleY 0
+ }
+ {
+  coords 741.077 145.38 2356.77
+  angleY 0
+ }
+ {
+  coords 686.416 177.525 2333.583
+  angleY 0
+ }
+ {
+  coords 618.713 139.682 2378.17
+  angleY 0
+ }
+ {
+  coords 598.145 123.125 2415.083
+  angleY 0
+ }
+ {
+  coords 572.112 109.215 2430.258
+  angleY 0
+ }
+ {
+  coords 540.434 108.865 2446.932
+  angleY 0
+ }
+ {
+  coords 481.93 143.611 2482.593
+  angleY 0
+ }
+ {
+  coords 407.118 185.496 2541.868
+  angleY 0
+ }
+ {
+  coords 361.056 226.551 2594.218
+  angleY 0
+ }
+ {
+  coords 308.258 264.937 2637.886
+  angleY 0
+ }
+ {
+  coords 217.206 212.973 2691.893
+  angleY 0
+ }
+ {
+  coords 201.392 164.013 2789.776
+  angleY 0
+ }
+ {
+  coords 161.914 110.489 2889.278
+  angleY 0
+ }
+ {
+  coords 176.105 97.136 2970.436
+  angleY 0
+ }
+ {
+  coords 208.313 67.423 3030.593
+  angleY 0
+ }
+ {
+  coords 271.431 36.724 3119.69
+  angleY 0
+ }
+ {
+  coords 299.102 36.406 3164.814
+  angleY 0
+ }
+ {
+  coords 285.266 53.957 3215.716
+  angleY 0
+ }
+ {
+  coords 389.355 51.054 3265.921
+  angleY 0
+ }
+ {
+  coords 465.303 51.005 3271.073
+  angleY 0
+ }
+ {
+  coords 538.129 41.729 3296.126
+  angleY 0
+ }
+ {
+  coords 750.375 38.633 3333.497
+  angleY 0
+ }
+ {
+  coords 870.154 34.428 3317.014
+  angleY 0
+ }
+}

--- a/Worlds/Lobby/Kunar/CRF_HVT_Get_Them_Out_Layers/BLUFOR.layer
+++ b/Worlds/Lobby/Kunar/CRF_HVT_Get_Them_Out_Layers/BLUFOR.layer
@@ -1,0 +1,31 @@
+SCR_AIGroup : "{3D4D53B053964445}Prefabs/Groups/BLUFOR/Standard/Command/CRF_BLUFOR_Platoon_p.et" {
+ coords 1033.662 122.386 2986.183
+ {
+  SCR_AIGroup : "{9C45BAF40F909576}Prefabs/Groups/BLUFOR/Standard/Infantry/CRF_BLUFOR_RifleSquad_p.et" {
+   coords 3.128 -1.473 6.176
+   {
+    SCR_AIGroup : "{9C45BAF40F909576}Prefabs/Groups/BLUFOR/Standard/Infantry/CRF_BLUFOR_RifleSquad_p.et" {
+     coords 4.543 -2.885 7.156
+     m_sCustomNameSet "2nd Squad"
+     {
+      SCR_AIGroup : "{9C45BAF40F909576}Prefabs/Groups/BLUFOR/Standard/Infantry/CRF_BLUFOR_RifleSquad_p.et" {
+       coords 4.39 -5.369 6.386
+       m_sCustomNameSet "3rd Squad"
+       {
+        SCR_AIGroup : "{9C45BAF40F909576}Prefabs/Groups/BLUFOR/Standard/Infantry/CRF_BLUFOR_RifleSquad_p.et" {
+         coords 5.986 -6.485 7.64
+         m_sCustomNameSet "4th Squad"
+         {
+          SCR_AIGroup : "{677549B9DAF416D1}Prefabs/Groups/BLUFOR/Standard/Support/CRF_BLUFOR_SniperTeam_p.et" {
+           coords 6.064 -3.899 6.147
+          }
+         }
+        }
+       }
+      }
+     }
+    }
+   }
+  }
+ }
+}

--- a/Worlds/Lobby/Kunar/CRF_HVT_Get_Them_Out_Layers/Briefing.layer
+++ b/Worlds/Lobby/Kunar/CRF_HVT_Get_Them_Out_Layers/Briefing.layer
@@ -1,0 +1,45 @@
+PS_MissionDescription : "{79EBB4201309B9F3}PrefabsEditable/MissionDescription/OPF_Brief.et" {
+ coords 688.738 76.554 2766.49
+ m_sTextData "There's a United States Army helicopter downed in the valley. We're not sure who took it down - either the Americans are trying to bait us into breaking the ceasefire or the local insurgents are provoking us both. Either way, they have already started firing at our position. Their surviving pilot in the valley seems to be alive - he will provide us the truth if we can capture him before the US army can rescue him."
+ m_aVisibleForFactions {
+  "OPFOR"
+ }
+}
+PS_MissionDescription : "{7D0DD3460BE3D185}PrefabsEditable/MissionDescription/Assets.et" {
+ coords 691.186 77.241 2764.548
+ m_sTextData "BLUFOR:"\
+ "1x Rifle Platoon"\
+ "1x Sniper Team"\
+ ""\
+ "OPFOR:"\
+ "1x Rifle Platoon"\
+ "1x Sniper Team"
+}
+PS_MissionDescription : "{8204C07A1B25066F}PrefabsEditable/MissionDescription/WelcomeDescription.et" {
+ coords 689.834 76.456 2764.343
+}
+PS_MissionDescription : "{AE37B19A0B021679}PrefabsEditable/MissionDescription/WinCondition.et" {
+ coords 690 76.827 2765.383
+ m_sTextData "BLUFOR:"\
+ ""\
+ "Secure the downed pilot and bring them to the FOB Thunderbolt extraction"\
+ "OR"\
+ "Eliminate all OPFOR"\
+ ""\
+ "OPFOR:"\
+ ""\
+ "Secure the downed pilot and bring them to the Kandar extraction"\
+ "OR"\
+ "Eliminate all BLUFOR"
+}
+PS_MissionDescription BLU_Brief_1 : "{DC34D37AC97B74B0}PrefabsEditable/MissionDescription/BLU_Brief.et" {
+ coords 682.341 76.749 2778.863
+ m_sTextData "The Russian MSV in the Iron Tower have officially broken the ceasefire and downed one of our Chinooks in the valley. The downed pilot is alive, but is unable to make it to our position up at OP Hawk, both because of their wounds and because of the enemy fire now coming from the Iron Tower. We will have to get into the valley and extract the pilot before they can capture him."
+ m_aVisibleForFactions {
+  "BLUFOR"
+ }
+}
+PS_MissionDescription : "{E600EB659F551D8E}PrefabsEditable/MissionDescription/Situation.et" {
+ coords 686.726 76.417 2769.216
+ m_sTextData "The Russian MSV in the Iron Tower and US Army MC at OP Hawk have maintained a tenuous ceasefire from opposite sides of the Kandar Valley. However, the suspicious movements of a United States Army Chinook have seemingly caused the Russian forces to down the helicopter in the valley. With the ceasefire officially broken, and the downed pilot stranded in the middle of the valley, each force must overcome the other to rescue/capture the pilot."
+}

--- a/Worlds/Lobby/Kunar/CRF_HVT_Get_Them_Out_Layers/OPFOR.layer
+++ b/Worlds/Lobby/Kunar/CRF_HVT_Get_Them_Out_Layers/OPFOR.layer
@@ -1,0 +1,31 @@
+SCR_AIGroup : "{6524B6A6C69BD3EE}Prefabs/Groups/OPFOR/Standard/Command/CRF_OPFOR_Platoon_p.et" {
+ coords 208.6 141.53 2916.065
+ {
+  SCR_AIGroup : "{92F50F60726EB86D}Prefabs/Groups/OPFOR/Standard/Infantry/CRF_OPFOR_RifleSquad_p.et" {
+   coords -6.322 -5.543 2.369
+   {
+    SCR_AIGroup : "{92F50F60726EB86D}Prefabs/Groups/OPFOR/Standard/Infantry/CRF_OPFOR_RifleSquad_p.et" {
+     coords -4.258 -2.531 0.832
+     m_sCustomNameSet "2nd Squad"
+     {
+      SCR_AIGroup : "{92F50F60726EB86D}Prefabs/Groups/OPFOR/Standard/Infantry/CRF_OPFOR_RifleSquad_p.et" {
+       coords -4.818 -3.715 3.078
+       m_sCustomNameSet "3rd Squad"
+       {
+        SCR_AIGroup : "{92F50F60726EB86D}Prefabs/Groups/OPFOR/Standard/Infantry/CRF_OPFOR_RifleSquad_p.et" {
+         coords -5.642 -4.085 2.822
+         m_sCustomNameSet "4th Squad"
+         {
+          SCR_AIGroup : "{F1CCAEAE38D65D9E}Prefabs/Groups/OPFOR/Standard/Support/CRF_OPFOR_SniperTeam_p.et" {
+           coords 14.445 15.907 -18.445
+          }
+         }
+        }
+       }
+      }
+     }
+    }
+   }
+  }
+ }
+}

--- a/Worlds/Lobby/Kunar/CRF_HVT_Get_Them_Out_Layers/Objectives.layer
+++ b/Worlds/Lobby/Kunar/CRF_HVT_Get_Them_Out_Layers/Objectives.layer
@@ -1,0 +1,68 @@
+PS_ManualMarker hostageInitPosMarker : "{054125164E41BAB1}PrefabsEditable/Markers/BLUFORSafeStartBorderMarker.et" {
+ coords 724.131 101.481 2799.609
+ angleY 90
+ m_MarkerColor 0.624 0.157 0.506 1
+ m_sQuadName "flag-2"
+ m_fWorldSize 60
+ m_sDescription "Hostage Init Pos"
+ m_aVisibleForFactions {
+  "OPFOR"
+ }
+}
+$grp PS_ManualMarker : "{7B677FB61E410D0D}PrefabsEditable/Markers/ObjectiveMarker.et" {
+ {
+  coords 839.002 114.644 2411.21
+  angleY 0
+  m_sDescription "Extract Hostage"
+  m_aVisibleForFactions {
+   "OPFOR"
+  }
+ }
+ {
+  coords 839.883 114.602 2412.962
+  angleY 0
+  m_sDescription "Prevent Hostage Extraction"
+  m_aVisibleForFactions {
+   "BLUFOR"
+  }
+ }
+ {
+  coords 477.324 46.668 3265.158
+  angleY 0
+  m_sDescription "Extract Hostage"
+  m_aVisibleForFactions {
+   "BLUFOR"
+  }
+ }
+ {
+  coords 478.762 46.506 3266.187
+  angleY 0
+  m_sDescription "Prevent Hostage Extraction"
+  m_aVisibleForFactions {
+   "OPFOR"
+  }
+ }
+ {
+  coords 717.479 102.299 2792.001
+  angleY 0
+  m_sDescription "Downed Helicopter"
+  m_aVisibleForFactions {
+   "BLUFOR" "OPFOR"
+  }
+ }
+}
+$grp PS_Objective : "{A4F0B4846EF850C4}Prefabs/Objective/Objective.et" {
+ {
+  coords 716.468 99.541 2802.423
+  m_sTitle "Extracted Hostage/Elim All BLUFOR"
+  m_iOrder 0
+  m_iScore 75
+  m_sFactionKey "OPFOR"
+ }
+ {
+  coords 711.514 100.112 2748.079
+  m_sTitle "Extracted Hostage/Elim All OPFOR"
+  m_iScore 75
+  m_sFactionKey "BLUFOR"
+ }
+}

--- a/Worlds/Lobby/Kunar/CRF_HVT_Get_Them_Out_Layers/Props.layer
+++ b/Worlds/Lobby/Kunar/CRF_HVT_Get_Them_Out_Layers/Props.layer
@@ -1,0 +1,100 @@
+ParticleEffectEntity {
+ coords 717.332 102.531 2792.945
+ EffectPath "{20B8063E61892CE3}Prefabs/Systems/Smoke/Smoke_inf_black.ptc"
+}
+$grp GenericEntity : "{01B8CDDADD56071C}Prefabs/Structures/Hesco/BigHescoWall.et" {
+ {
+  coords 354.676 232.662 2773.715
+  angleY 115
+  angleZ -3
+  scale 1.112
+ }
+ {
+  coords 358.544 232.297 2802.12
+  angleY 85
+  angleZ 2
+  scale 1.112
+ }
+ {
+  coords 359.182 231.961 2792.541
+  angleY 92
+  angleZ 0.498
+  scale 1.112
+ }
+ {
+  coords 357.79 232.212 2782.865
+  angleY 107
+  angleZ -3
+  scale 1.112
+ }
+ {
+  coords 348.616 235.204 2795.408
+  angleY 270
+  scale 1.112
+ }
+ {
+  coords 348.801 235.186 2785.854
+  angleY 270
+  scale 1.112
+ }
+}
+Vehicle M1152_TF_Transport_Tan1 : "{443FA665CFE5DCBE}Prefabs/Vehicles/Wheeled/M998/US/Utility/M1152_TF_Transport_Tan.et" {
+ coords 478.929 46.623 3263.686
+ angleX 5
+ angleY 240
+}
+Vehicle S1203_transport_beige1 : "{543799AC5C52989C}Prefabs/Vehicles/Wheeled/S1203/S1203_transport_beige.et" {
+ coords 843.017 114.986 2409.368
+ angleX 5
+ angleY 120
+}
+GenericEntity : "{54425F7795658997}Prefabs/Structures/Wreck/ch47.et" {
+ coords 717.076 101.083 2792.42
+ angleX 13
+ angleY 40
+}
+$grp GenericEntity : "{937999008F178E82}Prefabs/Props/Military/Sandbags/Sandbag_01_short_high_burlap.et" {
+ {
+  components {
+   Hierarchy "{59B6A7678CF0C99A}" {
+    Enabled 1
+   }
+  }
+  coords 927.05 192.021 2880.415
+  angleY 90
+ }
+ {
+  components {
+   Hierarchy "{59B6A7678CF0C99A}" {
+    Enabled 1
+   }
+  }
+  coords 927.067 191.95 2882.177
+  angleY 90
+ }
+ {
+  components {
+   Hierarchy "{59B6A7678CF0C99A}" {
+    Enabled 1
+   }
+  }
+  coords 927.071 190.738 2882.164
+  angleY 90
+ }
+}
+$grp SCR_DestructibleBuildingEntity : "{A24E20F839D2EB6F}Prefabs/Structures/Stairs/MEStairs.et" {
+ {
+  coords 973.353 2.738 2867.582
+  angleY 230
+ }
+ {
+  coords 962.658 -5.049 2853.215
+  angleY 305
+ }
+ {
+  coords 932.099 -6.036 2877.619
+  angleX 355
+  angleY 315
+  angleZ 5
+ }
+}


### PR DESCRIPTION
This Pull Request will:

Add the mission Get Them Out made by FanServ to the repository.

**Mission Creation Checklist:**
- [X] Mission File
- [X] Ingame Play Area Markers
- [X] Ingame Briefings to all players
- [X] Side-based briefings
- [X] Objective Entities
- [X] Mission .conf file

**Faction(s):**
BLUFOR - Attacking/Defending
- [X] RHS_USAF 

OPFOR - Attacking/Defending
- [X] RHS_AFRF

**Objectives/Win Conditions:**

BLUFOR:

Secure the downed pilot and bring them to the FOB Thunderbolt extraction
OR
Eliminate all OPFOR

OPFOR:

Secure the downed pilot and bring them to the Kandar extraction
OR
Eliminate all BLUFOR

**Terrain:**

Kunar Province

**Short mission description:**

The Russian MSV in the Iron Tower and US Army MC at OP Hawk have maintained a tenuous ceasefire from opposite sides of the Kandar Valley. However, the suspicious movements of a United States Army Chinook have seemingly caused the Russian forces to down the helicopter in the valley. With the ceasefire officially broken, and the downed pilot stranded in the middle of the valley, each force must overcome the other to rescue/capture the pilot.

**Slotting Ratio:**

1:1

**Time limit:**

60min

**Mission Briefing Screenshot:**

![GetThemOut](https://github.com/user-attachments/assets/e4239cf9-28d5-49c2-84ec-9bbbd85926bd)

**Design concept/thoughts:**

Symmetrical HVT mission with two outposts overlooking the HVT as well as the extracts. Teams will have to send some forces out of their outpost to get the HVT and to secure the extracts. Snipers are to prevent the enemy team from just waiting at their base (though that would be a bad strategy anyways).

**Other Notes:**

No special scripting, so victory will need to be triggered manually by Game Master.

BLUFOR:
1x Rifle Platoon
1x Sniper Team

OPFOR:
1x Rifle Platoon
1x Sniper Team
