### PR TITLE
Fix for players spawning in the wrong groups

### DIFF
--- a/scripts/Game/Systems/CRF_Gamemode.c
+++ b/scripts/Game/Systems/CRF_Gamemode.c
@@ -521,7 +521,7 @@ class CRF_Gamemode : SCR_BaseGameMode
 				if (!m_iBLUFORCurrentTickets == 0)
 				{
 					GetGame().GetCallqueue().CallLater(SendRespawnScreen, 250, false, playerID, groupID);
-					if (m_iBLUFORCurrentTickets != -1)
+					if (m_iBLUFORCurrentTickets != -1 && !CRF_GamemodeComponent.GetInstance().GetSafestartStatus())
 						m_iBLUFORCurrentTickets = m_iBLUFORCurrentTickets - 1;
 				}
 				break;
@@ -530,7 +530,7 @@ class CRF_Gamemode : SCR_BaseGameMode
 				if (!m_iOPFORCurrentTickets == 0)
 				{
 					GetGame().GetCallqueue().CallLater(SendRespawnScreen, 250, false, playerID, groupID);
-					if (m_iOPFORCurrentTickets != -1)
+					if (m_iOPFORCurrentTickets != -1 && !CRF_GamemodeComponent.GetInstance().GetSafestartStatus())
 						m_iOPFORCurrentTickets = m_iOPFORCurrentTickets - 1;
 				}
 				break;
