### PR TITLE
Setting for enabling AI while in game state

### DIFF
--- a/scripts/Game/Systems/CRF_Gamemode.c
+++ b/scripts/Game/Systems/CRF_Gamemode.c
@@ -112,6 +112,9 @@ class CRF_Gamemode : SCR_BaseGameMode
 	[Attribute("45", "auto", "Mission Time (set to -1 to disable)", category: "CRF Gamemode General")]
 	int m_iTimeLimitMinutes;
 	
+	[Attribute("false", "auto", "Enables AI autonomy while in GAME state", category: "CRF Gamemode General")]
+	bool EnableAIInGameState;
+	
 	[Attribute("true", "auto", "Should we delete all JIP slots after SafeStart turns off? COOP = FALSE", category: "CRF Gamemode General")]
 	bool m_bDeleteJIPSlots;
 	

--- a/scripts/Game/Systems/CRF_PlayableCharacter.c
+++ b/scripts/Game/Systems/CRF_PlayableCharacter.c
@@ -45,7 +45,7 @@ class CRF_PlayableCharacter : ScriptComponent
 		if(!GetGame().InPlayMode())
 			return;
 		
-		if(CRF_Gamemode.GetInstance().m_GamemodeState == CRF_GamemodeState.GAME && CRF_Gamemode.GetInstance().EnableAIInGameState)
+		if(CRF_Gamemode.GetInstance().m_GamemodeState == CRF_GamemodeState.GAME && CRF_Gamemode.GetInstance().EnableAIInGameState && owner.GetPrefabData().GetPrefabName() != "{59886ECB7BBAF5BC}Prefabs/Characters/CRF_InitialEntity.et")
 			m_bIsPlayable = false;
 
 		if(m_bIsPlayable)

--- a/scripts/Game/Systems/CRF_PlayableCharacter.c
+++ b/scripts/Game/Systems/CRF_PlayableCharacter.c
@@ -45,7 +45,7 @@ class CRF_PlayableCharacter : ScriptComponent
 		if(!GetGame().InPlayMode())
 			return;
 		
-		if(CRF_Gamemode.GetInstance().m_GamemodeState == CRF_GamemodeState.GAME)
+		if(CRF_Gamemode.GetInstance().m_GamemodeState == CRF_GamemodeState.GAME && CRF_Gamemode.GetInstance().EnableAIInGameState)
 			m_bIsPlayable = false;
 
 		if(m_bIsPlayable)

--- a/scripts/Game/Systems/VanillaOverrides/CRF_SCR_AIGroups.c
+++ b/scripts/Game/Systems/VanillaOverrides/CRF_SCR_AIGroups.c
@@ -10,7 +10,12 @@ modded class SCR_AIGroup
 		if(!GetGame().InPlayMode())
 			return;
 		
-		if(CRF_Gamemode.GetInstance().m_GamemodeState == CRF_GamemodeState.GAME && CRF_Gamemode.GetInstance().EnableAIInGameState)
+		GetGame().GetCallqueue().CallLater(CheckIfPlayableOnInit, 1250, false);
+	}
+	
+	protected void CheckIfPlayableOnInit()
+	{
+		if(CRF_Gamemode.GetInstance().m_GamemodeState == CRF_GamemodeState.GAME && CRF_Gamemode.GetInstance().EnableAIInGameState && !CRF_PlayableCharacter.Cast(GetLeaderEntity().FindComponent(CRF_PlayableCharacter)).IsPlayable())
 			m_bIsPlayable = false;
 		
 		#ifdef WORKBENCH

--- a/scripts/Game/Systems/VanillaOverrides/CRF_SCR_AIGroups.c
+++ b/scripts/Game/Systems/VanillaOverrides/CRF_SCR_AIGroups.c
@@ -10,7 +10,7 @@ modded class SCR_AIGroup
 		if(!GetGame().InPlayMode())
 			return;
 		
-		if(CRF_Gamemode.GetInstance().m_GamemodeState == CRF_GamemodeState.GAME)
+		if(CRF_Gamemode.GetInstance().m_GamemodeState == CRF_GamemodeState.GAME && CRF_Gamemode.GetInstance().EnableAIInGameState)
 			m_bIsPlayable = false;
 		
 		#ifdef WORKBENCH


### PR DESCRIPTION
Adds a setting that allows mission designers to enable/disable AI while in the game state; this is primarily so that during respawn or disconnect, the AI doesn't wander around.