### PR TITLE
Fixed Side Specific Briefing Items so they are uniform

### DIFF
--- a/scripts/Game/Systems/UI/Phases/CRF_BriefingMenu.c
+++ b/scripts/Game/Systems/UI/Phases/CRF_BriefingMenu.c
@@ -211,7 +211,7 @@ class CRF_PreviewMenuUI: ChimeraMenuBase
 			{
 				if(SCR_PlayerFactionAffiliationComponent.Cast(GetGame().GetPlayerController().FindComponent(SCR_PlayerFactionAffiliationComponent)).GetAffiliatedFactionKey() == factionKey)
 				{
-					m_cMissionDescriptionListBoxComponent.AddItem(description.m_sTitle);
+					m_cMissionDescriptionListBoxComponent.AddItem(description.m_sTitle, null, "{A564FC959554A1B9}UI/Listbox/DescriptionListboxElementNoIcon.layout");
 					m_aActiveDescriptors.Insert(description);
 					continue;
 				}


### PR DESCRIPTION
Fixed Side specific briefing items so they look universal to the rest.
![image](https://github.com/user-attachments/assets/64eae904-30cf-4532-9ea7-c6cfa715b449)