@@ -539,13 +539,13 @@ class CRF_Gamemode : SCR_BaseGameMode
 				if (!m_iINDFORCurrentTickets == 0)
 				{
 					GetGame().GetCallqueue().CallLater(SendRespawnScreen, 250, false, playerID, groupID);
-					if (m_iINDFORCurrentTickets != -1)
+					if (m_iINDFORCurrentTickets != -1 && !CRF_GamemodeComponent.GetInstance().GetSafestartStatus())
 						m_iINDFORCurrentTickets = m_iINDFORCurrentTickets - 1;	
 				}
 				break;
 			}
 			case "CIV" : {
-				if (!m_iCIVCurrentTickets == 0)
+				if (!m_iCIVCurrentTickets == 0 && !CRF_GamemodeComponent.GetInstance().GetSafestartStatus())
 				{
 					GetGame().GetCallqueue().CallLater(SendRespawnScreen, 250, false, playerID, groupID);
 					if (m_iCIVCurrentTickets != -1)

--- a/scripts/Game/Systems/CRF_Gamemode.c
+++ b/scripts/Game/Systems/CRF_Gamemode.c
@@ -219,7 +219,8 @@ class CRF_Gamemode : SCR_BaseGameMode
 		
 		// Throw em into deathscreen
 		if (m_bRespawnEnabled)
-			CheckTickets(playerId);
+			CheckTickets(playerId, SCR_GroupsManagerComponent.GetInstance().GetPlayerGroup(playerId).GetGroupID());
+		
 		
 		//Throw em into spectator
 		GetGame().GetCallqueue().CallLater(SetPlayerSpectator, 100, false, playerId, playerEntity);
@@ -458,79 +459,51 @@ class CRF_Gamemode : SCR_BaseGameMode
 	}
 
 	//------------------------------------------------------------------------------------------------
-	void CheckTickets(int playerID)
+	void CheckTickets(int playerID, int groupID)
 	{
 		bool canRespawn = true;
-		string faction = SCR_GroupsManagerComponent.GetInstance().FindGroup(GetRespawnGroupID(playerID)).GetFaction().GetFactionKey();	
+		string faction = SCR_GroupsManagerComponent.GetInstance().FindGroup(groupID).GetFaction().GetFactionKey();	
 		        
-		// TODO: Collapse these two switch statements together
 		switch(faction)
 		{
 			case "BLUFOR" : {
-				if (m_iBLUFORCurrentTickets == 0) {
-					canRespawn = false
-				}; 	
+				if (!m_iBLUFORCurrentTickets == 0)
+				{
+					GetGame().GetCallqueue().CallLater(SendRespawnScreen, 250, false, playerID, groupID);
+					if (m_iBLUFORCurrentTickets != -1)
+						m_iBLUFORCurrentTickets = m_iBLUFORCurrentTickets - 1;
+				}
 				break;
 			}
-			case "OPFOR"  : {
-				if (m_iOPFORCurrentTickets == 0) {
-					canRespawn = false
-				}; 	
+			case "OPFOR" : {
+				if (!m_iOPFORCurrentTickets == 0)
+				{
+					GetGame().GetCallqueue().CallLater(SendRespawnScreen, 250, false, playerID, groupID);
+					if (m_iOPFORCurrentTickets != -1)
+						m_iOPFORCurrentTickets = m_iOPFORCurrentTickets - 1;
+				}
 				break;
 			}
 			case "INDFOR" : {
-				if (m_iINDFORCurrentTickets == 0) {
-					canRespawn = false
-				}; 	
+				if (!m_iINDFORCurrentTickets == 0)
+				{
+					GetGame().GetCallqueue().CallLater(SendRespawnScreen, 250, false, playerID, groupID);
+					if (m_iINDFORCurrentTickets != -1)
+						m_iINDFORCurrentTickets = m_iINDFORCurrentTickets - 1;	
+				}
 				break;
 			}
 			case "CIV" : {
-				if (m_iCIVCurrentTickets == 0) {
-					canRespawn = false
-				}; 	
+				if (!m_iCIVCurrentTickets == 0)
+				{
+					GetGame().GetCallqueue().CallLater(SendRespawnScreen, 250, false, playerID, groupID);
+					if (m_iCIVCurrentTickets != -1)
+						m_iCIVCurrentTickets = m_iCIVCurrentTickets - 1;
+				}
 				break;
 			}
 		}
-		
-		if (canRespawn)
-		{
-			// Start respawn process
-			GetGame().GetCallqueue().CallLater(SendRespawnScreen, 250, false, playerID);	
-			
-			// Subtract respawn tickets		
-			switch(faction)
-			{
-				case "BLUFOR" 	: {
-					m_iBLUFORCurrentTickets = m_iBLUFORCurrentTickets - 1;	
-					break;
-				}
-				case "OPFOR"  	: {
-					m_iOPFORCurrentTickets = m_iOPFORCurrentTickets - 1;   	
-					break;
-				}
-				case "INDFOR" 	: {
-					m_iINDFORCurrentTickets = m_iINDFORCurrentTickets - 1;		
-					break;
-				}
-				case "CIV" 		: {
-					m_iCIVCurrentTickets = m_iCIVCurrentTickets - 1;			
-					break;
-				}
-			}
-			Replication.BumpMe();
-		}
-			
-	}
-
-	//------------------------------------------------------------------------------------------------
-	int GetRespawnGroupID(int playerID)
-	{
-		int playerEntityRplID = m_aEntitySlots.Get(m_aSlots.Find(playerID));
-		int playerGroupRplID = m_aPlayerGroupIDs.Get(m_aEntitySlots.Find(playerEntityRplID));
-		int GroupRplID = m_aGroupRplIDs.Get(m_aPlayerGroupIDs.Find(playerGroupRplID));
-		int groupID = m_aGroupRplIDs.Find(GroupRplID);
-		
-		return groupID;
+		Replication.BumpMe();
 	}
 	//------------------------------------------------------------------------------------------------
 	void UpdateRespawnTimer()
@@ -553,14 +526,14 @@ class CRF_Gamemode : SCR_BaseGameMode
 	}
 
 	//------------------------------------------------------------------------------------------------
-	void SendRespawnScreen(int playerId)
+	void SendRespawnScreen(int playerId, int groupID)
 	{
-		Rpc(RpcDo_SendRespawnScreen, playerId)	
+		Rpc(RpcDo_SendRespawnScreen, playerId, groupID)	
 	}
 
 	//------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Broadcast)]
-	void RpcDo_SendRespawnScreen(int playerId)
+	void RpcDo_SendRespawnScreen(int playerId, int groupID)
 	{
 		if(SCR_PlayerController.GetLocalPlayerId() != playerId)
 			return;
@@ -570,19 +543,21 @@ class CRF_Gamemode : SCR_BaseGameMode
 			topMenu.Close();
 
 		GetGame().GetMenuManager().CloseAllMenus();
-		GetGame().GetMenuManager().OpenMenu(ChimeraMenuPreset.CRF_RespawnMenu);
+		MenuBase respawnMenu = GetGame().GetMenuManager().OpenMenu(ChimeraMenuPreset.CRF_RespawnMenu);
+		CRF_RespawnMenu respawnMenuUI = CRF_RespawnMenu.Cast(respawnMenu);
+		respawnMenuUI.m_iGroupID = groupID;
 			
 	}
 
 	//------------------------------------------------------------------------------------------------
-	void RespawnPlayerTicket(int playerId)
+	void RespawnPlayerTicket(int playerId, int groupID)
 	{
-		Rpc(RpcDo_RespawnPlayerTicket, playerId)	
+		Rpc(RpcDo_RespawnPlayerTicket, playerId, groupID)	
 	}
 
 	//------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
-	void RpcDo_RespawnPlayerTicket(int playerID)
+	void RpcDo_RespawnPlayerTicket(int playerID, int groupID)
 	{
 		if(!Replication.IsServer())
 		{
@@ -593,8 +568,7 @@ class CRF_Gamemode : SCR_BaseGameMode
 		if(SCR_FactionManager.SGetPlayerFaction(playerID).GetFactionKey() == "SPEC")
 		{	
 			string respawnPrefab = CRF_GamemodeComponent.GetInstance().ReturnPlayerGearScriptsMapValue(playerID, "GSR");
-			int respawnGroupID = GetRespawnGroupID(playerID);
-			string faction = SCR_GroupsManagerComponent.GetInstance().FindGroup(respawnGroupID).GetFaction().GetFactionKey();
+			string faction = SCR_GroupsManagerComponent.GetInstance().FindGroup(groupID).GetFaction().GetFactionKey();
 			string spawnpoint
 			
 			if(respawnPrefab.IsEmpty())
@@ -625,7 +599,7 @@ class CRF_Gamemode : SCR_BaseGameMode
 			
 			Resource resource = Resource.Load(respawnPrefab);
 			SCR_WorldTools.FindEmptyTerrainPosition(finalSpawnLocation, spawnLocation, 3);
-			RespawnPlayer(playerID, respawnPrefab, finalSpawnLocation, respawnGroupID);
+			RespawnPlayer(playerID, respawnPrefab, finalSpawnLocation, groupID);
 		}
 	}
 	//------------------------------------------------------------------------------------------------	

--- a/scripts/Game/Systems/UI/HUDs/CRF_GameTimerDisplay.c
+++ b/scripts/Game/Systems/UI/HUDs/CRF_GameTimerDisplay.c
@@ -121,21 +121,21 @@ class CRF_GameTimerDisplay : SCR_InfoDisplay
 					{			
 						case "BLUFOR"	:	{
 							if (CRF_Gamemode.GetInstance().m_iBLUFORCurrentTickets == -1)
-								m_wTicketOneNumber.SetText("∞");
+								m_wTicketOneNumber.SetText("INF");
 							else
 								m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iBLUFORCurrentTickets.ToString());
 							break;
 						}
 						case "OPFOR"	:	{
 							if (CRF_Gamemode.GetInstance().m_iOPFORCurrentTickets == -1)
-								m_wTicketOneNumber.SetText("∞");
+								m_wTicketOneNumber.SetText("INF");
 							else		
 								m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iOPFORCurrentTickets.ToString());
 							break;
 						}
 						case "INDFOR"	:	{
 							if (CRF_Gamemode.GetInstance().m_iINDFORCurrentTickets == -1)
-								m_wTicketOneNumber.SetText("∞");
+								m_wTicketOneNumber.SetText("INF");
 							else
 								m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iINDFORCurrentTickets.ToString());
 	
@@ -143,7 +143,7 @@ class CRF_GameTimerDisplay : SCR_InfoDisplay
 						}
 						case "CIV"	:	{
 							if (CRF_Gamemode.GetInstance().m_iCIVCurrentTickets == -1)
-								m_wTicketOneNumber.SetText("∞");
+								m_wTicketOneNumber.SetText("INF");
 							else
 								m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iCIVCurrentTickets.ToString());
 							break;
@@ -155,7 +155,7 @@ class CRF_GameTimerDisplay : SCR_InfoDisplay
 				m_wTicketOneNumber.SetColor(factionManager.GetFactionByKey("BLUFOR").GetFactionColor());
 				m_wTicketOneImage.SetColor(factionManager.GetFactionByKey("BLUFOR").GetFactionColor());
 				if (CRF_Gamemode.GetInstance().m_iBLUFORCurrentTickets == -1)
-					m_wTicketOneNumber.SetText("∞");
+					m_wTicketOneNumber.SetText("INF");
 				else
 					m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iBLUFORCurrentTickets.ToString());
 				
@@ -163,7 +163,7 @@ class CRF_GameTimerDisplay : SCR_InfoDisplay
 				m_wTicketTwoNumber.SetColor(factionManager.GetFactionByKey("OPFOR").GetFactionColor());
 				m_wTicketTwoImage.SetColor(factionManager.GetFactionByKey("OPFOR").GetFactionColor());
 				if (CRF_Gamemode.GetInstance().m_iOPFORCurrentTickets == -1)
-					m_wTicketTwoNumber.SetText("∞");
+					m_wTicketTwoNumber.SetText("INF");
 				else
 					m_wTicketTwoNumber.SetText(CRF_Gamemode.GetInstance().m_iOPFORCurrentTickets.ToString());
 				
@@ -172,7 +172,7 @@ class CRF_GameTimerDisplay : SCR_InfoDisplay
 				m_wTicketThreeImage.SetColor(factionManager.GetFactionByKey("INDFOR").GetFactionColor());
 				m_wTicketThreeNumber.SetText(CRF_Gamemode.GetInstance().m_iINDFORCurrentTickets.ToString());
 				if (CRF_Gamemode.GetInstance().m_iINDFORCurrentTickets == -1)
-					m_wTicketThreeNumber.SetText("∞");
+					m_wTicketThreeNumber.SetText("INF");
 				else
 					m_wTicketThreeNumber.SetText(CRF_Gamemode.GetInstance().m_iINDFORCurrentTickets.ToString());
 				
@@ -180,7 +180,7 @@ class CRF_GameTimerDisplay : SCR_InfoDisplay
 				m_wTicketFourNumber.SetColor(factionManager.GetFactionByKey("CIV").GetFactionColor());
 				m_wTicketFourImage.SetColor(factionManager.GetFactionByKey("CIV").GetFactionColor());
 				if (CRF_Gamemode.GetInstance().m_iCIVCurrentTickets == -1)
-					m_wTicketFourNumber.SetText("∞");
+					m_wTicketFourNumber.SetText("INF");
 				else
 					m_wTicketFourNumber.SetText(CRF_Gamemode.GetInstance().m_iCIVCurrentTickets.ToString());
 			}

--- a/scripts/Game/Systems/UI/HUDs/CRF_GameTimerDisplay.c
+++ b/scripts/Game/Systems/UI/HUDs/CRF_GameTimerDisplay.c
@@ -60,10 +60,10 @@ class CRF_GameTimerDisplay : SCR_InfoDisplay
 			m_wTicketTwoNumber			= TextWidget.Cast(m_wRoot.FindWidget("TicketTwoNumber"));
 			m_wTicketTwoBackground       	= ImageWidget.Cast(m_wRoot.FindWidget("TicketTwoBackground"));
 			
-			m_wTicketThreeImage			= ImageWidget.Cast(m_wRoot.FindWidget("TicketThreeImage"));
-			m_wTicketThreeText			= TextWidget.Cast(m_wRoot.FindWidget("TicketThreeText"));
+			m_wTicketThreeImage				= ImageWidget.Cast(m_wRoot.FindWidget("TicketThreeImage"));
+			m_wTicketThreeText				= TextWidget.Cast(m_wRoot.FindWidget("TicketThreeText"));
 			m_wTicketThreeNumber			= TextWidget.Cast(m_wRoot.FindWidget("TicketThreeNumber"));
-			m_wTicketThreeBackground		= ImageWidget.Cast(m_wRoot.FindWidget("TicketThreeBackground"));
+			m_wTicketThreeBackground       	= ImageWidget.Cast(m_wRoot.FindWidget("TicketThreeBackground"));
 			
 			m_wTicketFourImage			= ImageWidget.Cast(m_wRoot.FindWidget("TicketFourImage"));
 			m_wTicketFourText			= TextWidget.Cast(m_wRoot.FindWidget("TicketFourText"));
@@ -108,39 +108,81 @@ class CRF_GameTimerDisplay : SCR_InfoDisplay
 			
 			if (!SCR_Global.IsAdmin(SCR_PlayerController.GetLocalPlayerId()) && CRF_Gamemode.GetInstance().m_bRespawnEnabled)
 			{
-				string faction = SCR_GroupsManagerComponent.GetInstance().FindGroup(CRF_Gamemode.GetInstance().GetRespawnGroupID(SCR_PlayerController.GetLocalPlayerId())).GetFaction().GetFactionKey();
+				string faction = SCR_FactionManager.SGetLocalPlayerFaction().GetFactionKey();
 				
-				m_wTicketOneText.SetColor(factionManager.GetFactionByKey(faction).GetFactionColor());
-				m_wTicketOneNumber.SetColor(factionManager.GetFactionByKey(faction).GetFactionColor());
-				m_wTicketOneImage.SetColor(factionManager.GetFactionByKey(faction).GetFactionColor());
-				
-				switch(faction)
-				{			
-					case "BLUFOR"	:{m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iBLUFORCurrentTickets.ToString()); 	break;}
-					case "OPFOR"	:{m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iOPFORCurrentTickets.ToString()); 	break;}
-					case "INDFOR"	:{m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iINDFORCurrentTickets.ToString()); 	break;}
-					case "CIV"		:{m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iCIVCurrentTickets.ToString()); 		break;}
+				// This will cause the ui to not update tickets when in spectator!
+				if (SCR_FactionManager.SGetLocalPlayerFaction().GetFactionKey() != "SPEC") 
+				{
+					m_wTicketOneText.SetColor(factionManager.GetFactionByKey(faction).GetFactionColor());
+					m_wTicketOneNumber.SetColor(factionManager.GetFactionByKey(faction).GetFactionColor());
+					m_wTicketOneImage.SetColor(factionManager.GetFactionByKey(faction).GetFactionColor());
+					
+					switch(faction)
+					{			
+						case "BLUFOR"	:	{
+							if (CRF_Gamemode.GetInstance().m_iBLUFORCurrentTickets == -1)
+								m_wTicketOneNumber.SetText("∞");
+							else
+								m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iBLUFORCurrentTickets.ToString());
+							break;
+						}
+						case "OPFOR"	:	{
+							if (CRF_Gamemode.GetInstance().m_iOPFORCurrentTickets == -1)
+								m_wTicketOneNumber.SetText("∞");
+							else		
+								m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iOPFORCurrentTickets.ToString());
+							break;
+						}
+						case "INDFOR"	:	{
+							if (CRF_Gamemode.GetInstance().m_iINDFORCurrentTickets == -1)
+								m_wTicketOneNumber.SetText("∞");
+							else
+								m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iINDFORCurrentTickets.ToString());
+	
+							break;
+						}
+						case "CIV"	:	{
+							if (CRF_Gamemode.GetInstance().m_iCIVCurrentTickets == -1)
+								m_wTicketOneNumber.SetText("∞");
+							else
+								m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iCIVCurrentTickets.ToString());
+							break;
+						}
+					}
 				}
 			}else{
 				m_wTicketOneText.SetColor(factionManager.GetFactionByKey("BLUFOR").GetFactionColor());
 				m_wTicketOneNumber.SetColor(factionManager.GetFactionByKey("BLUFOR").GetFactionColor());
 				m_wTicketOneImage.SetColor(factionManager.GetFactionByKey("BLUFOR").GetFactionColor());
-				m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iBLUFORCurrentTickets.ToString());
+				if (CRF_Gamemode.GetInstance().m_iBLUFORCurrentTickets == -1)
+					m_wTicketOneNumber.SetText("∞");
+				else
+					m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iBLUFORCurrentTickets.ToString());
 				
 				m_wTicketTwoText.SetColor(factionManager.GetFactionByKey("OPFOR").GetFactionColor());
 				m_wTicketTwoNumber.SetColor(factionManager.GetFactionByKey("OPFOR").GetFactionColor());
 				m_wTicketTwoImage.SetColor(factionManager.GetFactionByKey("OPFOR").GetFactionColor());
-				m_wTicketTwoNumber.SetText(CRF_Gamemode.GetInstance().m_iOPFORCurrentTickets.ToString());
+				if (CRF_Gamemode.GetInstance().m_iOPFORCurrentTickets == -1)
+					m_wTicketTwoNumber.SetText("∞");
+				else
+					m_wTicketTwoNumber.SetText(CRF_Gamemode.GetInstance().m_iOPFORCurrentTickets.ToString());
 				
 				m_wTicketThreeText.SetColor(factionManager.GetFactionByKey("INDFOR").GetFactionColor());
 				m_wTicketThreeNumber.SetColor(factionManager.GetFactionByKey("INDFOR").GetFactionColor());
 				m_wTicketThreeImage.SetColor(factionManager.GetFactionByKey("INDFOR").GetFactionColor());
 				m_wTicketThreeNumber.SetText(CRF_Gamemode.GetInstance().m_iINDFORCurrentTickets.ToString());
+				if (CRF_Gamemode.GetInstance().m_iINDFORCurrentTickets == -1)
+					m_wTicketThreeNumber.SetText("∞");
+				else
+					m_wTicketThreeNumber.SetText(CRF_Gamemode.GetInstance().m_iINDFORCurrentTickets.ToString());
 				
 				m_wTicketFourText.SetColor(factionManager.GetFactionByKey("CIV").GetFactionColor());
 				m_wTicketFourNumber.SetColor(factionManager.GetFactionByKey("CIV").GetFactionColor());
 				m_wTicketFourImage.SetColor(factionManager.GetFactionByKey("CIV").GetFactionColor());
-				m_wTicketFourNumber.SetText(CRF_Gamemode.GetInstance().m_iCIVCurrentTickets.ToString());
+				if (CRF_Gamemode.GetInstance().m_iCIVCurrentTickets == -1)
+					m_wTicketFourNumber.SetText("∞");
+				else
+					m_wTicketFourNumber.SetText(CRF_Gamemode.GetInstance().m_iCIVCurrentTickets.ToString());
 			}
 		}
 		

--- a/scripts/Game/Systems/UI/HUDs/CRF_GameTimerDisplay.c
+++ b/scripts/Game/Systems/UI/HUDs/CRF_GameTimerDisplay.c
@@ -62,7 +62,7 @@ class CRF_GameTimerDisplay : SCR_InfoDisplay
 			
 			m_wTicketThreeImage				= ImageWidget.Cast(m_wRoot.FindWidget("TicketThreeImage"));
 			m_wTicketThreeText				= TextWidget.Cast(m_wRoot.FindWidget("TicketThreeText"));
-			m_wTicketThreeNumber				= TextWidget.Cast(m_wRoot.FindWidget("TicketThreeNumber"));
+			m_wTicketThreeNumber			= TextWidget.Cast(m_wRoot.FindWidget("TicketThreeNumber"));
 			m_wTicketThreeBackground       	= ImageWidget.Cast(m_wRoot.FindWidget("TicketThreeBackground"));
 			
 			m_wTicketFourImage				= ImageWidget.Cast(m_wRoot.FindWidget("TicketFourImage"));
@@ -108,39 +108,81 @@ class CRF_GameTimerDisplay : SCR_InfoDisplay
 			
 			if (!SCR_Global.IsAdmin(SCR_PlayerController.GetLocalPlayerId()))
 			{
-				string faction = SCR_GroupsManagerComponent.GetInstance().FindGroup(CRF_Gamemode.GetInstance().GetRespawnGroupID(SCR_PlayerController.GetLocalPlayerId())).GetFaction().GetFactionKey();
+				string faction = SCR_FactionManager.SGetLocalPlayerFaction().GetFactionKey();
 				
-				m_wTicketOneText.SetColor(factionManager.GetFactionByKey(faction).GetFactionColor());
-				m_wTicketOneNumber.SetColor(factionManager.GetFactionByKey(faction).GetFactionColor());
-				m_wTicketOneImage.SetColor(factionManager.GetFactionByKey(faction).GetFactionColor());
-				
-				switch(faction)
-				{			
-					case "BLUFOR"	:{m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iBLUFORCurrentTickets.ToString()); 	break;}
-					case "OPFOR"	:{m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iOPFORCurrentTickets.ToString()); 	break;}
-					case "INDFOR"	:{m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iINDFORCurrentTickets.ToString()); 	break;}
-					case "CIV"		:{m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iCIVCurrentTickets.ToString()); 		break;}
+				// This will cause the ui to not update tickets when in spectator!
+				if (SCR_FactionManager.SGetLocalPlayerFaction().GetFactionKey() != "SPEC") 
+				{
+					m_wTicketOneText.SetColor(factionManager.GetFactionByKey(faction).GetFactionColor());
+					m_wTicketOneNumber.SetColor(factionManager.GetFactionByKey(faction).GetFactionColor());
+					m_wTicketOneImage.SetColor(factionManager.GetFactionByKey(faction).GetFactionColor());
+					
+					switch(faction)
+					{			
+						case "BLUFOR"	:	{
+							if (CRF_Gamemode.GetInstance().m_iBLUFORCurrentTickets == -1)
+								m_wTicketOneNumber.SetText("∞");
+							else
+								m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iBLUFORCurrentTickets.ToString());
+							break;
+						}
+						case "OPFOR"	:	{
+							if (CRF_Gamemode.GetInstance().m_iOPFORCurrentTickets == -1)
+								m_wTicketOneNumber.SetText("∞");
+							else		
+								m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iOPFORCurrentTickets.ToString());
+							break;
+						}
+						case "INDFOR"	:	{
+							if (CRF_Gamemode.GetInstance().m_iINDFORCurrentTickets == -1)
+								m_wTicketOneNumber.SetText("∞");
+							else
+								m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iINDFORCurrentTickets.ToString());
+	
+							break;
+						}
+						case "CIV"	:	{
+							if (CRF_Gamemode.GetInstance().m_iCIVCurrentTickets == -1)
+								m_wTicketOneNumber.SetText("∞");
+							else
+								m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iCIVCurrentTickets.ToString());
+							break;
+						}
+					}
 				}
 			}else{
 				m_wTicketOneText.SetColor(factionManager.GetFactionByKey("BLUFOR").GetFactionColor());
 				m_wTicketOneNumber.SetColor(factionManager.GetFactionByKey("BLUFOR").GetFactionColor());
 				m_wTicketOneImage.SetColor(factionManager.GetFactionByKey("BLUFOR").GetFactionColor());
-				m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iBLUFORCurrentTickets.ToString());
+				if (CRF_Gamemode.GetInstance().m_iBLUFORCurrentTickets == -1)
+					m_wTicketOneNumber.SetText("∞");
+				else
+					m_wTicketOneNumber.SetText(CRF_Gamemode.GetInstance().m_iBLUFORCurrentTickets.ToString());
 				
 				m_wTicketTwoText.SetColor(factionManager.GetFactionByKey("OPFOR").GetFactionColor());
 				m_wTicketTwoNumber.SetColor(factionManager.GetFactionByKey("OPFOR").GetFactionColor());
 				m_wTicketTwoImage.SetColor(factionManager.GetFactionByKey("OPFOR").GetFactionColor());
-				m_wTicketTwoNumber.SetText(CRF_Gamemode.GetInstance().m_iOPFORCurrentTickets.ToString());
+				if (CRF_Gamemode.GetInstance().m_iOPFORCurrentTickets == -1)
+					m_wTicketTwoNumber.SetText("∞");
+				else
+					m_wTicketTwoNumber.SetText(CRF_Gamemode.GetInstance().m_iOPFORCurrentTickets.ToString());
 				
 				m_wTicketThreeText.SetColor(factionManager.GetFactionByKey("INDFOR").GetFactionColor());
 				m_wTicketThreeNumber.SetColor(factionManager.GetFactionByKey("INDFOR").GetFactionColor());
 				m_wTicketThreeImage.SetColor(factionManager.GetFactionByKey("INDFOR").GetFactionColor());
 				m_wTicketThreeNumber.SetText(CRF_Gamemode.GetInstance().m_iINDFORCurrentTickets.ToString());
+				if (CRF_Gamemode.GetInstance().m_iINDFORCurrentTickets == -1)
+					m_wTicketThreeNumber.SetText("∞");
+				else
+					m_wTicketThreeNumber.SetText(CRF_Gamemode.GetInstance().m_iINDFORCurrentTickets.ToString());
 				
 				m_wTicketFourText.SetColor(factionManager.GetFactionByKey("CIV").GetFactionColor());
 				m_wTicketFourNumber.SetColor(factionManager.GetFactionByKey("CIV").GetFactionColor());
 				m_wTicketFourImage.SetColor(factionManager.GetFactionByKey("CIV").GetFactionColor());
-				m_wTicketFourNumber.SetText(CRF_Gamemode.GetInstance().m_iCIVCurrentTickets.ToString());
+				if (CRF_Gamemode.GetInstance().m_iCIVCurrentTickets == -1)
+					m_wTicketFourNumber.SetText("∞");
+				else
+					m_wTicketFourNumber.SetText(CRF_Gamemode.GetInstance().m_iCIVCurrentTickets.ToString());
 			}
 		}
 		

--- a/scripts/Game/Systems/UI/HUDs/CRF_GameTimerDisplay.c
+++ b/scripts/Game/Systems/UI/HUDs/CRF_GameTimerDisplay.c
@@ -46,24 +46,24 @@ class CRF_GameTimerDisplay : SCR_InfoDisplay
 		// Respawn support
 		if (!m_GamemodeComponent || !m_wTimer || !m_wBackground || !m_MapEntity) 
 		{
-			m_GamemodeComponent 	= CRF_GamemodeComponent.GetInstance();
-			m_wTimer            	= TextWidget.Cast(m_wRoot.FindWidget("timeLeftTimer"));
-			m_wBackground       	= ImageWidget.Cast(m_wRoot.FindWidget("timeLeftBackground"));
+			m_GamemodeComponent 		= CRF_GamemodeComponent.GetInstance();
+			m_wTimer            		= TextWidget.Cast(m_wRoot.FindWidget("timeLeftTimer"));
+			m_wBackground       		= ImageWidget.Cast(m_wRoot.FindWidget("timeLeftBackground"));
 			
 			m_wTicketOneImage			= ImageWidget.Cast(m_wRoot.FindWidget("TicketOneImage"));
-			m_wTicketOneText				= TextWidget.Cast(m_wRoot.FindWidget("TicketOneText"));
+			m_wTicketOneText			= TextWidget.Cast(m_wRoot.FindWidget("TicketOneText"));
 			m_wTicketOneNumber			= TextWidget.Cast(m_wRoot.FindWidget("TicketOneNumber"));
-			m_wTicketOneBackground       	= ImageWidget.Cast(m_wRoot.FindWidget("TicketOneBackground"));
+			m_wTicketOneBackground     	= ImageWidget.Cast(m_wRoot.FindWidget("TicketOneBackground"));
 			
 			m_wTicketTwoImage			= ImageWidget.Cast(m_wRoot.FindWidget("TicketTwoImage"));
-			m_wTicketTwoText				= TextWidget.Cast(m_wRoot.FindWidget("TicketTwoText"));
+			m_wTicketTwoText			= TextWidget.Cast(m_wRoot.FindWidget("TicketTwoText"));
 			m_wTicketTwoNumber			= TextWidget.Cast(m_wRoot.FindWidget("TicketTwoNumber"));
-			m_wTicketTwoBackground       	= ImageWidget.Cast(m_wRoot.FindWidget("TicketTwoBackground"));
+			m_wTicketTwoBackground     	= ImageWidget.Cast(m_wRoot.FindWidget("TicketTwoBackground"));
 			
-			m_wTicketThreeImage				= ImageWidget.Cast(m_wRoot.FindWidget("TicketThreeImage"));
-			m_wTicketThreeText				= TextWidget.Cast(m_wRoot.FindWidget("TicketThreeText"));
-			m_wTicketThreeNumber			= TextWidget.Cast(m_wRoot.FindWidget("TicketThreeNumber"));
-			m_wTicketThreeBackground       	= ImageWidget.Cast(m_wRoot.FindWidget("TicketThreeBackground"));
+			m_wTicketThreeImage			= ImageWidget.Cast(m_wRoot.FindWidget("TicketThreeImage"));
+			m_wTicketThreeText			= TextWidget.Cast(m_wRoot.FindWidget("TicketThreeText"));
+			m_wTicketThreeNumber		= TextWidget.Cast(m_wRoot.FindWidget("TicketThreeNumber"));
+			m_wTicketThreeBackground	= ImageWidget.Cast(m_wRoot.FindWidget("TicketThreeBackground"));
 			
 			m_wTicketFourImage			= ImageWidget.Cast(m_wRoot.FindWidget("TicketFourImage"));
 			m_wTicketFourText			= TextWidget.Cast(m_wRoot.FindWidget("TicketFourText"));

--- a/scripts/Game/Systems/UI/Respawn/CRF_RespawnUI.c
+++ b/scripts/Game/Systems/UI/Respawn/CRF_RespawnUI.c
@@ -12,6 +12,8 @@ class CRF_RespawnMenu: ChimeraMenuBase
 	
 	int m_iCurrentWaveTimer;
 	
+	int m_iGroupID;
+	
 	void displayTimer()
 	{
 		TextWidget timerWidget = TextWidget.Cast(GetRootWidget().FindAnyWidget("timerCountDown"));
@@ -25,7 +27,7 @@ class CRF_RespawnMenu: ChimeraMenuBase
 		
 		if (m_iCurrentWaveTimer < 0)
 		{
-			SCR_PlayerController.Cast(GetGame().GetPlayerController()).RespawnWithTicket(GetGame().GetPlayerController().GetPlayerId());
+			SCR_PlayerController.Cast(GetGame().GetPlayerController()).RespawnWithTicket(GetGame().GetPlayerController().GetPlayerId(), m_iGroupID);
 			GetGame().GetMenuManager().CloseAllMenus();
 		}
 		

--- a/scripts/Game/Systems/VanillaOverrides/CRF_SCR_PlayerController.c
+++ b/scripts/Game/Systems/VanillaOverrides/CRF_SCR_PlayerController.c
@@ -145,15 +145,15 @@ modded class SCR_PlayerController
 	}
 	
 	// Ask server to respawn player after timer ends
-	void RespawnWithTicket(int playerId)
+	void RespawnWithTicket(int playerId, int groupID)
 	{
-		Rpc(RpcDo_RespawnWithTicket, playerId)	
+		Rpc(RpcDo_RespawnWithTicket, playerId, groupID)	
 	}
 	
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
-	void RpcDo_RespawnWithTicket(int playerID)
+	void RpcDo_RespawnWithTicket(int playerID, int groupID)
 	{
-		CRF_Gamemode.GetInstance().RespawnPlayerTicket(playerID);
+		CRF_Gamemode.GetInstance().RespawnPlayerTicket(playerID, groupID);
 	}
 	
 	void UpdateCameraPos(vector cameraPos[4])

--- a/scripts/Game/Systems/VanillaOverrides/CRF_SCR_PlayerController.c
+++ b/scripts/Game/Systems/VanillaOverrides/CRF_SCR_PlayerController.c
@@ -134,15 +134,15 @@ modded class SCR_PlayerController
 	}
 	
 	// Ask server to respawn player after timer ends
-	void RespawnWithTicket(int playerId)
+	void RespawnWithTicket(int playerId, int groupID)
 	{
-		Rpc(RpcDo_RespawnWithTicket, playerId)	
+		Rpc(RpcDo_RespawnWithTicket, playerId, groupID)	
 	}
 	
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
-	void RpcDo_RespawnWithTicket(int playerID)
+	void RpcDo_RespawnWithTicket(int playerID, int groupID)
 	{
-		CRF_Gamemode.GetInstance().RespawnPlayerTicket(playerID);
+		CRF_Gamemode.GetInstance().RespawnPlayerTicket(playerID, groupID);
 	}
 	
 	void UpdateCameraPos(vector cameraPos[4])


### PR DESCRIPTION
Instead of getting the groupIDs from the lobby arrays get it from the OnPlayerKilled event which should hopefully be more reliable and not put people in the wrong groups when they respawn and some cleanup and handling of tickets