### PR TITLE
Assign Squardleaders automatically

### DIFF
--- a/scripts/Game/Systems/CRF_ClientComponent.c
+++ b/scripts/Game/Systems/CRF_ClientComponent.c
@@ -1,23 +1,23 @@
 [ComponentEditorProps(category: "Client Component", description: "")]
-class CRF_ClientComponentClass : ScriptComponentClass
+class CRF_ClientComponentClass: ScriptComponentClass
 {
-
+	
 }
 
-class CRF_ClientComponent : ScriptComponent
+class CRF_ClientComponent: ScriptComponent
 {
 	string m_sHintText = "Type Here";
-
-	ref array<string> m_aScriptedMarkers = {};
-
+	
+	ref array<string> m_aScriptedMarkers = new array<string>; 
+	
 	protected CRF_GamemodeComponent m_gamemodeComponent;
-
+		
 	//------------------------------------------------------------------------------------------------
 
 	// override/static functions
 
 	//------------------------------------------------------------------------------------------------
-
+	
 	static CRF_ClientComponent GetInstance()
 	{
 		if (GetGame().GetPlayerController())
@@ -25,100 +25,101 @@ class CRF_ClientComponent : ScriptComponent
 		else
 			return null;
 	}
-
+	
 	//------------------------------------------------------------------------------------------------
-	override protected void OnPostInit(IEntity owner)
+	override protected void OnPostInit(IEntity owner) 
 	{
 		super.OnPostInit(owner);
-
-		if (!GetGame().InPlayMode() || RplSession.Mode() == RplMode.Dedicated)
+		
+		if (!GetGame().InPlayMode() || RplSession.Mode() == RplMode.Dedicated) 
 			return;
 
+		
 		GetGame().GetInputManager().AddActionListener("CRF_ToggleSideReady", EActionTrigger.DOWN, ToggleSideReady);
 		GetGame().GetInputManager().AddActionListener("CRF_AdminForceReady", EActionTrigger.DOWN, AdminForceReady);
-
+	
 		SCR_PlayerController.Cast(owner).m_OnControlledEntityChanged.Insert(OnControlledEntityChanged);
 		GetGame().GetCallqueue().CallLater(WaitTillGameStart, 500, true);
 		GetGame().GetCallqueue().CallLater(AddAdvanceAction, 0, false);
 	}
-
+	
 	//------------------------------------------------------------------------------------------------
 	//\***********************************************************************************************
 	//\***********************************************************************************************
-
+	
 	// Specific Gamemode Functions
-
+	
 	//\***********************************************************************************************
 	//\***********************************************************************************************
 	//------------------------------------------------------------------------------------------------
-
+	
 	//------------------------------------------------------------------------------------------------
 	// Functions for Search and Destroy
 	//------------------------------------------------------------------------------------------------
-
+	
 	void Owner_ToggleBombPlanted(string sitePlanted, bool togglePlanted)
-	{
+	{	
 		Rpc(RpcAsk_ToggleBombPlanted, sitePlanted, togglePlanted);
 	}
-
+	
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcAsk_ToggleBombPlanted(string sitePlanted, bool togglePlanted)
 	{
 		CRF_SearchAndDestroyGameModeComponent.Cast(GetGame().GetGameMode().FindComponent(CRF_SearchAndDestroyGameModeComponent)).ToggleBombPlanted(sitePlanted, togglePlanted);
 	}
-
+	
 	//------------------------------------------------------------------------------------------------
 	// Functions for Frontline
 	//------------------------------------------------------------------------------------------------
-
+	
 	void UpdateMapMarkers(array<string> zoneStatus, array<string> zoneObjectNames, FactionKey bluforSide, FactionKey opforSide)
-	{
+	{	
 		RemoveALLScriptedMarkers();
-
-		foreach (int i, string zoneName : zoneObjectNames)
+		
+		foreach(int i, string zoneName : zoneObjectNames)
 		{
 			string status = zoneStatus[i];
 			string imageTexture;
 			int imageColor;
-
+			
 			array<string> zoneStatusArray = {};
 			status.Split(":", zoneStatusArray, false);
-
+			
 			string zoneLocked = zoneStatusArray[1];
 			FactionKey zoneFactionStored = zoneStatusArray[2];
-
-			switch (i)
+			
+			switch(i)
 			{
-				case 0 : {imageTexture = "{21A2A457BD0E42C1}UI\Objectives\A.edds"; break; };
-				case 1 : {imageTexture = "{7F4A8D140283CCCE}UI\Objectives\B.edds"; break; };
-				case 2 : {imageTexture = "{8B42CA8C0F5EA4BA}UI\Objectives\C.edds"; break; };
-				case 3 : {imageTexture = "{C29ADF937D98D0D0}UI\Objectives\D.edds"; break; };
-				case 4 : {imageTexture = "{3692980B7045B8A4}UI\Objectives\E.edds"; break; };
+				case 0 : {imageTexture = "{21A2A457BD0E42C1}UI\Objectives\A.edds"; break;};
+				case 1 : {imageTexture = "{7F4A8D140283CCCE}UI\Objectives\B.edds"; break;};
+				case 2 : {imageTexture = "{8B42CA8C0F5EA4BA}UI\Objectives\C.edds"; break;};
+				case 3 : {imageTexture = "{C29ADF937D98D0D0}UI\Objectives\D.edds"; break;};
+				case 4 : {imageTexture = "{3692980B7045B8A4}UI\Objectives\E.edds"; break;};
 			}
-
-			if (zoneLocked == "Locked")
+			
+			if(zoneLocked == "Locked")
 				AddScriptedMarker(zoneName, "0 0 0", 0, "", "{91427B7866707601}UI\Objectives\lock.edds", 50, ARGB(255, 142, 142, 142));
-
-			switch (zoneFactionStored)
+			
+			switch(zoneFactionStored)
 			{
-				case bluforSide : {imageColor = ARGB(255, 0, 25, 225); break; }; //Blufor
-				case opforSide : {imageColor = ARGB(255, 225, 25, 0); break; }; //Opfor
-				default : {imageColor = ARGB(255, 225, 225, 225); break; }; //Uncaptured
+				case bluforSide : {imageColor = ARGB(255, 0, 25, 225);     break;};  //Blufor
+				case opforSide  : {imageColor = ARGB(255, 225, 25, 0);     break;};  //Opfor
+				default         : {imageColor = ARGB(255, 225, 225, 225);  break;};  //Uncaptured
 			}
-
+			
 			AddScriptedMarker(zoneName, "0 0 0", 0, "", imageTexture, 45, imageColor);
 		}
 	}
-
+	
 	//------------------------------------------------------------------------------------------------
 	// Functions for scripted markers
 	//------------------------------------------------------------------------------------------------
-
+	
 	TStringArray GetScriptedMarkersArray()
 	{
 		return m_aScriptedMarkers;
 	}
-
+	
 	//------------------------------------------------------------------------------------------------
 	//! !LOCAL! Adds a scripted marker on the users map which will follow the specified entity
 	//! \param[in] markerEntityName is the name of the entity the marker will track.
@@ -138,27 +139,27 @@ class CRF_ClientComponent : ScriptComponent
 	{
 		m_aScriptedMarkers.RemoveItemOrdered(string.Format("%1||%2||%3||%4||%5||%6||%7", markerEntityName, markerOffset.ToString(), timeDelay.ToString(), markerText, markerImage, zOrder.ToString(), markerColor.ToString()));
 	}
-
+	
 	//------------------------------------------------------------------------------------------------
 	//! !LOCAL! Removes all scripted markers from the users maps
 	void RemoveALLScriptedMarkers()
 	{
 		m_aScriptedMarkers.Clear();
 	}
-
+	
 	//------------------------------------------------------------------------------------------------
 	//\***********************************************************************************************
 	//\***********************************************************************************************
-
+	
 	// Admin Menu
-
+	
 	//\***********************************************************************************************
 	//\***********************************************************************************************
 	//------------------------------------------------------------------------------------------------
-
+	
 	void SendAdminMessage(string data)
 	{
-
+		
 		PlayerController pc = GetGame().GetPlayerController();
 		if (!pc)
 			return;
@@ -169,418 +170,413 @@ class CRF_ClientComponent : ScriptComponent
 		data = string.Format("PlayerID: %1 | Player Name: %3 | \"%2\"", GetGame().GetPlayerController().GetPlayerId(), data, GetGame().GetPlayerManager().GetPlayerName(GetGame().GetPlayerController().GetPlayerId()));
 		Rpc(RpcAsk_SendAdminMessage, data);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcAsk_SendAdminMessage(string data)
 	{
 		m_gamemodeComponent = CRF_GamemodeComponent.Cast(GetGame().GetGameMode().FindComponent(CRF_GamemodeComponent));
 		m_gamemodeComponent.SendAdminMessage(data);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void ReplyAdminMessage(string data, bool logAction)
 	{
-		array<string> dataSplit = {};
+		ref array<string> dataSplit = {};
 		data.Split(" ", dataSplit, false);
 		int playerID;
 		string toSend;
-		for (int i = 0; i < dataSplit.Count(); i++)
+		for(int i = 0; i < dataSplit.Count(); i++)
 		{
-			if (dataSplit[i] == "0")
+			if(dataSplit[i] == "0")
 			{
 				dataSplit.RemoveOrdered(i);
 				playerID = 0;
 				toSend = SCR_StringHelper.Join(" ", dataSplit, true);
 				break;
 			}
-
-			if (dataSplit[i].ToInt() > 0)
+			
+			if(dataSplit[i].ToInt() > 0)
 			{
 				playerID = dataSplit[i].ToInt();
 				dataSplit.RemoveOrdered(i);
 				toSend = SCR_StringHelper.Join(" ", dataSplit, true);
 				break;
 			}
-		}
+		}	
 		PlayerController pc = GetGame().GetPlayerController();
 		if (!pc)
 			return;
 		SCR_ChatComponent chatComponent = SCR_ChatComponent.Cast(pc.FindComponent(SCR_ChatComponent));
 		if (!chatComponent)
 			return;
-		if (!playerID)
+		if(!playerID)
 		{
 			chatComponent.ShowMessage("INVALID PLAYER ID");
 			return;
 		}
-		if (!GetGame().GetPlayerManager().GetPlayerName(playerID))
+		if(!GetGame().GetPlayerManager().GetPlayerName(playerID))
 		{
 			chatComponent.ShowMessage("INVALID PLAYER ID");
 			return;
 		}
-
+				
 		chatComponent.ShowMessage(string.Format("Message Sent to %2: \"%1\"", toSend, GetGame().GetPlayerManager().GetPlayerName(playerID)));
 		toSend = string.Format("\"%1\"", toSend);
 		Rpc(RpcAsk_ReplyAdminMessage, toSend, playerID, logAction);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcAsk_ReplyAdminMessage(string data, int playerID, bool logAction)
 	{
 		m_gamemodeComponent = CRF_GamemodeComponent.Cast(GetGame().GetGameMode().FindComponent(CRF_GamemodeComponent));
 		m_gamemodeComponent.ReplyAdminMessage(data, playerID, logAction);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// Respawn
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SpawnOnGroup(int playerID, vector spawnLocation, int groupID, bool logAction)
 	{
 		Rpc(RpcAsk_SpawnOnGroup, playerID, spawnLocation, groupID, logAction);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcAsk_SpawnOnGroup(int playerID, vector spawnLocation, int groupID, bool logAction)
 	{
 		m_gamemodeComponent = CRF_GamemodeComponent.Cast(GetGame().GetGameMode().FindComponent(CRF_GamemodeComponent));
 		m_gamemodeComponent.SpawnOnGroupServer(playerID, spawnLocation, groupID, logAction);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void RequestGroupIdFromServer(int requestedId, int requesterID)
 	{
 		Rpc(RpcAsk_RequestGroupIdFromServer, requestedId, requesterID);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcAsk_RequestGroupIdFromServer(int requestedId, int requesterID)
 	{
 		m_gamemodeComponent = CRF_GamemodeComponent.Cast(GetGame().GetGameMode().FindComponent(CRF_GamemodeComponent));
 		m_gamemodeComponent.SendGroupIDToPlayer(requestedId, requesterID);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// Gear
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void ResetGear(int playerID, ResourceName prefab, bool logAction)
 	{
 		Rpc(RpcAsk_ResetGear, playerID, prefab, logAction);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcAsk_ResetGear(int playerID, ResourceName prefab, bool logAction)
 	{
 		m_gamemodeComponent = CRF_GamemodeComponent.Cast(GetGame().GetGameMode().FindComponent(CRF_GamemodeComponent));
 		m_gamemodeComponent.SetPlayerGear(playerID, prefab, logAction);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void AddItem(int playerID, string prefab, bool logAction)
 	{
 		Rpc(RpcAsk_AddItem, playerID, prefab, logAction);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcAsk_AddItem(int playerID, string prefab, bool logAction)
 	{
 		m_gamemodeComponent = CRF_GamemodeComponent.Cast(GetGame().GetGameMode().FindComponent(CRF_GamemodeComponent));
 		m_gamemodeComponent.AddItem(playerID, prefab, logAction);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// Teleport
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void TeleportLocalPlayer(int playerID1, int playerID2)
 	{
 		IEntity entity2 = GetGame().GetPlayerManager().GetPlayerControlledEntity(playerID2);
 		EntitySpawnParams spawnParams = new EntitySpawnParams();
-		spawnParams.TransformMode = ETransformMode.WORLD;
+	    spawnParams.TransformMode = ETransformMode.WORLD;
 		vector teleportLocation = vector.Zero;
 		SCR_WorldTools.FindEmptyTerrainPosition(teleportLocation, entity2.GetOrigin(), 10);
-		spawnParams.Transform[3] = teleportLocation;
-
+	    spawnParams.Transform[3] = teleportLocation;
+	
 		SCR_Global.TeleportPlayer(playerID1, teleportLocation);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void TeleportPlayers(int playerID1, int playerID2, bool logAction)
 	{
 		Rpc(RpcAsk_TeleportPlayers, playerID1, playerID2, logAction);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcAsk_TeleportPlayers(int playerID1, int playerID2, bool logAction)
 	{
 		m_gamemodeComponent = CRF_GamemodeComponent.Cast(GetGame().GetGameMode().FindComponent(CRF_GamemodeComponent));
 		m_gamemodeComponent.TeleportPlayers(playerID1, playerID2, logAction);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// Hint
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SendHintAll(string data)
 	{
 		Rpc(RpcAsk_SendHintAll, data);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcAsk_SendHintAll(string data)
 	{
 		m_gamemodeComponent = CRF_GamemodeComponent.Cast(GetGame().GetGameMode().FindComponent(CRF_GamemodeComponent));
 		m_gamemodeComponent.SendHintAll(data);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SendHintPlayer(string data, int playerID)
 	{
 		Rpc(RpcAsk_SendHintPlayer, data, playerID);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcAsk_SendHintPlayer(string data, int playerID)
 	{
 		m_gamemodeComponent = CRF_GamemodeComponent.Cast(GetGame().GetGameMode().FindComponent(CRF_GamemodeComponent));
 		m_gamemodeComponent.SendHintPlayer(data, playerID);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SendHintFaction(string data, string factionKey)
 	{
 		Rpc(RpcAsk_SendHintFaction, data, factionKey);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcAsk_SendHintFaction(string data, string factionKey)
 	{
 		m_gamemodeComponent = CRF_GamemodeComponent.Cast(GetGame().GetGameMode().FindComponent(CRF_GamemodeComponent));
 		m_gamemodeComponent.SendHintFaction(data, factionKey);
 	}
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// Heal
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void HealPlayer(int playerID, bool logAction)
 	{
 		Rpc(RpcAsk_HealPlayer, playerID, logAction);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcAsk_HealPlayer(int playerID, bool logAction)
 	{
 		m_gamemodeComponent = CRF_GamemodeComponent.Cast(GetGame().GetGameMode().FindComponent(CRF_GamemodeComponent));
 		m_gamemodeComponent.HealPlayer(playerID, logAction);
 	}
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void HealPlayerVehicle(int playerID, bool logAction)
 	{
 		Rpc(RpcAsk_HealPlayerVehicle, playerID, logAction);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcAsk_HealPlayerVehicle(int playerID, bool logAction)
 	{
 		m_gamemodeComponent = CRF_GamemodeComponent.Cast(GetGame().GetGameMode().FindComponent(CRF_GamemodeComponent));
 		m_gamemodeComponent.HealPlayerVehicle(playerID, logAction);
 	}
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// Log Admin Action
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void LogAdminAction(string data, int playerID, bool sendToPlayer)
 	{
 		Rpc(RpcAsk_LogAdminAction, data, playerID, sendToPlayer);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcAsk_LogAdminAction(string data, int playerID, bool sendToPlayer)
 	{
 		m_gamemodeComponent = CRF_GamemodeComponent.Cast(GetGame().GetGameMode().FindComponent(CRF_GamemodeComponent));
 		m_gamemodeComponent.LogAdminAction(data, playerID, sendToPlayer);
 	}
-
+	
 	//------------------------------------------------------------------------------------------------
 	//\***********************************************************************************************
 	//\***********************************************************************************************
-
+	
 	// Gearscript
-
+	
 	//\***********************************************************************************************
 	//\***********************************************************************************************
 	//------------------------------------------------------------------------------------------------
-
+	
 	//------------------------------------------------------------------------------------------------
 	protected void WaitTillGameStart()
 	{
-		if (!SCR_BaseGameMode.Cast(GetGame().GetGameMode()).IsRunning())
+		if(!SCR_BaseGameMode.Cast(GetGame().GetGameMode()).IsRunning())
 			return;
-
+		
 		GetGame().GetCallqueue().Remove(WaitTillGameStart);
 		GetGame().GetCallqueue().CallLater(DelayUpdate, 5000, false);
 	}
-
+	
 	//------------------------------------------------------------------------------------------------
 	protected void DelayUpdate()
 	{
 		IEntity entity = SCR_PlayerController.GetLocalMainEntity();
-
-		if (entity && entity.GetPrefabData().GetPrefabName() != "{59886ECB7BBAF5BC}Prefabs/Characters/CRF_InitialEntity.et")
+		
+		if(entity && entity.GetPrefabData().GetPrefabName() != "{59886ECB7BBAF5BC}Prefabs/Characters/CRF_InitialEntity.et")
 		{
 			OnControlledEntityChanged(SCR_PlayerController.GetLocalMainEntity(), SCR_PlayerController.GetLocalMainEntity());
 		}
 	}
-
+	
 	//------------------------------------------------------------------------------------------------
 	protected void OnControlledEntityChanged(IEntity from, IEntity to)
 	{
-		if (!to.GetPrefabData().GetPrefabName().Contains("CRF_GS_"))
+		if(!to.GetPrefabData().GetPrefabName().Contains("CRF_GS_"))
 			return;
-
+		
 		Rpc(RpcAsk_UpdatePlayerGearScriptMap, to.GetPrefabData().GetPrefabName(), SCR_PlayerController.GetLocalPlayerId(), "GSR"); // GSR = Gear Script Resource
 	}
-
+	
 	//------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	protected void RpcAsk_UpdatePlayerGearScriptMap(string value, int playerID, string key)
 	{
 		CRF_GamemodeComponent.GetInstance().SetPlayerGearScriptsMapValue(value, playerID, key);
 	}
-
+	
 	//------------------------------------------------------------------------------------------------
 	//\***********************************************************************************************
 	//\***********************************************************************************************
-
+	
 	// Safestart
-
+	
 	//\***********************************************************************************************
 	//\***********************************************************************************************
 	//------------------------------------------------------------------------------------------------
-
-	void ToggleSideReady()
+	
+	void ToggleSideReady() 
 	{
 		SCR_GroupsManagerComponent groupManager = SCR_GroupsManagerComponent.GetInstance();
-		if (!groupManager)
-			return;
-
+		if(!groupManager) return;
+		
 		SCR_AIGroup playersGroup = groupManager.GetPlayerGroup(SCR_PlayerController.GetLocalPlayerId());
-		if (!playersGroup)
-			return;
-
+		if(!playersGroup) return;
+		
 		string playerName = GetGame().GetPlayerManager().GetPlayerName(SCR_PlayerController.GetLocalPlayerId());
-
-		if (!playerName || playerName == "")
-			return;
-
-		if (playersGroup.IsPlayerLeader(SCR_PlayerController.GetLocalPlayerId()))
+		
+		if (!playerName || playerName == "") return;
+		
+		if (playersGroup.IsPlayerLeader(SCR_PlayerController.GetLocalPlayerId())) 
 			Owner_ToggleSideReady(playerName);
 	}
-
+	
 	void AdminForceReady()
-	{
-		if (!SCR_Global.IsAdmin())
-			return;
+	{		
+		if (!SCR_Global.IsAdmin()) return;
 		Rpc(RpcAsk_ToggleSideReady, "", GetGame().GetPlayerManager().GetPlayerName(SCR_PlayerController.GetLocalPlayerId()), true);
 	}
-
+	
 	//------------------------------------------------------------------------------------------------
 	void Owner_ToggleSideReady(string playerName)
-	{
+	{	
 		SCR_FactionManager factionManager = SCR_FactionManager.Cast(GetGame().GetFactionManager());
 		Faction faction = factionManager.GetPlayerFaction(SCR_PlayerController.GetLocalPlayerId());
-
-		if (faction.GetFactionKey() == "")
-			return;
+		
+		if (faction.GetFactionKey() == "") return;
 		Rpc(RpcAsk_ToggleSideReady, faction.GetFactionKey(), playerName, false);
 	}
-
+	
 	//------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcAsk_ToggleSideReady(string setReady, string playerName, bool adminForced)
 	{
 		CRF_GamemodeComponent.GetInstance().ToggleSideReady(setReady, playerName, adminForced);
 	}
-
+	
 	//------------------------------------------------------------------------------------------------
 	//\***********************************************************************************************
 	//\***********************************************************************************************
-
+	
 	// Radio  Respawn
-
+	
 	//\***********************************************************************************************
 	//\***********************************************************************************************
 	//------------------------------------------------------------------------------------------------
-
+	
 	void SpawnGroupServer(int groupID)
 	{
 		Rpc(RpcAsk_SpawnGroupServer, groupID);
 	}
-
+	
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcAsk_SpawnGroupServer(int groupID)
 	{
 //		CRF_RadioRespawnSystemComponent m_radioComponent = CRF_RadioRespawnSystemComponent.Cast(GetGame().GetGameMode().FindComponent(CRF_RadioRespawnSystemComponent));
 //		m_radioComponent.SpawnGroupServer(groupID);
 	}
-
+	
 	//------------------------------------------------------------------------------------------------
 	//\***********************************************************************************************
 	//\***********************************************************************************************
-
+	
 	// Spectator
-
+	
 	//\***********************************************************************************************
 	//\***********************************************************************************************
 	//------------------------------------------------------------------------------------------------
-
+	
 	void RequestSpectator(int playerId)
 	{
 		Rpc(RpcAsk_RequestSpectator, playerId);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcAsk_RequestSpectator(int playerId)
 	{
 		CRF_Gamemode.GetInstance().EnterSpectator(playerId);
 	}
-
+	
 	//------------------------------------------------------------------------------------------------
 	//\***********************************************************************************************
 	//\***********************************************************************************************
-
+	
 	// AAR Screen
-
+	
 	//\***********************************************************************************************
 	//\***********************************************************************************************
 	//------------------------------------------------------------------------------------------------
-
-	void AddAdvanceAction()
+	
+	void AddAdvanceAction() 
 	{
 		SCR_ChatPanelManager chatPanelManager = SCR_ChatPanelManager.GetInstance();
 		ChatCommandInvoker invoker = chatPanelManager.GetCommandInvoker("aar");
 		invoker.Insert(Advance_Callback);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void Advance_Callback(SCR_ChatPanel panel, string data)
 	{
 		if (!SCR_Global.IsAdmin())
 			return;
-
+		
 		Rpc(RpcAsk_Advance_Callback)
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcAsk_Advance_Callback()
 	{

--- a/scripts/Game/Systems/CRF_Gamemode.c
+++ b/scripts/Game/Systems/CRF_Gamemode.c
@@ -915,17 +915,17 @@ class CRF_Gamemode : SCR_BaseGameMode
 	{	
 		if(RplSession.Mode() == RplMode.Dedicated)
 		{			
-			IEntity entity = GetGame().GetPlayerManager().GetPlayerControlledEntity(aiGroup.GetLeaderID());
-			if (!entity)
+			IEntity currentLeaderEntity = GetGame().GetPlayerManager().GetPlayerControlledEntity(aiGroup.GetLeaderID());
+			if (!currentLeaderEntity)
 				return;
 			
-			if (!CheckLeaderRole(entity))
+			if (!IsSquadLeaderRole(currentLeaderEntity))
 			{
 				IEntity player = GetGame().GetPlayerManager().GetPlayerControlledEntity(playerID);
 				if (!player)
 					return;
 				
-				if (CheckLeaderRole(player))
+				if (IsSquadLeaderRole(player))
 				{
 					SCR_GroupsManagerComponent.GetInstance().SetGroupLeader(aiGroup.GetGroupID(), playerID);
 				}
@@ -938,31 +938,21 @@ class CRF_Gamemode : SCR_BaseGameMode
 	{
 		if(RplSession.Mode() == RplMode.Dedicated)
 		{
-			IEntity entity = GetGame().GetPlayerManager().GetPlayerControlledEntity(aiGroup.GetLeaderID());
-			if (!entity)
+			IEntity currentLeaderEntity = GetGame().GetPlayerManager().GetPlayerControlledEntity(aiGroup.GetLeaderID());
+			if (!currentLeaderEntity)
 				return;
 
-			if (!CheckLeaderRole(entity))
+			if (!IsSquadLeaderRole(currentLeaderEntity))
 			{
 				array<int> groupMembers = aiGroup.GetPlayerIDs();
 				
 				foreach (int member : groupMembers)
 				{
 					IEntity memberEntity = GetGame().GetPlayerManager().GetPlayerControlledEntity(member);
-					ResourceName prefab = memberEntity.GetPrefabData().GetPrefabName();
-					
-					if(!prefab.Contains("CRF_GS_") || !memberEntity)
+					if (!memberEntity)
 						return;
 					
-					array<string> value = {};
-					prefab.Split("_", value, true);
-					
-					string role = "_" + value[3] + "_" + value[4];
-					
-					role.Split(".", value, true);
-					role = value[0];
-					
-					if (role == "_TL_P")
+					if (IsTeamLeaderRole(memberEntity))
 					{
 						SCR_GroupsManagerComponent.GetInstance().SetGroupLeader(aiGroup.GetGroupID(), member);
 						break;
@@ -974,13 +964,33 @@ class CRF_Gamemode : SCR_BaseGameMode
 
 
 	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-	bool CheckLeaderRole(IEntity entity)
+	bool IsSquadLeaderRole(IEntity entity)
 	{
-		ref TStringArray m_aLeaderRoles = {"_COY_P","_PL_P","_MO_P","_SL_P","_VehLead_P","_IndirectLead_P","_LogiLead_P"};
+		ref TStringArray roles = {"_COY_P","_PL_P","_MO_P","_SL_P","_VehLead_P","_IndirectLead_P","_LogiLead_P"};
 		ResourceName prefab = entity.GetPrefabData().GetPrefabName();
 		if(!prefab.Contains("CRF_GS_"))
 			return false;
 		
+		string role = PrefabToRole(prefab);
+		
+		return roles.Contains(role);
+	}
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	bool IsTeamLeaderRole(IEntity entity)
+	{
+		ref TStringArray roles = {"_TL_P"};
+		ResourceName prefab = entity.GetPrefabData().GetPrefabName();
+		if(!prefab.Contains("CRF_GS_"))
+			return false;
+		
+		string role = PrefabToRole(prefab);
+		
+		return roles.Contains(role);
+	}
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	string PrefabToRole(ResourceName prefab)
+	{		
 		array<string> value = {};
 		prefab.Split("_", value, true);
 		
@@ -989,7 +999,7 @@ class CRF_Gamemode : SCR_BaseGameMode
 		role.Split(".", value, true);
 		role = value[0];
 		
-		return m_aLeaderRoles.Contains(role);
+		return role;
 	}
 	
 	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/scripts/Game/Systems/CRF_Gamemode.c
+++ b/scripts/Game/Systems/CRF_Gamemode.c
@@ -1,6 +1,6 @@
-class CRF_GamemodeClass : SCR_BaseGameModeClass
+class CRF_GamemodeClass: SCR_BaseGameModeClass
 {
-}
+};
 
 enum CRF_GamemodeState
 {
@@ -22,13 +22,13 @@ class CRF_MissionDescriptor
 {
 	[Attribute("")]
 	string m_sTitle;
-
+	
 	[Attribute(defvalue: "", uiwidget: UIWidgets.EditBoxMultiline)]
 	string m_sTextData;
-
+	
 	[Attribute("")]
 	ref array<string> m_aFactionKeys;
-
+	
 	[Attribute("")]
 	bool m_bShowForAnyFaction;
 }
@@ -37,156 +37,156 @@ class CRF_Gamemode : SCR_BaseGameMode
 {
 	[RplProp(onRplName: "OnGamemodeStateChanged")]
 	int m_GamemodeState = CRF_GamemodeState.INITIAL;
-
+	
 	[RplProp()]
 	ref array<string> m_aVONChannels = {"Deafen|", "Global|"};
-
+	
 	[RplProp()]
 	ref array<int> m_aPlayersRegistedVON = {};
-
+	
 	[RplProp()]
 	int m_iChannelChanges = 0;
-
+	
 	[RplProp()]
 	int m_SlottingState = CRF_SlottingState.LEADERSANDMEDICS;
-
+	
 	//Stores when a player is talking
 	[RplProp()]
 	ref array<int> m_aPlayersTalking = {};
-
+	
 	//Slot ID given to an entity
 	[RplProp()]
 	ref array<int> m_aSlots = {};
-
+	
 	//Slot name of entity
 	[RplProp()]
 	ref array<string> m_aSlotNames = {};
-
+	
 	//Player that is slotted in the entities name
 	[RplProp()]
 	ref array<string> m_aSlotPlayerNames = {};
-
+	
 	//Slot icon off of UI Info
 	[RplProp()]
 	ref array<ResourceName> m_aSlotIcons = {};
-
+	
 	[RplProp()]
 	ref array<ResourceName> m_aSlotPrefabs = {};
-
+	
 	//Entities slot type, leader, specialty, everyone
 	[RplProp()]
 	ref array<int> m_aEntitySlotTypes = {};
-
+	
 	//Is the entity dead or alive, needed as entities pop in and out of streamable.
 	[RplProp()]
 	ref array<bool> m_aEntityDeathStatus = {};
-
+	
 	[RplProp()]
 	ref array<RplId> m_aCharacters = {};
-
+	
 	[RplProp()]
 	ref array<string> m_aCharacterNames = {};
-
+	
 	//RplId of entities that are playable
 	[RplProp()]
 	ref array<RplId> m_aEntitySlots = {};
-
+	
 	//Stores the group ID for each slot, so I can reference what group a slot is in. CAUSE THERE IS NO WAY TO DO THAT ON THE CLIENT.
 	[RplProp()]
 	ref array<RplId> m_aPlayerGroupIDs = {};
-
+	
 	//Communicates change across all clients so they can refresh their slots in the UI
 	[RplProp()]
 	int m_iSlotChanges = 0;
-
+	
 	//Is a group locked
 	[RplProp()]
 	ref array<bool> m_aGroupLockedStatus = {};
-
+	
 	//Stores SCR_AIGroup RplId, CAUSE YOU CAN'T FUCKING GRAB NON PLAYABLE GROUPS BOHEMIA
 	[RplProp()]
 	ref array<RplId> m_aGroupRplIDs = {};
-
+	
 	//Stores the playable group created whenever an AI group is created in the editor
 	[RplProp()]
 	ref array<RplId> m_aActivePlayerGroupsIDs = {};
-
+	
 	//Just stores a generic spawnpoint for players to spawn the spectator cam on. Cause of entities being streamable and such.
 	[RplProp()]
 	vector m_vGenericSpawn[4];
-
+	
 	[Attribute("45", "auto", "Mission Time (set to -1 to disable)", category: "CRF Gamemode General")]
 	int m_iTimeLimitMinutes;
-
+	
 	[Attribute("false", "auto", "Only works with BLUFOR, OPFOR, INDFOR. Players will hear enemy radio chatter but may not talk on the enemies net", category: "CRF Gamemode General")]
 	bool m_bAllowEspionage;
-
+	
 	[Attribute("false", "auto", "Enables AI autonomy while in GAME state", category: "CRF Gamemode General")]
 	bool EnableAIInGameState;
-
+	
 	[Attribute("true", "auto", "Should we delete all JIP slots after SafeStart turns off? COOP = FALSE", category: "CRF Gamemode General")]
 	bool m_bDeleteJIPSlots;
-
+	
 	[Attribute("true", "auto", "If safestart turns on instantly after the lobby screen.", category: "CRF Gamemode General")]
 	bool m_bSafestartInstantlyEnabled;
-
+	
 	//Descriptions on the left in briefing
 	[Attribute("", category: "CRF Gamemode General")]
 	ref	array<ref CRF_MissionDescriptor> m_aMissionDescriptors;
-
+	
 	//This just is what is auto set in the slotting UI for ratio calculation
 	[Attribute("1", "auto", "", category: "CRF Gamemode Slotting")]
 	int m_iFactionOneRatio;
-
+	
 	//This just is what is auto set in the slotting UI for ratio calculation
 	[Attribute("", uiwidget: UIWidgets.ComboBox, enums: {ParamEnum("", ""), ParamEnum("BLU", "BLU"), ParamEnum("OPF", "OPF"), ParamEnum("IND", "IND"), ParamEnum("CIV", "CIV")}, category: "CRF Gamemode Slotting")]
 	string m_sFactionOneKey;
-
+	
 	//This just is what is auto set in the slotting UI for ratio calculation
 	[Attribute("1", "auto", "", category: "CRF Gamemode Slotting")]
 	int m_iFactionTwoRatio;
-
+	
 	//This just is what is auto set in the slotting UI for ratio calculation
 	[Attribute("", uiwidget: UIWidgets.ComboBox, enums: {ParamEnum("", ""), ParamEnum("BLU", "BLU"), ParamEnum("OPF", "OPF"), ParamEnum("IND", "IND"), ParamEnum("CIV", "CIV")}, category: "CRF Gamemode Slotting")]
 	string m_sFactionTwoKey;
-
+	
 	[Attribute("", UIWidgets.Auto, desc: "Gearscript applied to all blufor players", category: "CRF Gamemode Gearscript")]
 	ref CRF_GearScriptContainer m_BLUFORGearScriptSettings;
-
+	
 	[Attribute("", UIWidgets.Auto, desc: "Gearscript applied to all opfor players", category: "CRF Gamemode Gearscript")]
 	ref CRF_GearScriptContainer m_OPFORGearScriptSettings;
-
+	
 	[Attribute("", UIWidgets.Auto, desc: "Gearscript applied to all indfor players", category: "CRF Gamemode Gearscript")]
 	ref CRF_GearScriptContainer m_INDFORGearScriptSettings;
-
+	
 	[Attribute("", UIWidgets.Auto, desc: "Gearscript applied to all civ players", category: "CRF Gamemode Gearscript")]
 	ref CRF_GearScriptContainer m_CIVILIANGearScriptSettings;
-
+	
 	// Respawn Settings
 	[Attribute("0", "auto", "", category: "CRF Gamemode Respawn")]
 	bool m_bRespawnEnabled;
-
+	
 	[Attribute("0", "auto", "", category: "CRF Gamemode Respawn")]
-	bool m_bWaveRespawn;
+	bool m_bWaveRespawn;	
 
 	[Attribute("300", UIWidgets.EditBox, "Time To Respawn in Seconds", category: "CRF Gamemode Respawn")]
 	int m_iTimeToRespawn;
-
+	
 	[Attribute("-1", UIWidgets.EditBox, "Amount of BLUFOR Tickets. 0 = disabled/-1 = unlimited", category: "CRF Gamemode Respawn"), RplProp()]
 	int m_iBLUFORTickets;
-
+	
 	[Attribute("-1", UIWidgets.EditBox, "Amount of OPFOR Tickets. 0 = disabled/-1 = unlimited", category: "CRF Gamemode Respawn"), RplProp()]
 	int m_iOPFORTickets;
-
+	
 	[Attribute("-1", UIWidgets.EditBox, "Amount of INDFOR Tickets. 0 = disabled/-1 = unlimited", category: "CRF Gamemode Respawn"), RplProp()]
 	int m_iINDFORTickets;
-
+	
 	[Attribute("-1", UIWidgets.EditBox, "Amount of INDFOR Tickets. 0 = disabled/-1 = unlimited", category: "CRF Gamemode Respawn"), RplProp()]
 	int m_iCIVTickets;
-
+	
 	[RplProp(onRplName: "WaveRespawnTimer")]
 	int m_iRespawnWaveCurrentTime;
-
+	
 	int m_iRespawnTimer
 
 	IEntity m_eGamemodeEntity;
@@ -194,8 +194,8 @@ class CRF_Gamemode : SCR_BaseGameMode
 	protected ref array<CRF_GamemodeComponent> m_aAdditionalCRFGamemodeComponents = {};
 	protected ref array<IEntity> m_aRespawnPoints = {};
 	protected static ref SCR_PlayerData m_PlayerData;
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	static CRF_Gamemode GetInstance()
 	{
 		BaseGameMode gameMode = GetGame().GetGameMode();
@@ -204,24 +204,24 @@ class CRF_Gamemode : SCR_BaseGameMode
 		else
 			return null;
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	override void OnControllableSpawned(IEntity entity)
 	{
 		super.OnControllableSpawned(entity);
 		GetGame().GetCallqueue().CallLater(LogCharacter, 500, false, entity);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void LogCharacter(IEntity entity)
 	{
 		#ifdef WORKBENCH
-		if (!SCR_ChimeraCharacter.Cast(entity))
+		if(!SCR_ChimeraCharacter.Cast(entity))
 				return;
 			m_aCharacters.Insert(RplComponent.Cast(entity.FindComponent(RplComponent)).Id());
-			if (CRF_PlayableCharacter.Cast(entity.FindComponent(CRF_PlayableCharacter)))
+			if(CRF_PlayableCharacter.Cast(entity.FindComponent(CRF_PlayableCharacter)))
 			{
-				if (CRF_PlayableCharacter.Cast(entity.FindComponent(CRF_PlayableCharacter)).GetName())
+				if(CRF_PlayableCharacter.Cast(entity.FindComponent(CRF_PlayableCharacter)).GetName())
 					m_aCharacterNames.Insert(CRF_PlayableCharacter.Cast(entity.FindComponent(CRF_PlayableCharacter)).GetName());
 				else
 					m_aCharacterNames.Insert(SCR_EditableCharacterComponent.Cast(entity.FindComponent(SCR_EditableCharacterComponent)).GetDisplayName());
@@ -232,12 +232,12 @@ class CRF_Gamemode : SCR_BaseGameMode
 		#else
 		if (RplSession.Mode() == RplMode.Dedicated)
 		{
-			if (!SCR_ChimeraCharacter.Cast(entity))
+			if(!SCR_ChimeraCharacter.Cast(entity))
 				return;
 			m_aCharacters.Insert(RplComponent.Cast(entity.FindComponent(RplComponent)).Id());
-			if (CRF_PlayableCharacter.Cast(entity.FindComponent(CRF_PlayableCharacter)))
+			if(CRF_PlayableCharacter.Cast(entity.FindComponent(CRF_PlayableCharacter)))
 			{
-				if (CRF_PlayableCharacter.Cast(entity.FindComponent(CRF_PlayableCharacter)).GetName())
+				if(CRF_PlayableCharacter.Cast(entity.FindComponent(CRF_PlayableCharacter)).GetName())
 					m_aCharacterNames.Insert(CRF_PlayableCharacter.Cast(entity.FindComponent(CRF_PlayableCharacter)).GetName());
 				else
 					m_aCharacterNames.Insert(SCR_EditableCharacterComponent.Cast(entity.FindComponent(SCR_EditableCharacterComponent)).GetDisplayName());
@@ -248,14 +248,14 @@ class CRF_Gamemode : SCR_BaseGameMode
 		}
 		#endif
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	override void EOnInit(IEntity owner)
 	{
 		super.EOnInit(owner);
 		m_eGamemodeEntity = owner;
-
-		array<Managed> additionalComponents = {};
+		
+		array<Managed> additionalComponents = new array<Managed>();
 		int count = owner.FindComponents(CRF_GamemodeComponent, additionalComponents);
 		m_aAdditionalCRFGamemodeComponents.Clear();
 		for (int i = 0; i < count; i++)
@@ -263,7 +263,7 @@ class CRF_Gamemode : SCR_BaseGameMode
 			CRF_GamemodeComponent comp = CRF_GamemodeComponent.Cast(additionalComponents[i]);
 			m_aAdditionalCRFGamemodeComponents.Insert(comp);
 		}
-
+		
 		if (m_bRespawnEnabled)
 			InitilizeRespawns();
 		
@@ -271,116 +271,116 @@ class CRF_Gamemode : SCR_BaseGameMode
 		SCR_AIGroup.GetOnPlayerRemoved().Insert(OnPlayerLeftGroup);
 	}
 
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	protected override void OnControllableDestroyed(IEntity entity, IEntity killerEntity, notnull Instigator instigator)
 	{
 		super.OnControllableDestroyed(entity, killerEntity, instigator);
-
-		if (RplSession.Mode() == RplMode.Client)
+		
+		if(RplSession.Mode() == RplMode.Client)
 			return;
-
+		
 		SCR_InstigatorContextData instigatorContextData = new SCR_InstigatorContextData(-1, entity, killerEntity, instigator);
-
-		if (instigatorContextData.GetVictimCharacterControlType() == SCR_ECharacterControlType.POSSESSED_AI || instigatorContextData.GetVictimCharacterControlType() == SCR_ECharacterControlType.AI)
+		
+		if(instigatorContextData.GetVictimCharacterControlType() == SCR_ECharacterControlType.POSSESSED_AI || instigatorContextData.GetVictimCharacterControlType() == SCR_ECharacterControlType.AI)
 			return;
-
+		
 		int playerId = instigatorContextData.GetVictimPlayerID();
 
 		int delay = 250;
-		if (entity.GetPrefabData().GetPrefabName() == "{59886ECB7BBAF5BC}Prefabs/Characters/CRF_InitialEntity.et")
+		if(entity.GetPrefabData().GetPrefabName() == "{59886ECB7BBAF5BC}Prefabs/Characters/CRF_InitialEntity.et")
 			delay = 0;
-
+		
 		// If respawn is enabled
-		if (m_bRespawnEnabled && entity.GetPrefabData().GetPrefabName() != "{59886ECB7BBAF5BC}Prefabs/Characters/CRF_InitialEntity.et")
+		if (m_bRespawnEnabled && entity.GetPrefabData().GetPrefabName() != "{59886ECB7BBAF5BC}Prefabs/Characters/CRF_InitialEntity.et") 
 		{
 			string faction = SCR_FactionManager.SGetPlayerFaction(playerId).GetFactionKey();
-
-			if (TicketsRemaining(faction))
+			
+			if (TicketsRemaining(faction)) 
 			{
 				// Remove tickets if used
 				SubtractTicket(faction);
-
+				
 				// Put them in death screen/timer screen
 				GetGame().GetCallqueue().CallLater(SendRespawnScreen, (delay + 150), false, playerId);
 			}
 		}
-
+		
 		//Throw em into spectator
 		GetGame().GetCallqueue().CallLater(EnterSpectator, delay, false, playerId, entity);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void EnterSpectator(int playerId, IEntity entity = null)
 	{
-		IEntity initialEntity = GetGame().SpawnEntityPrefab(Resource.Load("{59886ECB7BBAF5BC}Prefabs/Characters/CRF_InitialEntity.et"), GetGame().GetWorld());
-
+		IEntity initialEntity = GetGame().SpawnEntityPrefab(Resource.Load("{59886ECB7BBAF5BC}Prefabs/Characters/CRF_InitialEntity.et"), GetGame().GetWorld()); 
+		
 		SCR_PlayerController pc = SCR_PlayerController.Cast(GetGame().GetPlayerManager().GetPlayerController(playerId));
 
 		GetGame().GetCallqueue().CallLater(pc.SetInitialMainEntity, 250, false, initialEntity);
-
+		
 		SCR_AIGroup currentGroup = SCR_GroupsManagerComponent.GetInstance().GetPlayerGroup(playerId);
-		if (currentGroup)
+		if(currentGroup)
 			currentGroup.RemovePlayer(playerId);
-
+		
 		SCR_CharacterDamageManagerComponent.Cast(initialEntity.FindComponent(SCR_CharacterDamageManagerComponent)).EnableDamageHandling(false);
 		SCR_PlayerFactionAffiliationComponent.Cast(GetGame().GetPlayerManager().GetPlayerController(playerId).FindComponent(SCR_PlayerFactionAffiliationComponent)).RequestFaction(GetGame().GetFactionManager().GetFactionByKey("SPEC"));
 
 		vector cameraPos[4];
-		if (m_GamemodeState == CRF_GamemodeState.GAME)
+		if(m_GamemodeState == CRF_GamemodeState.GAME)
 		{
-			if (m_aSlots.Find(playerId) != -1 && entity != null)
+			if(m_aSlots.Find(playerId) != -1 && entity != null)
 			{
 				entity.GetWorldTransform(cameraPos);
 				cameraPos[3][1] = cameraPos[3][1] + 1.5;
 			} else
 				cameraPos[3] = m_vGenericSpawn[3];
-		} else
+		} else 
 			cameraPos[3] = "0 10000 0";
-
+		
 		Rpc(RpcDo_SendSpecClientInit, playerId, cameraPos);
 		RpcDo_SendSpecClientInit(playerId, cameraPos);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Broadcast)]
 	void RpcDo_SendSpecClientInit(int playerId, vector cameraPos[4])
 	{
-		if (SCR_PlayerController.GetLocalPlayerId() != playerId)
+		if(SCR_PlayerController.GetLocalPlayerId() != playerId)
 			return;
-
+		
 		SCR_PlayerController pc = SCR_PlayerController.Cast(GetGame().GetPlayerManager().GetPlayerController(playerId));
 		pc.SpecCameraInit(cameraPos);
 	}
-
+	
 	//Called to enter the actual game, just puts the player into a slot or spectator.
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void EnterGame(int playerId)
 	{
-		if (m_aSlots.Find(playerId) == -1 && GetGame().GetPlayerManager().GetPlayerControlledEntity(playerId).GetPrefabData().GetPrefabName() != "{59886ECB7BBAF5BC}Prefabs/Characters/CRF_InitialEntity.et")
+		if(m_aSlots.Find(playerId) == -1 && GetGame().GetPlayerManager().GetPlayerControlledEntity(playerId).GetPrefabData().GetPrefabName() != "{59886ECB7BBAF5BC}Prefabs/Characters/CRF_InitialEntity.et")
 			EnterSpectator(playerId);
-
-		if (m_aSlots.Find(playerId) == -1)
+		
+		if(m_aSlots.Find(playerId) == -1)
 			return;
-
-		if (m_aEntityDeathStatus.Get(m_aSlots.Find(playerId)))
+		
+		if(m_aEntityDeathStatus.Get(m_aSlots.Find(playerId)))
 		{
 			EnterSpectator(playerId);
 			return;
 		}
-
+		
 		RplId oldGroup = RplId.Invalid();
-		if (GetGame().GetPlayerManager().GetPlayerControlledEntity(playerId).GetPrefabData().GetPrefabName() != "{59886ECB7BBAF5BC}Prefabs/Characters/CRF_InitialEntity.et")
+		if(GetGame().GetPlayerManager().GetPlayerControlledEntity(playerId).GetPrefabData().GetPrefabName() != "{59886ECB7BBAF5BC}Prefabs/Characters/CRF_InitialEntity.et")
 			oldGroup = m_aActivePlayerGroupsIDs.Get(m_aGroupRplIDs.Find(m_aPlayerGroupIDs.Get(m_aEntitySlots.Find(RplComponent.Cast(GetGame().GetPlayerManager().GetPlayerControlledEntity(playerId).FindComponent(RplComponent)).Id()))));
-
+	
 		SCR_PlayerController.Cast(GetGame().GetPlayerManager().GetPlayerController(playerId)).SetInitialMainEntity(RplComponent.Cast(Replication.FindItem(m_aEntitySlots.Get(m_aSlots.Find(playerId)))).GetEntity());
-
+		
 		SCR_PlayerFactionAffiliationComponent.Cast(GetGame().GetPlayerManager().GetPlayerController(playerId).FindComponent(SCR_PlayerFactionAffiliationComponent)).RequestFaction(SCR_AIGroup.Cast(RplComponent.Cast(Replication.FindItem(m_aActivePlayerGroupsIDs.Get(m_aGroupRplIDs.Find(m_aPlayerGroupIDs.Get(m_aSlots.Find(playerId)))))).GetEntity()).GetFaction());
-
+		
 		int groupId = SCR_AIGroup.Cast(RplComponent.Cast(Replication.FindItem(m_aActivePlayerGroupsIDs.Get(m_aGroupRplIDs.Find(m_aPlayerGroupIDs.Get(m_aSlots.Find(playerId)))))).GetEntity()).GetGroupID();
-
-		if (oldGroup != RplId.Invalid())
+		
+		if(oldGroup != RplId.Invalid())
 		{
-			if (oldGroup != m_aActivePlayerGroupsIDs.Get(m_aGroupRplIDs.Find(m_aPlayerGroupIDs.Get(m_aSlots.Find(playerId)))))
+			if(oldGroup != m_aActivePlayerGroupsIDs.Get(m_aGroupRplIDs.Find(m_aPlayerGroupIDs.Get(m_aSlots.Find(playerId)))))
 			{
 				SCR_GroupsManagerComponent.GetInstance().AddPlayerToGroup(groupId, playerId);
 				SCR_PlayerControllerGroupComponent.GetPlayerControllerComponent(playerId).RequestJoinGroup(groupId);
@@ -390,9 +390,9 @@ class CRF_Gamemode : SCR_BaseGameMode
 			SCR_PlayerControllerGroupComponent.GetPlayerControllerComponent(playerId).RequestJoinGroup(groupId);
 		}
 	}
-
+	
 	//Initializes group into the replicated arrays
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void AddGroup(SCR_AIGroup group)
 	{
 		m_aGroupRplIDs.Insert(RplComponent.Cast(group.FindComponent(RplComponent)).Id());
@@ -402,26 +402,26 @@ class CRF_Gamemode : SCR_BaseGameMode
 		m_aActivePlayerGroupsIDs.Insert(RplComponent.Cast(newGroup.FindComponent(RplComponent)).Id());
 		Replication.BumpMe();
 	}
-
+	
 	//Sets the group to be locked
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SetGroupLockedStatus(int index, bool input)
 	{
 		m_aGroupLockedStatus.Set(index, input);
 	}
-
+	
 	//Sets slot to player or removes him from it
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SetSlot(int index, int playerId)
-	{
-		if (playerId > 0)
+	{	
+		if(playerId > 0)
 		{
 			SCR_PlayerFactionAffiliationComponent.Cast(GetGame().GetPlayerManager().GetPlayerController(playerId).FindComponent(SCR_PlayerFactionAffiliationComponent)).RequestFaction(FactionAffiliationComponent.Cast(RplComponent.Cast(Replication.FindItem(m_aEntitySlots.Get(index))).GetEntity().FindComponent(FactionAffiliationComponent)).GetAffiliatedFaction());
 			m_aSlotPlayerNames.Set(index, GetGame().GetPlayerManager().GetPlayerName(playerId));
 		}
 		else
 		{
-			if (m_aSlots.Get(index) > 0)
+			if(m_aSlots.Get(index) > 0)
 			{
 				SCR_PlayerFactionAffiliationComponent.Cast(GetGame().GetPlayerManager().GetPlayerController(m_aSlots.Get(index)).FindComponent(SCR_PlayerFactionAffiliationComponent)).RequestFaction(GetGame().GetFactionManager().GetFactionByKey("SPEC"));
 				m_aSlotPlayerNames.Set(index, "");
@@ -431,21 +431,21 @@ class CRF_Gamemode : SCR_BaseGameMode
 		m_iSlotChanges++;
 		Replication.BumpMe();
 	}
-
+	
 	//Sets if an entity is dead or not in the array
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SetDeathState(IEntity entity, bool input)
 	{
-		if (entity.GetPrefabData().GetPrefabName() != "{59886ECB7BBAF5BC}Prefabs/Characters/CRF_InitialEntity.et")
+		if(entity.GetPrefabData().GetPrefabName() != "{59886ECB7BBAF5BC}Prefabs/Characters/CRF_InitialEntity.et")
 		{
 			m_aEntityDeathStatus.Set(m_aEntitySlots.Find(RplComponent.Cast(entity.FindComponent(RplComponent)).Id()), input);
 			m_iSlotChanges++;
 			Replication.BumpMe();
 		};
 	}
-
+	
 	//Initializes playable entities and adds their values into the replicated arrays
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	int AddPlayableEntity(IEntity entity)
 	{
 		int index = m_aSlots.Insert(0);
@@ -456,28 +456,28 @@ class CRF_Gamemode : SCR_BaseGameMode
 		m_aSlotIcons.Insert(SCR_EditableCharacterComponent.Cast(entity.FindComponent(SCR_EditableCharacterComponent)).GetInfo().GetIconPath());
 		m_aEntityDeathStatus.Insert(false);
 		m_aSlotPlayerNames.Insert("");
-
-		if (CRF_PlayableCharacter.Cast(entity.FindComponent(CRF_PlayableCharacter)).IsLeader())
+		
+		if(CRF_PlayableCharacter.Cast(entity.FindComponent(CRF_PlayableCharacter)).IsLeader())
 			m_aEntitySlotTypes.Insert(0);
-		else if (CRF_PlayableCharacter.Cast(entity.FindComponent(CRF_PlayableCharacter)).IsSpecialty())
+		else if(CRF_PlayableCharacter.Cast(entity.FindComponent(CRF_PlayableCharacter)).IsSpecialty())
 			m_aEntitySlotTypes.Insert(1);
 		else
 			m_aEntitySlotTypes.Insert(2);
-
-		if (m_aSlots.Count() == 1)
+		
+		if(m_aSlots.Count() == 1)
 			entity.GetTransform(m_vGenericSpawn);
 
 		return index;
-
+		
 		Replication.BumpMe();
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void RemovePlayableEntity(RplId entityID)
 	{
-		if (!Replication.FindItem(entityID) || SCR_PossessingManagerComponent.GetInstance().GetIdFromMainEntity(RplComponent.Cast(Replication.FindItem(entityID)).GetEntity()) != 0)
+		if(!Replication.FindItem(entityID) || SCR_PossessingManagerComponent.GetInstance().GetIdFromMainEntity(RplComponent.Cast(Replication.FindItem(entityID)).GetEntity()) != 0)
 			return;
-
+		
 		int index = m_aEntitySlots.Find(entityID);
 		m_aSlots.RemoveOrdered(index);
 		m_aPlayerGroupIDs.RemoveOrdered(index);
@@ -488,36 +488,36 @@ class CRF_Gamemode : SCR_BaseGameMode
 		m_aSlotPlayerNames.RemoveOrdered(index);
 		m_aEntitySlotTypes.RemoveOrdered(index);
 		m_aEntitySlots.RemoveOrdered(index);
-
+		
 		SCR_EntityHelper.DeleteEntityAndChildren(RplComponent.Cast(Replication.FindItem(entityID)).GetEntity());
-
+		
 		m_iSlotChanges++;
-
+		
 		Replication.BumpMe();
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// Respawn Ticket System
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void InitilizeRespawns()
 	{
 		m_iRespawnWaveCurrentTime = m_iTimeToRespawn;
 		m_iRespawnTimer = m_iRespawnWaveCurrentTime;
-
+		
 		if (m_bWaveRespawn && RplSession.Mode() == RplMode.Dedicated)
 		{
 			GetGame().GetCallqueue().CallLater(WaveRespawnTimer, 1000, true);
 		}
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	bool TicketsRemaining(string faction)
 	{
 		bool result = false;
 		switch (faction)
 		{
 			case "BLUFOR" : {
-				if (m_iBLUFORTickets > 0 || m_iBLUFORTickets == -1)
+				if (m_iBLUFORTickets > 0 || m_iBLUFORTickets == -1) 
 					result = true;
 				break;
 			};
@@ -540,7 +540,7 @@ class CRF_Gamemode : SCR_BaseGameMode
 		return result;
 	}
 
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SubtractTicket(string faction)
 	{
 		switch (faction)
@@ -557,7 +557,7 @@ class CRF_Gamemode : SCR_BaseGameMode
 			}
 			case "INDFOR" : {
 				if (m_iINDFORTickets > 0 && m_iINDFORTickets != -1 && !CRF_GamemodeComponent.GetInstance().GetSafestartStatus())
-					m_iINDFORTickets = m_iINDFORTickets - 1;
+					m_iINDFORTickets = m_iINDFORTickets - 1;	
 					break;
 			}
 			case "CIV" : {
@@ -568,15 +568,15 @@ class CRF_Gamemode : SCR_BaseGameMode
 		}
 		Replication.BumpMe();
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void WaveRespawnTimer()
 	{
 		if (m_GamemodeState != CRF_GamemodeState.GAME)
 			return;
-
+		
 		m_iRespawnWaveCurrentTime--;
-
+		
 		if (m_iRespawnWaveCurrentTime == 0)
 		{
 			m_iRespawnWaveCurrentTime = m_iTimeToRespawn;
@@ -584,83 +584,84 @@ class CRF_Gamemode : SCR_BaseGameMode
 
 		Replication.BumpMe();
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void RespawnTimer()
-	{
+	{	
 		m_iRespawnTimer--;
-
+		
 		if (m_iRespawnTimer <= 0)
 		{
 			m_iRespawnTimer = m_iRespawnWaveCurrentTime;
 			SCR_PlayerController.Cast(GetGame().GetPlayerController()).RespawnPlayer(SCR_PlayerController.GetLocalPlayerId());
-			GetGame().GetCallqueue().Remove(RespawnTimer);
+			GetGame().GetCallqueue().Remove(RespawnTimer);			
 			GetGame().GetMenuManager().CloseAllMenus();
 		}
-
+		
 		MenuBase topMenu = GetGame().GetMenuManager().GetTopMenu();
-
+		
 		if (!topMenu.IsInherited(CRF_RespawnMenu) && topMenu.IsInherited(CRF_SpectatorMenuUI))
 			MenuBase respawnMenu = GetGame().GetMenuManager().OpenMenu(ChimeraMenuPreset.CRF_RespawnMenu);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void RegisterRespawnPoint(IEntity respawnPoint)
 	{
 		m_aRespawnPoints.Insert(respawnPoint);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void UnRegisterRespawnPoint(IEntity respawnPoint)
 	{
-		if (m_aRespawnPoints.Find(respawnPoint) != -1)
+		if(m_aRespawnPoints.Find(respawnPoint) != -1)
 			m_aRespawnPoints.Remove(m_aRespawnPoints.Find(respawnPoint));
 	}
 
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SendRespawnScreen(int playerId)
 	{
 		Rpc(RpcDo_SendRespawnScreen, playerId);
 		RpcDo_SendRespawnScreen(playerId);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Broadcast)]
 	void RpcDo_SendRespawnScreen(int playerId)
 	{
-		if (SCR_PlayerController.GetLocalPlayerId() != playerId)
+		if(SCR_PlayerController.GetLocalPlayerId() != playerId)
 			return;
-
+		
 		MenuBase topMenu = GetGame().GetMenuManager().GetTopMenu();
 		if (topMenu)
 			topMenu.Close();
 
 		GetGame().GetMenuManager().CloseAllMenus();
 		MenuBase respawnMenu = GetGame().GetMenuManager().OpenMenu(ChimeraMenuPreset.CRF_RespawnMenu);
-
+		
+		
 		GetGame().GetCallqueue().CallLater(RespawnTimer, 1000, true);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void RespawnSide(string faction)
 	{
 		array<int> allPlayers = {};
 		GetGame().GetPlayerManager().GetAllPlayers(allPlayers);
-
-		foreach (int player : allPlayers)
+		
+		foreach(int player : allPlayers)
 		{
-			if (!m_aSlots.Contains(player))
+			if(!m_aSlots.Contains(player))
 				continue;
-
+			
 			RplId groupID = m_aActivePlayerGroupsIDs.Get(m_aGroupRplIDs.Find(m_aPlayerGroupIDs.Get(m_aSlots.Find(player))));
 			SCR_AIGroup playerGroup = SCR_AIGroup.Cast(RplComponent.Cast(Replication.FindItem(groupID)).GetEntity());
 			SCR_AIGroup aiGroup = SCR_AIGroup.Cast(RplComponent.Cast(Replication.FindItem(m_aGroupRplIDs.Get(m_aActivePlayerGroupsIDs.Find(RplComponent.Cast(playerGroup.FindComponent(RplComponent)).Id())))).GetEntity());
 			string playerFactionKey = aiGroup.GetFaction().GetFactionKey();
-
-			// Make sure the player is still in that faction
+			
+			// Make sure the player is still in that faction 
 			if (playerFactionKey != faction)
 				continue;
-
+			
 			// If tickets are enabled by MM
 			if (TicketsRemaining(faction)) { // Always true if tickets > 0 or tickets == -1
 				RespawnPlayer(player);
@@ -668,122 +669,123 @@ class CRF_Gamemode : SCR_BaseGameMode
 			}
 		}
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void RespawnPlayer(int playerId, vector spawnLocation = vector.Zero, int groupID = -1)
 	{
 		if (RplSession.Mode() == RplMode.Client)
-			return;
-
+			return; 
+		
 		if (SCR_FactionManager.SGetPlayerFaction(playerId).GetFactionKey() == "SPEC" && GetGame().GetPlayerManager().IsPlayerConnected(playerId))
-		{
+		{	
 			string respawnPrefab = CRF_GamemodeComponent.GetInstance().ReturnPlayerGearScriptsMapValue(playerId, "GSR");
-
+			
 			SCR_AIGroup group;
-			if (groupID == -1)
+			if(groupID == -1)
 			{
 				RplId groupRPLID = m_aActivePlayerGroupsIDs.Get(m_aGroupRplIDs.Find(m_aPlayerGroupIDs.Get(m_aSlots.Find(playerId))));
 				group = SCR_AIGroup.Cast(RplComponent.Cast(Replication.FindItem(groupRPLID)).GetEntity());
 			} else {
 				group = SCR_GroupsManagerComponent.GetInstance().FindGroup(groupID);
 			};
-
+			
 			string faction = group.GetFaction().GetFactionKey();
-
-			if (respawnPrefab.IsEmpty())
+			
+			if(respawnPrefab.IsEmpty())
 			{
-				switch (faction)
+				switch(faction)
 				{
-					case "BLUFOR" 	: {respawnPrefab = "{6F99DE8453E6B423}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_Rifleman_P.et"; 	break; }
-					case "OPFOR" 	: {respawnPrefab = "{FC0904D71EF8DB6A}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_Rifleman_P.et"; 	break; }
-					case "INDFOR" 	: {respawnPrefab = "{A303C25424BC7149}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_Rifleman_P.et";	break; }
-					case "CIV" 		: {respawnPrefab = "{2046F9D64B1221F1}Prefabs/Characters/Factions/CIV/CRF_GS_CIV_1SG_P.et";				break; }
+					case "BLUFOR" 	: {respawnPrefab = "{6F99DE8453E6B423}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_Rifleman_P.et"; 	break;}
+					case "OPFOR"  	: {respawnPrefab = "{FC0904D71EF8DB6A}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_Rifleman_P.et";   	break;}
+					case "INDFOR" 	: {respawnPrefab = "{A303C25424BC7149}Prefabs/Characters/Factions/INDFOR/CRF_GS_INDFOR_Rifleman_P.et";	break;}
+					case "CIV" 		: {respawnPrefab = "{2046F9D64B1221F1}Prefabs/Characters/Factions/CIV/CRF_GS_CIV_1SG_P.et";				break;}
 				}
 			}
-
-			foreach (IEntity spawnPoint : m_aRespawnPoints)
+			
+			foreach(IEntity spawnPoint : m_aRespawnPoints)
 			{
-				if (!spawnPoint || CRF_RespawnPointComponent.Cast(spawnPoint.FindComponent(CRF_RespawnPointComponent)).m_sRespawnPointFaction != faction || !CRF_RespawnPointComponent.Cast(spawnPoint.FindComponent(CRF_RespawnPointComponent)).m_bActiveRespawnPoint || spawnLocation != vector.Zero)
+				if(!spawnPoint || CRF_RespawnPointComponent.Cast(spawnPoint.FindComponent(CRF_RespawnPointComponent)).m_sRespawnPointFaction != faction || !CRF_RespawnPointComponent.Cast(spawnPoint.FindComponent(CRF_RespawnPointComponent)).m_bActiveRespawnPoint || spawnLocation != vector.Zero)
 					continue;
-
-				spawnLocation = spawnPoint.GetOrigin();
+				
+				spawnLocation = spawnPoint.GetOrigin(); 
 			};
-
-			if (spawnLocation == vector.Zero)
+			
+			if(spawnLocation == vector.Zero)
 				EnterSpectator(playerId);
-
+			
 			RespawnPlayerRplId(playerId, respawnPrefab, spawnLocation, group);
 		}
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// Should only ever be ran on the server
 	void RespawnPlayerRplId(int playerId, string prefab, vector position, SCR_AIGroup group)
 	{
-		if (RplSession.Mode() == RplMode.Client)
+		if(RplSession.Mode() == RplMode.Client)
 			return;
 
 		EntitySpawnParams spawnParams = new EntitySpawnParams();
-		spawnParams.TransformMode = ETransformMode.WORLD;
+        spawnParams.TransformMode = ETransformMode.WORLD;
 		vector finalSpawnLocation = vector.Zero;
-
+		
 		SCR_WorldTools.FindEmptyTerrainPosition(finalSpawnLocation, position, 10);
-		spawnParams.Transform[3] = finalSpawnLocation;
-
-		IEntity newEntity = GetGame().SpawnEntityPrefab(Resource.Load(prefab), GetGame().GetWorld(), spawnParams);
-
+        spawnParams.Transform[3] = finalSpawnLocation;
+		
+		IEntity newEntity = GetGame().SpawnEntityPrefab(Resource.Load(prefab),GetGame().GetWorld(),spawnParams);
+		
 		GetGame().GetCallqueue().CallLater(RespawnPlayerRplIdDelay, 100, false, playerId, group, newEntity);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void RespawnPlayerRplIdDelay(int playerId, SCR_AIGroup group, IEntity newEntity)
 	{
-		SCR_AIGroup aiGroup = SCR_AIGroup.Cast(RplComponent.Cast(Replication.FindItem(m_aGroupRplIDs.Get(m_aActivePlayerGroupsIDs.Find(RplComponent.Cast(group.FindComponent(RplComponent)).Id())))).GetEntity());
+		SCR_AIGroup aiGroup = SCR_AIGroup.Cast(RplComponent.Cast(Replication.FindItem(m_aGroupRplIDs.Get(m_aActivePlayerGroupsIDs.Find(RplComponent.Cast(group.FindComponent(RplComponent)).Id())))).GetEntity());		
 		aiGroup.AddAIEntityToGroup(newEntity);
 
 		int index = AddPlayableEntity(newEntity);
-
-		if (m_aSlots.Find(playerId) != -1)
+		
+		if(m_aSlots.Find(playerId) != -1)
 			SetSlot(m_aSlots.Find(playerId), -2);
-
+		
 		SetSlot(index, playerId);
-
+		
 		Rpc(RpcDo_EnterGame, playerId);
 		RpcDo_EnterGame(playerId);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------	
 	[RplRpc(RplChannel.Reliable, RplRcver.Broadcast)]
 	void RpcDo_EnterGame(int playerId)
 	{
-		if (SCR_PlayerController.GetLocalPlayerId() != playerId)
+		if(SCR_PlayerController.GetLocalPlayerId() != playerId)
 			return;
-
+		
 		SCR_PlayerController.Cast(GetGame().GetPlayerController()).EnterGame(playerId);
 	}
-
+	
 	//Puts the player into an entity when they connect
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	override void OnPlayerConnected(int playerId)
 	{
 		super.OnPlayerConnected(playerId);
 //		if(m_aSlots.Find(playerId) == -1)
 //			EnterSpectator(playerId);
 
-		if (m_aSlots.Find(playerId) != -1)
+		if(m_aSlots.Find(playerId) != -1)
 		{
 			m_iSlotChanges++;
 			Replication.BumpMe();
 		}
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	protected override void OnPlayerDisconnected(int playerId, KickCauseCode cause, int timeout)
 	{
 		m_OnPlayerDisconnected.Invoke(playerId, cause, timeout);
-
+		
 		// RespawnSystemComponent is not a SCR_BaseGameModeComponent, so for now we have to
-		// propagate these events manually.
+		// propagate these events manually. 
 		if (IsMaster())
 			m_pRespawnSystemComponent.OnPlayerDisconnected_S(playerId, cause, timeout);
 
@@ -791,56 +793,56 @@ class CRF_Gamemode : SCR_BaseGameMode
 		{
 			comp.OnPlayerDisconnected(playerId, cause, timeout);
 		}
-
+		
 		m_OnPostCompPlayerDisconnected.Invoke(playerId, cause, timeout);
 		//Updates connection status
-		if (m_aSlots.Find(playerId) != -1)
+		if(m_aSlots.Find(playerId) != -1)
 		{
 			m_iSlotChanges++;
 			Replication.BumpMe();
 		}
 	}
-
+	
 	// Rush game mode respawn - no tickets
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void RushRespawnPlayers()
 	{
-		// Stubbed for old mission support
+		// Stubbed for old mission support 
 		RespawnSide("BLUFOR");
 		RespawnSide("INDFOR");
 		RespawnSide("OPFOR");
 	}
-
+	
 	//Sets if the player is talking for UI purposes
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SetPlayerTalking(int playerId)
 	{
-		if (m_aPlayersTalking.Find(playerId) != -1)
+		if(m_aPlayersTalking.Find(playerId) != -1)
 			return;
-
+		
 		m_aPlayersTalking.Insert(playerId);
 		Replication.BumpMe();
 	}
-
+	
 	//Sets if the player is talking for UI purposes
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void RemovePlayerTalking(int playerId)
 	{
 		m_aPlayersTalking.RemoveItem(playerId);
 		Replication.BumpMe();
 	}
-
+	
 	//Advances the slotting state
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void AdvanceSlottingState()
 	{
 		m_SlottingState += 1;
 		m_iSlotChanges++;
 		Replication.BumpMe();
 	}
-
+	
 	//Opens the menu on the player
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void OpenCurrentStateMenu()
 	{
 		//Close any menu that wriggles its way in
@@ -849,39 +851,39 @@ class CRF_Gamemode : SCR_BaseGameMode
 			topMenu.Close();
 		GetGame().GetMenuManager().CloseAllMenus();
 		//Opens menu based on current game state : )
-		switch (m_GamemodeState)
+		switch(m_GamemodeState)
 		{
-			case CRF_GamemodeState.INITIAL: 	{GetGame().GetMenuManager().OpenMenu(ChimeraMenuPreset.CRF_PreviewMenu);											break; }
-			case CRF_GamemodeState.SLOTTING:	{GetGame().GetMenuManager().OpenMenu(ChimeraMenuPreset.CRF_SlottingMenu);											break; }
-			case CRF_GamemodeState.GAME: 		{SCR_PlayerController.Cast(GetGame().GetPlayerController()).EnterGame(SCR_PlayerController.GetLocalPlayerId());		break; }
-			case CRF_GamemodeState.AAR: 		{GetGame().GetMenuManager().OpenMenu(ChimeraMenuPreset.CRF_AARMenu);												break; }
+			case CRF_GamemodeState.INITIAL: 	{GetGame().GetMenuManager().OpenMenu(ChimeraMenuPreset.CRF_PreviewMenu);											break;}
+			case CRF_GamemodeState.SLOTTING:	{GetGame().GetMenuManager().OpenMenu(ChimeraMenuPreset.CRF_SlottingMenu);											break;}
+			case CRF_GamemodeState.GAME: 		{SCR_PlayerController.Cast(GetGame().GetPlayerController()).EnterGame(SCR_PlayerController.GetLocalPlayerId());		break;}
+			case CRF_GamemodeState.AAR: 		{GetGame().GetMenuManager().OpenMenu(ChimeraMenuPreset.CRF_AARMenu);												break;}
 		}
-		if (m_GamemodeState != CRF_GamemodeState.GAME)
+		if(m_GamemodeState != CRF_GamemodeState.GAME)
 		{
 			BaseContainer video = GetGame().GetEngineUserSettings().GetModule("VideoUserSettings");
-			if (SCR_PlayerController.Cast(GetGame().GetPlayerController()).m_iFPS)
+			if(SCR_PlayerController.Cast(GetGame().GetPlayerController()).m_iFPS)
 				video.Get("MaxFps", SCR_PlayerController.Cast(GetGame().GetPlayerController()).m_iFPS);
 			video.Set("MaxFps", 30);
 			GetGame().UserSettingsChanged();
-			if (SCR_PlayerController.Cast(GetGame().GetPlayerController()).m_iAudioSetting)
+			if(SCR_PlayerController.Cast(GetGame().GetPlayerController()).m_iAudioSetting)
 				SCR_PlayerController.Cast(GetGame().GetPlayerController()).m_iAudioSetting = AudioSystem.GetMasterVolume(AudioSystem.SFX);
 			AudioSystem.SetMasterVolume(AudioSystem.SFX, 0);
 		}
 	}
 
 	//Advances the overall gamemode state
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void AdvanceGamemodeState(bool overriden = false)
 	{
-		if ((m_GamemodeState == CRF_GamemodeState.AAR || m_GamemodeState == CRF_GamemodeState.GAME) && !overriden)
+		if((m_GamemodeState == CRF_GamemodeState.AAR || m_GamemodeState == CRF_GamemodeState.GAME) && !overriden)
 			return;
-
+		
 		m_GamemodeState += 1;
 		Replication.BumpMe();
 		OnGamemodeStateChanged();
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	ScriptInvoker GetOnStateChanged()
 	{
 		if (!m_OnStateChanged)
@@ -889,43 +891,133 @@ class CRF_Gamemode : SCR_BaseGameMode
 
 		return m_OnStateChanged;
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void OnGamemodeStateChanged()
 	{
-		if (RplSession.Mode() == RplMode.Dedicated)
+		if(RplSession.Mode() == RplMode.Dedicated)
 		{
 			if (m_OnStateChanged)
 				m_OnStateChanged.Invoke(m_GamemodeState);
-
+			
 			foreach (CRF_GamemodeComponent component : m_aAdditionalCRFGamemodeComponents)
-			{
 				component.OnGamemodeStateChanged();
-			}
-
-			if (m_GamemodeState == CRF_GamemodeState.AAR)
+			
+			if(m_GamemodeState == CRF_GamemodeState.AAR)
 				EnterAAR();
 		}
 		else
 			OpenCurrentStateMenu();
 	}
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	void OnPlayerJoinedGroup(SCR_AIGroup aiGroup, int playerID)
+	{	
+		if(RplSession.Mode() == RplMode.Dedicated)
+		{			
+			IEntity currentLeaderEntity = GetGame().GetPlayerManager().GetPlayerControlledEntity(aiGroup.GetLeaderID());
+			if (!currentLeaderEntity)
+				return;
+			
+			if (!IsSquadLeaderRole(currentLeaderEntity))
+			{
+				IEntity player = GetGame().GetPlayerManager().GetPlayerControlledEntity(playerID);
+				if (!player)
+					return;
+				
+				if (IsSquadLeaderRole(player))
+				{
+					SCR_GroupsManagerComponent.GetInstance().SetGroupLeader(aiGroup.GetGroupID(), playerID);
+				}
+			}
+		}	
+	}
 
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	void OnPlayerLeftGroup(SCR_AIGroup aiGroup, int playerID)
+	{
+		if(RplSession.Mode() == RplMode.Dedicated)
+		{
+			IEntity currentLeaderEntity = GetGame().GetPlayerManager().GetPlayerControlledEntity(aiGroup.GetLeaderID());
+			if (!currentLeaderEntity)
+				return;
+
+			if (!IsSquadLeaderRole(currentLeaderEntity))
+			{
+				array<int> groupMembers = aiGroup.GetPlayerIDs();
+				
+				foreach (int member : groupMembers)
+				{
+					IEntity memberEntity = GetGame().GetPlayerManager().GetPlayerControlledEntity(member);
+					if (!memberEntity)
+						return;
+					
+					if (IsTeamLeaderRole(memberEntity))
+					{
+						SCR_GroupsManagerComponent.GetInstance().SetGroupLeader(aiGroup.GetGroupID(), member);
+						break;
+					}
+				}
+			}
+		}
+	}
+
+
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	bool IsSquadLeaderRole(IEntity entity)
+	{
+		ref TStringArray roles = {"_COY_P","_PL_P","_MO_P","_SL_P","_VehLead_P","_IndirectLead_P","_LogiLead_P"};
+		ResourceName prefab = entity.GetPrefabData().GetPrefabName();
+		if(!prefab.Contains("CRF_GS_"))
+			return false;
+		
+		string role = PrefabToRole(prefab);
+		
+		return roles.Contains(role);
+	}
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	bool IsTeamLeaderRole(IEntity entity)
+	{
+		ref TStringArray roles = {"_TL_P"};
+		ResourceName prefab = entity.GetPrefabData().GetPrefabName();
+		if(!prefab.Contains("CRF_GS_"))
+			return false;
+		
+		string role = PrefabToRole(prefab);
+		
+		return roles.Contains(role);
+	}
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	string PrefabToRole(ResourceName prefab)
+	{		
+		array<string> value = {};
+		prefab.Split("_", value, true);
+		
+		string role = "_" + value[3] + "_" + value[4];
+		
+		role.Split(".", value, true);
+		role = value[0];
+		
+		return role;
+	}
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void EnterAAR()
 	{
-		array<int> players = {};
+		ref array<int> players = {};
 		GetGame().GetPlayerManager().GetAllPlayers(players);
-		foreach (int player : players)
+		foreach(int player: players)
 		{
-			if (!GetGame().GetPlayerManager().IsPlayerConnected(player))
+			if(!GetGame().GetPlayerManager().IsPlayerConnected(player))
 				continue;
-
-			if (GetGame().GetPlayerManager().GetPlayerControlledEntity(player).GetPrefabData().GetPrefabName() == "{59886ECB7BBAF5BC}Prefabs/Characters/CRF_InitialEntity.et")
+			
+			if(GetGame().GetPlayerManager().GetPlayerControlledEntity(player).GetPrefabData().GetPrefabName() == "{59886ECB7BBAF5BC}Prefabs/Characters/CRF_InitialEntity.et")
 				continue;
-
+			
 			GetGame().GetCallqueue().CallLater(EnterSpectator, 500, false, player);
 		}
-
+		
 		// Log player data
 		if (!m_PlayerData)
 		{
@@ -935,9 +1027,9 @@ class CRF_Gamemode : SCR_BaseGameMode
 				Print ("SCR_CareerEndScreenUI: No data collector was found.", LogLevel.ERROR);
 				return;
 			}
-
+			
 			m_PlayerData = dataCollector.GetPlayerData(0, false);
-
+			
 			//If there's still no player data, we wait for the invoker on data received to let us now that we got the instance through rpl
 			if (!m_PlayerData)
 			{
@@ -949,22 +1041,23 @@ class CRF_Gamemode : SCR_BaseGameMode
 				m_PlayerData.CalculateStatsChange();
 		}
 	}
-
+	
 	protected void OnDataReceived(SCR_PlayerData playerData)
 	{
 		m_PlayerData = playerData;
 		m_PlayerData.CalculateStatsChange();
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SetChannel(int index, string inputString, bool channelCreation)
 	{
 		m_aVONChannels.Set(index, inputString);
 		if (!channelCreation)
 		{
-			foreach (string channel : m_aVONChannels)
+			foreach(string channel: m_aVONChannels)
 			{
-				array<string> channelSplit = {};
+				ref array<string> channelSplit = {};
 				channel.Split("|", channelSplit, true);
 				if (channelSplit.Count() == 1 && m_aVONChannels.Find(channel) > 1)
 					m_aVONChannels.RemoveOrdered(m_aVONChannels.Find(channel));
@@ -973,23 +1066,23 @@ class CRF_Gamemode : SCR_BaseGameMode
 		m_iChannelChanges++;
 		Replication.BumpMe();
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	bool IsPlayerInAnyChannel(int playerId, out int channelId)
 	{
 		bool isInChannel = false;
 		channelId = -1;
-		foreach (string channel : m_aVONChannels)
+		foreach(string channel: m_aVONChannels)
 		{
-			if (isInChannel)
+			if(isInChannel)
 				break;
-			array<string> channelSplit = {};
+			ref array<string> channelSplit = {};
 			channel.Split("|", channelSplit, true);
-			array<string> players = {};
+			ref array<string> players = {};
 			if (channelSplit.Count() == 1)
 				continue;
 			channelSplit.Get(1).Split(",", players, true);
-			foreach (string player : players)
+			foreach(string player: players)
 			{
 				if	(player == "")
 					continue;
@@ -1001,53 +1094,53 @@ class CRF_Gamemode : SCR_BaseGameMode
 				}
 			}
 		}
-		return isInChannel;
+		return isInChannel;	
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void AddPlayerToChannel(int playerId, int channelIndex, bool channelCreation)
 	{
 		int index;
 		if (IsPlayerInAnyChannel(playerId, index))
 			RemovePlayerFromAnyChannel(playerId, channelCreation);
-		array<string> channelSplit = {};
+		ref array<string> channelSplit = {};
 		m_aVONChannels.Get(channelIndex).Split("|", channelSplit, true);
-		array<string> players = {};
+		ref array<string> players = {};
 		if (channelSplit.Count() > 1)
 			channelSplit.Get(1).Split(",", players, true);
 		players.Insert(playerId.ToString());
 		if (channelSplit.Count() > 1)
-			channelSplit.Set(1, SCR_StringHelper.Join(",", players));
+			channelSplit.Set(1, SCR_StringHelper.Join("," , players));
 		else
-			channelSplit.Insert(SCR_StringHelper.Join(",", players));
+			channelSplit.Insert(SCR_StringHelper.Join("," , players));
 		SetChannel(channelIndex, SCR_StringHelper.Join("|", channelSplit), channelCreation);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void RemovePlayerFromAnyChannel(int playerId, bool channelCreation)
 	{
 		int index;
-		if (!IsPlayerInAnyChannel(playerId, index))
+		if(!IsPlayerInAnyChannel(playerId, index))
 			return;
-		array<string> channelSplit = {};
+		ref array<string> channelSplit = {};
 		m_aVONChannels.Get(index).Split("|", channelSplit, true);
-		array<string> players = {};
+		ref array<string> players = {};
 		if (channelSplit.Count() > 1)
 			channelSplit.Get(1).Split(",", players, true);
 		players.RemoveOrdered(players.Find(playerId.ToString()));
 		if (channelSplit.Count() > 1)
-			channelSplit.Set(1, SCR_StringHelper.Join(",", players));
+			channelSplit.Set(1, SCR_StringHelper.Join("," , players));
 		else
-			channelSplit.Insert(SCR_StringHelper.Join(",", players));
+			channelSplit.Insert(SCR_StringHelper.Join("," , players));
 		SetChannel(index, SCR_StringHelper.Join("|", channelSplit), channelCreation);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	bool IsPlayerInChannel(int playerId, int index)
 	{
-		array<string> channelSplit = {};
+		ref array<string> channelSplit = {};
 		m_aVONChannels.Get(index).Split("|", channelSplit, true);
-		array<string> players = {};
+		ref array<string> players = {};
 		if (channelSplit.Count() == 1)
 			return false;
 		else
@@ -1055,10 +1148,10 @@ class CRF_Gamemode : SCR_BaseGameMode
 		if (players.Contains(playerId.ToString()))
 			return true;
 		else
-			return false;
+			return false;	
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	int CreateChannel(string name, int playerId)
 	{
 		int index = m_aVONChannels.Insert(name + "|");
@@ -1067,15 +1160,15 @@ class CRF_Gamemode : SCR_BaseGameMode
 		Replication.BumpMe();
 		return index;
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	int GetChannel(int playerId)
 	{
-		foreach (string channel : m_aVONChannels)
+		foreach(string channel: m_aVONChannels)
 		{
-			array<string> channelSplit = {};
+			ref array<string> channelSplit = {};
 			channel.Split("|", channelSplit, true);
-			array<string> players = {};
+			ref array<string> players = {};
 			if (channelSplit.Count() == 1)
 				continue;
 			else
@@ -1087,27 +1180,27 @@ class CRF_Gamemode : SCR_BaseGameMode
 		}
 		return 1;
 	}
-
+	
 	void RequestToJoinChannel(int channel, int requestId)
 	{
-		array<int> players = {};
+		ref array<int> players = {};
 		GetGame().GetPlayerManager().GetAllPlayers(players);
-		foreach (int player : players)
+		foreach(int player: players)
 		{
 			if (IsPlayerInChannel(player, channel))
 				Rpc(RpcDo_SendRequest, player, requestId, channel);
 		}
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Broadcast)]
 	void RpcDo_SendRequest(int playerId, int requestId, int channel)
 	{
 		if (playerId != SCR_PlayerController.GetLocalPlayerId())
 			return;
-
+		
 		CRF_SpectatorMenuUI specMenu = CRF_SpectatorMenuUI.Cast(GetGame().GetMenuManager().GetTopMenu());
-
+		
 		if (!specMenu)
 			return;
 		Widget compWidget = GetGame().GetWorkspace().CreateWidgets("{49490337615BA9B8}UI/Listbox/VONChannelRequestListBox.layout", specMenu.m_wRoot.FindAnyWidget("Requests"));
@@ -1119,8 +1212,8 @@ class CRF_Gamemode : SCR_BaseGameMode
 		comp.GetDeny().m_OnClicked.Insert(Deny);
 		FrameSlot.SetPosX(compWidget.FindAnyWidget("ButtonAnim"), 500);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void Accept()
 	{
 		if (!WidgetManager.GetWidgetUnderCursor())
@@ -1134,13 +1227,13 @@ class CRF_Gamemode : SCR_BaseGameMode
 		else if (!WidgetManager.GetWidgetUnderCursor().GetParent().GetParent().GetParent().GetParent())
 			return;
 		else if (!WidgetManager.GetWidgetUnderCursor().GetParent().GetParent().GetParent().GetParent().GetParent())
-			return;
-
+			return;		
+		
 		CRF_ListBoxElementComponent comp = CRF_ListBoxElementComponent.Cast(WidgetManager.GetWidgetUnderCursor().GetParent().GetParent().GetParent().GetParent().GetParent().FindHandler(CRF_ListBoxElementComponent));
 		SCR_PlayerController.Cast(GetGame().GetPlayerController()).Accept(comp.m_iPlayerId, comp.m_iChannelId);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void Deny()
 	{
 		if (!WidgetManager.GetWidgetUnderCursor())
@@ -1154,42 +1247,42 @@ class CRF_Gamemode : SCR_BaseGameMode
 		else if (!WidgetManager.GetWidgetUnderCursor().GetParent().GetParent().GetParent().GetParent())
 			return;
 		else if (!WidgetManager.GetWidgetUnderCursor().GetParent().GetParent().GetParent().GetParent().GetParent())
-			return;
+			return;		
 		CRF_ListBoxElementComponent comp = CRF_ListBoxElementComponent.Cast(WidgetManager.GetWidgetUnderCursor().GetParent().GetParent().GetParent().GetParent().GetParent().FindHandler(CRF_ListBoxElementComponent));
 
-		array<int> players = {};
+		ref array<int> players = {};
 		GetGame().GetPlayerManager().GetAllPlayers(players);
-		foreach (int player : players)
+		foreach(int player: players)
 		{
 			if (IsPlayerInChannel(player, comp.m_iChannelId))
 				Rpc(RpcDo_Deny, player, comp.m_iPlayerId);
 		}
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Broadcast)]
 	void RpcDo_Deny(int playerId, int requestId)
 	{
 		if (playerId != SCR_PlayerController.GetLocalPlayerId())
 			return;
-
+		
 		CRF_SpectatorMenuUI specMenu = CRF_SpectatorMenuUI.Cast(GetGame().GetMenuManager().GetTopMenu());
-
+		
 		if (!specMenu)
 			return;
-
-		foreach (Widget request : specMenu.m_aRequest)
+		
+		foreach (Widget request: specMenu.m_aRequest)
 		{
 			CRF_ListBoxElementComponent comp = CRF_ListBoxElementComponent.Cast(request.FindHandler(CRF_ListBoxElementComponent));
 			if (!comp)
 				continue;
-
+			
 			if (requestId == comp.m_iPlayerId)
 			{
 				comp.GetAccept().m_OnClicked.Clear();
 				comp.GetDeny().m_OnClicked.Clear();
 				comp.m_bDeleteRequest = true;
-				return;
+				return;			
 			}
 		}
 	}
@@ -1198,18 +1291,16 @@ class CRF_Gamemode : SCR_BaseGameMode
 //Ditto the RL Devs WHY IS THIS HARDCODED
 modded class SCR_ManualCamera
 {
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	override protected bool IsDisabledByMenu()
 	{
-		if (!m_MenuManager)
-			return false;
-
-		if (m_MenuManager.IsAnyDialogOpen())
-			return true;
-
+		if (!m_MenuManager) return false;
+		
+		if (m_MenuManager.IsAnyDialogOpen()) return true;
+		
 		MenuBase topMenu = m_MenuManager.GetTopMenu();
-
+		
 		// WHY IT'S HARDCODED?
 		return topMenu && (!topMenu.IsInherited(EditorMenuUI) && !topMenu.IsInherited(CRF_SpectatorMenuUI));
 	}
-}
+};

--- a/scripts/Game/Systems/CRF_Gamemode.c
+++ b/scripts/Game/Systems/CRF_Gamemode.c
@@ -266,6 +266,9 @@ class CRF_Gamemode : SCR_BaseGameMode
 		
 		if (m_bRespawnEnabled)
 			InitilizeRespawns();
+		
+		SCR_AIGroup.GetOnPlayerAdded().Insert(OnPlayerJoinedGroup);
+		SCR_AIGroup.GetOnPlayerRemoved().Insert(OnPlayerLeftGroup);
 	}
 
 	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -905,6 +908,88 @@ class CRF_Gamemode : SCR_BaseGameMode
 		}
 		else
 			OpenCurrentStateMenu();
+	}
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	void OnPlayerJoinedGroup(SCR_AIGroup aiGroup, int playerID)
+	{	
+		if(RplSession.Mode() == RplMode.Dedicated)
+		{			
+			IEntity entity = GetGame().GetPlayerManager().GetPlayerControlledEntity(aiGroup.GetLeaderID());
+			if (!entity)
+				return;
+			
+			if (!CheckLeaderRole(entity))
+			{
+				IEntity player = GetGame().GetPlayerManager().GetPlayerControlledEntity(playerID);
+				if (!player)
+					return;
+				
+				if (CheckLeaderRole(player))
+				{
+					SCR_GroupsManagerComponent.GetInstance().SetGroupLeader(aiGroup.GetGroupID(), playerID);
+				}
+			}
+		}	
+	}
+
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	void OnPlayerLeftGroup(SCR_AIGroup aiGroup, int playerID)
+	{
+		if(RplSession.Mode() == RplMode.Dedicated)
+		{
+			IEntity entity = GetGame().GetPlayerManager().GetPlayerControlledEntity(aiGroup.GetLeaderID());
+			if (!entity)
+				return;
+
+			if (!CheckLeaderRole(entity))
+			{
+				array<int> groupMembers = aiGroup.GetPlayerIDs();
+				
+				foreach (int member : groupMembers)
+				{
+					IEntity memberEntity = GetGame().GetPlayerManager().GetPlayerControlledEntity(member);
+					ResourceName prefab = memberEntity.GetPrefabData().GetPrefabName();
+					
+					if(!prefab.Contains("CRF_GS_") || !memberEntity)
+						return;
+					
+					array<string> value = {};
+					prefab.Split("_", value, true);
+					
+					string role = "_" + value[3] + "_" + value[4];
+					
+					role.Split(".", value, true);
+					role = value[0];
+					
+					if (role == "_TL_P")
+					{
+						SCR_GroupsManagerComponent.GetInstance().SetGroupLeader(aiGroup.GetGroupID(), member);
+						break;
+					}
+				}
+			}
+		}
+	}
+
+
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	bool CheckLeaderRole(IEntity entity)
+	{
+		ref TStringArray m_aLeaderRoles = {"_COY_P","_PL_P","_MO_P","_SL_P","_VehLead_P","_IndirectLead_P","_LogiLead_P"};
+		ResourceName prefab = entity.GetPrefabData().GetPrefabName();
+		if(!prefab.Contains("CRF_GS_"))
+			return false;
+		
+		array<string> value = {};
+		prefab.Split("_", value, true);
+		
+		string role = "_" + value[3] + "_" + value[4];
+		
+		role.Split(".", value, true);
+		role = value[0];
+		
+		return m_aLeaderRoles.Contains(role);
 	}
 	
 	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/scripts/Game/Systems/CRF_GamemodeComponent.c
+++ b/scripts/Game/Systems/CRF_GamemodeComponent.c
@@ -1,18 +1,18 @@
-class CRF_GamemodeComponentClass : SCR_BaseGameModeComponentClass {}
+class CRF_GamemodeComponentClass: SCR_BaseGameModeComponentClass {}
 
-class CRF_GamemodeComponent : SCR_BaseGameModeComponent
+class CRF_GamemodeComponent: SCR_BaseGameModeComponent
 {
-	//------------------------------------------------------------------------------------------------
-	//------------------------------------------------------------------------------------------------
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// Globally Used Functions/Variables
-	//------------------------------------------------------------------------------------------------
-	//------------------------------------------------------------------------------------------------
-	//------------------------------------------------------------------------------------------------
-
-	protected ref RandomGenerator m_RNG = new RandomGenerator();
-
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	
+	protected ref RandomGenerator m_RNG = new RandomGenerator;
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	static CRF_GamemodeComponent GetInstance()
 	{
 		BaseGameMode gameMode = GetGame().GetGameMode();
@@ -21,184 +21,183 @@ class CRF_GamemodeComponent : SCR_BaseGameModeComponent
 		else
 			return null;
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	override void OnPostInit(IEntity owner)
 	{
 		super.OnPostInit(owner);
-
+		
 		// Only run on in-game post init
 		// Is the the right way to do this? WHO KNOWS !
-		if (!GetGame().InPlayMode())
-			return;
-
+		if (!GetGame().InPlayMode()) return;
+		
 		GetGame().GetInputManager().AddActionListener("SwitchSpectatorUI", EActionTrigger.DOWN, UpdateHUDVisible);
 		GetGame().GetCallqueue().CallLater(AddMsgAction, 0, false);
-
+			
 		#ifdef WORKBENCH
 		if (Replication.IsServer())
 		{
 			GetGame().GetCallqueue().CallLater(UpdatePlayerGearScriptsArray, m_RNG.RandInt(10000, 20000), true);
-
+			
 			m_Logging = CRF_LoggingServerComponent.Cast(this.FindComponent(CRF_LoggingServerComponent));
 			GetGame().GetCallqueue().CallLater(WaitTillGameStart, 1000, true);
-		}
+		} 
 		#else
 		if (RplSession.Mode() == RplMode.Dedicated)
 		{
 			GetGame().GetCallqueue().CallLater(UpdatePlayerGearScriptsArray, m_RNG.RandInt(10000, 20000), true);
-
+			
 			m_Logging = CRF_LoggingServerComponent.Cast(this.FindComponent(CRF_LoggingServerComponent));
 			GetGame().GetCallqueue().CallLater(WaitTillGameStart, 1000, true);
-		}
+		} 
 		#endif
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void WaitTillGameStart()
 	{
-		if (CRF_Gamemode.GetInstance().m_GamemodeState != CRF_GamemodeState.GAME)
+		if(CRF_Gamemode.GetInstance().m_GamemodeState != CRF_GamemodeState.GAME)
 			return;
-
-		m_bSafeStartEnabled = !CRF_Gamemode.GetInstance().m_bSafestartInstantlyEnabled;
-		Replication.BumpMe();//Broadcast m_bSafeStartEnabled change
-
-		GetGame().GetCallqueue().Remove(WaitTillGameStart);
+ 		
+		m_SafeStartEnabled = !CRF_Gamemode.GetInstance().m_bSafestartInstantlyEnabled;
+		Replication.BumpMe();//Broadcast m_SafeStartEnabled change
+		
+		GetGame().GetCallqueue().Remove(WaitTillGameStart);		
 		GetGame().GetCallqueue().CallLater(ToggleSafeStartServer, 1000, false, CRF_Gamemode.GetInstance().m_bSafestartInstantlyEnabled);
 	}
-
+	
 	void OnGamemodeStateChanged()
 	{}
-
-	//------------------------------------------------------------------------------------------------
-	//------------------------------------------------------------------------------------------------
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// GearScripts Functions/Variables
-	//------------------------------------------------------------------------------------------------
-	//------------------------------------------------------------------------------------------------
-	//------------------------------------------------------------------------------------------------
-
-	const int HEADGEAR = 0;
-	const int SHIRT = 1;
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	
+	const int HEADGEAR    = 0;
+	const int SHIRT       = 1;
 	const int ARMOREDVEST = 2;
-	const int PANTS = 3;
-	const int BOOTS = 4;
-	const int BACKPACK = 5;
-	const int VEST = 6;
-	const int HANDWEAR = 7;
-	const int HEAD = 8;
-	const int EYES = 9;
-	const int EARS = 10;
-	const int FACE = 11;
-	const int NECK = 12;
-	const int EXTRA1 = 13;
-	const int EXTRA2 = 14;
-	const int WAIST = 15;
-	const int EXTRA3 = 16;
-	const int EXTRA4 = 17;
-
+	const int PANTS       = 3;
+	const int BOOTS       = 4;
+	const int BACKPACK    = 5;
+	const int VEST        = 6;
+	const int HANDWEAR    = 7;
+	const int HEAD        = 8;
+	const int EYES        = 9;
+	const int EARS        = 10;
+	const int FACE        = 11;	
+	const int NECK        = 12;
+	const int EXTRA1      = 13;
+	const int EXTRA2      = 14;
+	const int WAIST       = 15;
+	const int EXTRA3      = 16;
+	const int EXTRA4      = 17;
+	
 	const ref array<EWeaponType> WEAPON_TYPES_THROWABLE = {EWeaponType.WT_FRAGGRENADE, EWeaponType.WT_SMOKEGRENADE};
-
+	
 	const ref TStringArray m_aLeadershipRolesUGL = {"_COY_P", "_PL_P", "_SL_P", "_FO_P", "_JTAC_P", "_1SG_P", "_PSG_P"};
 	const ref TStringArray m_aLeadershipRolesCarbine = {"_MO_P", "_IndirectLead_P", "_LogiLead_P", "_VehLead_P"};
-
+		
 	const ref TStringArray m_aSquadLevelRolesUGL = {"_TL_P", "_Gren_P", "_RTO_P"};
 	const ref TStringArray m_aSquadLevelRolesRifle = {"_Rifleman_P", "_Demo_P", "_AAT_P", "_AAR_P"};
 	const ref TStringArray m_aSquadLevelRolesCarbine = {"_Medic_P"};
-
+		
 	const ref TStringArray m_aInfantrySpecialtiesRolesRifle = {"_AHAT_P", "_AMAT_P", "_AHMG_P", "_AMMG_P", "_AAA_P", "_DroneOp_P"};
-
+		
 	const ref TStringArray m_aVehicleSpecialtiesRolesCarbine = {"_VehDriver_P", "_VehGunner_P", "_VehLoader_P", "_LogiRunner_P", "_IndirectGunner_P", "_IndirectLoader_P"};
 	const ref TStringArray m_aVehicleSpecialtiesRolesPistol = {"_Pilot_P", "_CrewChief_P"};
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 	// A array we use primarily for replication of m_mAllPlayerGearScriptsMap to clients.
 	[RplProp(onRplName: "UpdateLocalPlayerGearScriptsMap")]
-	protected ref array<string> m_aAllPlayerGearScriptsArray = {};
-
+	protected ref array<string> m_aAllPlayerGearScriptsArray = new array<string>;
+	
 	// A hashmap that is modified only on each client by a .BumpMe from the authority.
-	protected ref map<string, string> m_mAllPlayerGearScriptsMap = new map<string, string>();
-
-	//------------------------------------------------------------------------------------------------
+	protected ref map<string, string> m_mAllPlayerGearScriptsMap = new map<string, string>;
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	override void OnControllableSpawned(IEntity entity)
 	{
 		super.OnControllableSpawned(entity);
-
-		if (RplSession.Mode() == RplMode.Client)
+		
+		if(RplSession.Mode() == RplMode.Client)
 			return;
-
-		if (entity.GetPrefabData().GetPrefabName() == "{59886ECB7BBAF5BC}Prefabs/Characters/CRF_InitialEntity.et")
+		
+		if(entity.GetPrefabData().GetPrefabName() == "{59886ECB7BBAF5BC}Prefabs/Characters/CRF_InitialEntity.et")
 			return;
-
+		
 		GetGame().GetCallqueue().CallLater(CheckWorldValid, 150, false, entity);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void CheckWorldValid(IEntity entity)
 	{
-		if (!GetGame().GetWorld())
+		if(!GetGame().GetWorld())
 		{
 			GetGame().GetCallqueue().CallLater(CheckWorldValid, 500, false, entity);
 			return;
 		}
-
+		
 		GetGame().GetCallqueue().CallLater(SetupAddGearToEntity, m_RNG.RandInt(100, 250), false, entity, entity.GetPrefabData().GetPrefabName());
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	ResourceName GetGearScriptResource(string factionKey)
 	{
 		if (!GetGearScriptSettings(factionKey))
 		{
-			PrintFormat("NO GEARSCRIPT ASSIGNED TO: %1", factionKey, LogLevel.WARNING);
+			PrintFormat("NO GEARSCRIPT ASSIGNED TO: %1", factionKey);
 			return "";
 		};
-
+		
 		return GetGearScriptSettings(factionKey).m_rGearScript;
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	CRF_GearScriptContainer GetGearScriptSettings(string factionKey)
 	{
 		CRF_GearScriptContainer gearScriptContainer;
-
-		switch (factionKey)
+		
+		switch(factionKey)
 		{
-			case "BLUFOR" : {gearScriptContainer = CRF_Gamemode.GetInstance().m_BLUFORGearScriptSettings; break; }
-			case "OPFOR" : {gearScriptContainer = CRF_Gamemode.GetInstance().m_OPFORGearScriptSettings; break; }
-			case "INDFOR" : {gearScriptContainer = CRF_Gamemode.GetInstance().m_INDFORGearScriptSettings; break; }
-			case "CIV" : {gearScriptContainer = CRF_Gamemode.GetInstance().m_CIVILIANGearScriptSettings; break; }
+			case "BLUFOR" : {gearScriptContainer = CRF_Gamemode.GetInstance().m_BLUFORGearScriptSettings;   break;}
+			case "OPFOR"  : {gearScriptContainer = CRF_Gamemode.GetInstance().m_OPFORGearScriptSettings;    break;}
+			case "INDFOR" : {gearScriptContainer = CRF_Gamemode.GetInstance().m_INDFORGearScriptSettings;   break;}
+			case "CIV"    : {gearScriptContainer = CRF_Gamemode.GetInstance().m_CIVILIANGearScriptSettings; break;}
 		}
-
+		
 		return gearScriptContainer;
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// Functions to replicate and store values to each clients m_mAllPlayerGearScriptsMap
-	//------------------------------------------------------------------------------------------------
-
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	override protected void OnGameEnd()
 	{
 		super.OnGameEnd();
-
+		
 		//--- Server only
 		if (RplSession.Mode() == RplMode.Client)
 			return;
-
+		
 		GetGame().GetCallqueue().Remove(UpdatePlayerGearScriptsArray);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	string ReturnPlayerGearScriptsMapValue(int playerID, string key)
 	{
 		// Get the players key
 		key = string.Format("%1%2", playerID, key);
 		return m_mAllPlayerGearScriptsMap.Get(key);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SetPlayerGearScriptsMapValue(string value, int playerID, string key)
 	{
 		// Get the players key
@@ -206,18 +205,18 @@ class CRF_GamemodeComponent : SCR_BaseGameModeComponent
 		m_mAllPlayerGearScriptsMap.Set(key, value);
 	}
 
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	protected void UpdatePlayerGearScriptsArray()
 	{
 		// Create a temp array so we arent broadcasting for each change to m_aAllPlayerGearScriptsArray.
-		protected ref array<string> tempPlayerArray = {};
+		protected ref array<string> tempPlayerArray = new array<string>;
 
 		// Fill tempPlayerArray with all keys and values in m_mAllPlayerGearScriptsMap.
 		for (int i = 0; i < m_mAllPlayerGearScriptsMap.Count(); i++)
 		{
 			string key = m_mAllPlayerGearScriptsMap.GetKey(i);
 			string value = m_mAllPlayerGearScriptsMap.Get(key);
-
+			
 			tempPlayerArray.Insert(string.Format("%1~%2", key, value));
 		};
 
@@ -226,7 +225,7 @@ class CRF_GamemodeComponent : SCR_BaseGameModeComponent
 		Replication.BumpMe();
 	}
 
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	protected void UpdateLocalPlayerGearScriptsMap()
 	{
 		// Fill m_mAllPlayerGearScriptsMap with all keys and values from authorities m_mAllPlayerGearScriptsMap.
@@ -237,245 +236,250 @@ class CRF_GamemodeComponent : SCR_BaseGameModeComponent
 			m_mAllPlayerGearScriptsMap.Set(playerKeyAndValueArray[0], playerKeyAndValueArray[1]);
 		};
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// Functions to for Gear Script
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SetupAddGearToEntity(IEntity entity, ResourceName prefabName)
 	{
+		//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 		// CHECKS & DEFINING KEY VARIABLES
-
-		ResourceName ResourceNameToScan = prefabName;
-
-		if (!ResourceNameToScan.Contains("CRF_GS_") || !entity)
+		//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------	
+		
+		ResourceName ResourceNameToScan = prefabName;	
+		
+		if(!ResourceNameToScan.Contains("CRF_GS_") || !entity)
 			return;
-
+		
 		string factionKey;
-
-		switch (true)
+		
+		switch(true)
 		{
-			case(ResourceNameToScan.Contains("BLUFOR")) : {factionKey = "BLUFOR"; break; }
-			case(ResourceNameToScan.Contains("OPFOR")) : {factionKey = "OPFOR"; break; }
-			case(ResourceNameToScan.Contains("INDFOR")) : {factionKey = "INDFOR"; break; }
-			case(ResourceNameToScan.Contains("CIV")) : {factionKey = "CIV"; break; }
+			case(ResourceNameToScan.Contains("BLUFOR")) : {factionKey = "BLUFOR";   break;}
+			case(ResourceNameToScan.Contains("OPFOR"))  : {factionKey = "OPFOR";    break;}
+			case(ResourceNameToScan.Contains("INDFOR")) : {factionKey = "INDFOR";   break;}
+			case(ResourceNameToScan.Contains("CIV"))    : {factionKey = "CIV";      break;}
 		}
-
-		ResourceName gearScriptResourceName = GetGearScriptResource(factionKey);
+		
+		ResourceName gearScriptResourceName = GetGearScriptResource(factionKey);		
 		CRF_GearScriptContainer gearScriptSettings = GetGearScriptSettings(factionKey);
-
-		if (gearScriptResourceName.IsEmpty() || !gearScriptSettings)
+		
+		if(gearScriptResourceName.IsEmpty() || !gearScriptSettings)
 			return;
-
+		
+		//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 		// GET COMPONENTS
-
+		//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+		
 		SCR_CharacterInventoryStorageComponent inventory = SCR_CharacterInventoryStorageComponent.Cast(entity.FindComponent(SCR_CharacterInventoryStorageComponent));
 		SCR_InventoryStorageManagerComponent inventoryManager = SCR_InventoryStorageManagerComponent.Cast(entity.FindComponent(SCR_InventoryStorageManagerComponent));
-
-		if (!inventory || !inventoryManager)
+		
+		if(!inventory || !inventoryManager)
 		{
 			Print(string.Format("CRF GEAR SCRIPT ERROR: %1 DOESN'T HAVE COMPONENTS WE NEED!", entity), LogLevel.ERROR);
 			return;
 		}
-
+		
+		//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 		// GET ROLE
-
+		//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+		
 		array<string> value = {};
 		ResourceNameToScan.Split("_", value, true);
-
+		
 		string role = "_" + value[3] + "_" + value[4];
-
+		
 		role.Split(".", value, true);
 		role = value[0];
 
+		//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 		// CLEAR CHARACTER
-
+		//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+		
 		array<IEntity> items = {};
 		array<IEntity> itemsRoot = {};
 		inventoryManager.GetAllItems(items, inventory);
 		inventoryManager.GetAllRootItems(itemsRoot);
-
+		
 		items.InsertAll(itemsRoot);
-
-		foreach (IEntity item : items)
-		{
+		
+		foreach(IEntity item : items)
 			SCR_EntityHelper.DeleteEntityAndChildren(item);
-		}
-
+		
+		//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 		// ADD CLOTHING/WEAPONS/ITEMS
+		//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+		
 		GetGame().GetCallqueue().CallLater(AddGearToEntity, m_RNG.RandInt(100, 250), false, entity, role, gearScriptResourceName, gearScriptSettings, inventory, inventoryManager);
 	}
-
+		
 	protected void AddGearToEntity(IEntity entity, string role, ResourceName gearScriptResourceName, CRF_GearScriptContainer gearScriptSettings, SCR_CharacterInventoryStorageComponent inventory, SCR_InventoryStorageManagerComponent inventoryManager)
-	{
+	{		
 		CRF_GearScriptConfig gearConfig = CRF_GearScriptConfig.Cast(BaseContainerTools.CreateInstanceFromContainer(BaseContainerTools.LoadContainer(gearScriptResourceName).GetResource().ToBaseContainer()));
-
+		
 		EntitySpawnParams spawnParams = new EntitySpawnParams();
-		spawnParams.TransformMode = ETransformMode.WORLD;
-		spawnParams.Transform[3] = entity.GetOrigin();
-
+        spawnParams.TransformMode = ETransformMode.WORLD;
+        spawnParams.Transform[3] = entity.GetOrigin();
+		
+		//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 		// CLOTHING
+		//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-		if (gearConfig.m_DefaultFactionGear)
-		{
-			foreach (CRF_Clothing clothing : gearConfig.m_DefaultFactionGear.m_DefaultClothing)
-			{
+		if(gearConfig.m_DefaultFactionGear)
+			foreach(CRF_Clothing clothing : gearConfig.m_DefaultFactionGear.m_DefaultClothing)
 				UpdateClothingSlot(clothing.m_ClothingPrefabs, clothing.m_sClothingType, role, spawnParams, inventory, inventoryManager);
-			}
-		}
-
+		
+		//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 		// CUSTOM GEAR
-
+		//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+		
 		bool isLeader = false;
 		bool isSquad = false;
 		bool isInfSpec = false;
 		bool isVehSpec = false;
-
-		if (gearConfig.m_FactionWeapons)
+		
+		if(gearConfig.m_FactionWeapons)
 		{
-			switch (true)
+			switch(true)
 			{
-				// Leadership ------------------------------------------------------------------------------------------------------------------------------------------------------------------
-				case(m_aLeadershipRolesUGL.Contains(role)) : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "RifleUGL", "", true); isLeader = true; break; }
-				case(m_aLeadershipRolesCarbine.Contains(role)) : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "Carbine", "", true); isLeader = true; break; }
-				// Squad Level -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-				case(m_aSquadLevelRolesUGL.Contains(role)) : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "RifleUGL", "", false); isSquad = true; break; }
-				case(m_aSquadLevelRolesCarbine.Contains(role)) : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "Carbine", "", false); isSquad = true; break; }
-				case(m_aSquadLevelRolesRifle.Contains(role)) : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "Rifle", "", false); isSquad = true; break; }
-				case(role == "_AT_P") : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "Rifle", "AT", false); isSquad = true; break; }
-				case(role == "_AR_P") : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "AR", "", true); isSquad = true; break; }
-				// Infantry Specialties --------------------------------------------------------------------------------------------------------------------------------------------------------
-				case(m_aInfantrySpecialtiesRolesRifle.Contains(role)) : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "Rifle", "", false); isInfSpec = true; break; }
-				case(role == "_HAT_P") : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "Rifle", "HAT", false); isInfSpec = true; break; }
-				case(role == "_MAT_P") : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "Rifle", "MAT", false); isInfSpec = true; break; }
-				case(role == "_HMG_P") : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "HMG", "", true); isInfSpec = true; break; }
-				case(role == "_MMG_P") : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "MMG", "", true); isInfSpec = true; break; }
-				case(role == "_AA_P") : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "Rifle", "AA", false); isInfSpec = true; break; }
-				case(role == "_Sniper_P") : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "Sniper", "", true); isInfSpec = true; break; }
-				case(role == "_Spotter_P") : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "RifleUGL", "", false); isInfSpec = true; break; }
-				// Vehicle Specialties ---------------------------------------------------------------------------------------------------------------------------------------------------------
-				case(m_aVehicleSpecialtiesRolesCarbine.Contains(role)) : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "Carbine", "", false); isVehSpec = true; break; }
-				case(m_aVehicleSpecialtiesRolesPistol.Contains(role)) : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "", "", true); isVehSpec = true; break; }
-				// Default ---------------------------------------------------------------------------------------------------------------------------------------------------------------------
-				default : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "Rifle", "", false); break; }
+				// Leadership --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+				case(m_aLeadershipRolesUGL.Contains(role))             : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "RifleUGL", "",    true);  isLeader = true;  break;}
+				case(m_aLeadershipRolesCarbine.Contains(role))         : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "Carbine",  "",    true);  isLeader = true;  break;}	
+				// Squad Level -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+				case(m_aSquadLevelRolesUGL.Contains(role))             : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "RifleUGL", "",    false); isSquad = true;   break;}
+				case(m_aSquadLevelRolesCarbine.Contains(role))         : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "Carbine",  "",    false); isSquad = true;   break;}
+				case(m_aSquadLevelRolesRifle.Contains(role))           : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "Rifle",    "",    false); isSquad = true;   break;}
+				case(role == "_AT_P")                                  : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "Rifle",    "AT",  false); isSquad = true;   break;}
+				case(role == "_AR_P")                                  : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "AR",       "",    true); isSquad = true;   break;}
+				// Infantry Specialties ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+				case(m_aInfantrySpecialtiesRolesRifle.Contains(role))  : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "Rifle",    "",    false); isInfSpec = true; break;}
+				case(role == "_HAT_P")                                 : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "Rifle",    "HAT", false); isInfSpec = true; break;}
+				case(role == "_MAT_P")                                 : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "Rifle",    "MAT", false); isInfSpec = true; break;}
+				case(role == "_HMG_P")                                 : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "HMG",      "",    true);  isInfSpec = true; break;}
+				case(role == "_MMG_P")                                 : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "MMG",      "",    true);  isInfSpec = true; break;}
+				case(role == "_AA_P")                                  : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "Rifle",    "AA",  false); isInfSpec = true; break;}
+				case(role == "_Sniper_P")                              : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "Sniper",   "",    true);  isInfSpec = true; break;}
+				case(role == "_Spotter_P")                             : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "RifleUGL", "",    false); isInfSpec = true; break;}
+				// Vehicle Specialties -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+				case(m_aVehicleSpecialtiesRolesCarbine.Contains(role)) : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "Carbine",  "",    false); isVehSpec = true; break;}
+				case(m_aVehicleSpecialtiesRolesPistol.Contains(role))  : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "",         "",    true);  isVehSpec = true; break;}
+				// Default -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+				default                                                : {AddWeapons(spawnParams, inventory, inventoryManager, gearConfig, "Rifle",    "",    false); break;}
 			}
 		} else
 			Print(string.Format("CRF GEAR SCRIPT ERROR: NO WEAPONS SET: %1", gearScriptResourceName), LogLevel.ERROR);
-
-		if (gearConfig.m_CustomFactionGear)
+			
+		if(gearConfig.m_CustomFactionGear)
 		{
-			switch (true)
+			switch(true)
 			{
-				case(isLeader) : {UpdateLeadershipCustomGear(gearConfig.m_CustomFactionGear.m_LeadershipCustomGear, role, spawnParams, inventory, inventoryManager); break; }
-				case(isSquad) : {UpdateSquadLevelCustomGear(gearConfig.m_CustomFactionGear.m_SquadLevelCustomGear, role, spawnParams, inventory, inventoryManager); break; }
-				case(isInfSpec) : {UpdateInfantrySpecialtiesCustomGear(gearConfig.m_CustomFactionGear.m_InfantrySpecialtiesCustomGear, role, spawnParams, inventory, inventoryManager); break; }
-				case(isVehSpec) : {UpdateVehicleSpecialtiesCustomGear(gearConfig.m_CustomFactionGear.m_VehicleSpecialtiesCustomGear, role, spawnParams, inventory, inventoryManager); break; }
+				case(isLeader)  : {UpdateLeadershipCustomGear(gearConfig.m_CustomFactionGear.m_LeadershipCustomGear, role, spawnParams, inventory, inventoryManager);                   break;}
+				case(isSquad)   : {UpdateSquadLevelCustomGear(gearConfig.m_CustomFactionGear.m_SquadLevelCustomGear, role, spawnParams, inventory, inventoryManager);                   break;}
+				case(isInfSpec) : {UpdateInfantrySpecialtiesCustomGear(gearConfig.m_CustomFactionGear.m_InfantrySpecialtiesCustomGear, role, spawnParams, inventory, inventoryManager); break;}
+				case(isVehSpec) : {UpdateVehicleSpecialtiesCustomGear(gearConfig.m_CustomFactionGear.m_VehicleSpecialtiesCustomGear, role, spawnParams, inventory, inventoryManager);   break;}
 			}
 		}
-
+		
+		//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 		// ITEMS
-
-		if (gearConfig.m_DefaultFactionGear)
+		//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+		
+		if(gearConfig.m_DefaultFactionGear)
 		{
 			//Who we give Leadership Radios
-			if (gearScriptSettings.m_bEnableLeadershipRadios && (m_aLeadershipRolesUGL.Contains(role) || m_aLeadershipRolesCarbine.Contains(role) || role == "_Spotter_P" || role == "_Pilot_P" || role == "_CrewChief_P" || role == "_Medic_P"))
+			if(gearScriptSettings.m_bEnableLeadershipRadios && (m_aLeadershipRolesUGL.Contains(role) || m_aLeadershipRolesCarbine.Contains(role) || role == "_Spotter_P" || role == "_Pilot_P" || role == "_CrewChief_P" || role == "_Medic_P"))
 				AddInventoryItem(gearScriptSettings.m_rLeadershipRadiosPrefab, 1, spawnParams, inventory, inventoryManager);
-
+			
 			//Who we give GI Radios
-			if (gearScriptSettings.m_bEnableGIRadios && !(m_aLeadershipRolesUGL.Contains(role) || m_aLeadershipRolesCarbine.Contains(role) || role == "_Spotter_P" || role == "_Pilot_P" || role == "_CrewChief_P" || role == "_Medic_P" || role == "_RTO_P"))
+			if(gearScriptSettings.m_bEnableGIRadios && !(m_aLeadershipRolesUGL.Contains(role) || m_aLeadershipRolesCarbine.Contains(role) || role == "_Spotter_P" || role == "_Pilot_P" || role == "_CrewChief_P" || role == "_Medic_P" || role == "_RTO_P"))
 				AddInventoryItem(gearScriptSettings.m_rGIRadiosPrefab, 1, spawnParams, inventory, inventoryManager);
-
+			
 			//Who we give RTO Radios
-			if (gearScriptSettings.m_bEnableRTORadios && role == "_RTO_P")
+			if(gearScriptSettings.m_bEnableRTORadios && role == "_RTO_P")
 				AddInventoryItem(gearScriptSettings.m_rRTORadiosPrefab, 1, spawnParams, inventory, inventoryManager);
-
+			
 			//Who we give Leadership Binos
-			if (gearConfig.m_DefaultFactionGear.m_bEnableLeadershipBinoculars && (m_aLeadershipRolesUGL.Contains(role) || m_aLeadershipRolesCarbine.Contains(role) || role == "_Spotter_P" || role == "_TL_P"))
+			if(gearConfig.m_DefaultFactionGear.m_bEnableLeadershipBinoculars && (m_aLeadershipRolesUGL.Contains(role) || m_aLeadershipRolesCarbine.Contains(role) || role == "_Spotter_P" || role == "_TL_P"))
 				AddInventoryItem(gearConfig.m_DefaultFactionGear.m_sLeadershipBinocularsPrefab, 1, spawnParams, inventory, inventoryManager);
-
+			
 			//Who we give Assistant Binos/Extra magazines
-			if (role == "_AAR_P" || role == "_AMMG_P" || role == "_AHMG_P" || role == "_AMAT_P" || role == "_AHAT_P" || role == "_AAA_P" || role == "_AAT_P")
+			if(role == "_AAR_P" || role == "_AMMG_P" || role == "_AHMG_P" || role == "_AMAT_P" || role == "_AHAT_P" || role == "_AAA_P" || role == "_AAT_P")
 			{
 				array<ref CRF_Spec_Magazine_Class> magazineArray = {};
-
-				switch (role)
+		
+				switch(role)
 				{
-					case "_AAR_P" : {if(!gearConfig.m_FactionWeapons.m_AR || !gearConfig.m_FactionWeapons.m_AR.m_Weapon) {return; } magazineArray = gearConfig.m_FactionWeapons.m_AR.m_MagazineArray; break; }
-					case "_AMMG_P" : {if(!gearConfig.m_FactionWeapons.m_MMG || !gearConfig.m_FactionWeapons.m_MMG.m_Weapon) {return; } magazineArray = gearConfig.m_FactionWeapons.m_MMG.m_MagazineArray; break; }
-					case "_AHMG_P" : {if(!gearConfig.m_FactionWeapons.m_HMG || !gearConfig.m_FactionWeapons.m_HMG.m_Weapon) {return; } magazineArray = gearConfig.m_FactionWeapons.m_HMG.m_MagazineArray; break; }
-					case "_AMAT_P" : {if(!gearConfig.m_FactionWeapons.m_MAT || !gearConfig.m_FactionWeapons.m_MAT.m_Weapon) {return; } magazineArray = gearConfig.m_FactionWeapons.m_MAT.m_MagazineArray; break; }
-					case "_AHAT_P" : {if(!gearConfig.m_FactionWeapons.m_HAT || !gearConfig.m_FactionWeapons.m_HAT.m_Weapon) {return; } magazineArray = gearConfig.m_FactionWeapons.m_HAT.m_MagazineArray; break; }
-					case "_AAA_P" : {if(!gearConfig.m_FactionWeapons.m_AA || !gearConfig.m_FactionWeapons.m_AA.m_Weapon) {return; } magazineArray = gearConfig.m_FactionWeapons.m_AA.m_MagazineArray; break; }
-					case "_AAT_P" : {if(!gearConfig.m_FactionWeapons.m_AT || !gearConfig.m_FactionWeapons.m_AT.m_Weapon) {return; } magazineArray = gearConfig.m_FactionWeapons.m_AT.m_MagazineArray; break; }
+					case "_AAR_P"  : {if(!gearConfig.m_FactionWeapons.m_AR  || !gearConfig.m_FactionWeapons.m_AR.m_Weapon)  {return;} magazineArray = gearConfig.m_FactionWeapons.m_AR.m_MagazineArray;  break;}
+					case "_AMMG_P" : {if(!gearConfig.m_FactionWeapons.m_MMG || !gearConfig.m_FactionWeapons.m_MMG.m_Weapon) {return;} magazineArray = gearConfig.m_FactionWeapons.m_MMG.m_MagazineArray; break;}
+					case "_AHMG_P" : {if(!gearConfig.m_FactionWeapons.m_HMG || !gearConfig.m_FactionWeapons.m_HMG.m_Weapon) {return;} magazineArray = gearConfig.m_FactionWeapons.m_HMG.m_MagazineArray; break;}
+					case "_AMAT_P" : {if(!gearConfig.m_FactionWeapons.m_MAT || !gearConfig.m_FactionWeapons.m_MAT.m_Weapon) {return;} magazineArray = gearConfig.m_FactionWeapons.m_MAT.m_MagazineArray; break;}
+					case "_AHAT_P" : {if(!gearConfig.m_FactionWeapons.m_HAT || !gearConfig.m_FactionWeapons.m_HAT.m_Weapon) {return;} magazineArray = gearConfig.m_FactionWeapons.m_HAT.m_MagazineArray; break;}
+					case "_AAA_P"  : {if(!gearConfig.m_FactionWeapons.m_AA  || !gearConfig.m_FactionWeapons.m_AA.m_Weapon)  {return;} magazineArray = gearConfig.m_FactionWeapons.m_AA.m_MagazineArray;  break;}
+					case "_AAT_P"  : {if(!gearConfig.m_FactionWeapons.m_AT  || !gearConfig.m_FactionWeapons.m_AT.m_Weapon)  {return;} magazineArray = gearConfig.m_FactionWeapons.m_AT.m_MagazineArray;  break;}
 				}
-
-				foreach (ref CRF_Spec_Magazine_Class magazine : magazineArray)
-				{
+		
+				foreach(ref CRF_Spec_Magazine_Class magazine : magazineArray)
 					AddInventoryItem(magazine.m_Magazine, magazine.m_AssistantMagazineCount, spawnParams, inventory, inventoryManager, role, true);
-				}
-
-				if (gearConfig.m_DefaultFactionGear.m_bEnableAssistantBinoculars)
+				
+				if(gearConfig.m_DefaultFactionGear.m_bEnableAssistantBinoculars)
 					AddInventoryItem(gearConfig.m_DefaultFactionGear.m_sAssistantBinocularsPrefab, 1, spawnParams, inventory, inventoryManager, role);
 			}
-
+			
 			//Who we give extra medical items
-			if (role == "_Medic_P" || role == "_MO_P")
-			{
-				foreach (CRF_Inventory_Item item : gearConfig.m_DefaultFactionGear.m_DefaultMedicMedicalItems)
-				{
+			if(role == "_Medic_P" || role == "_MO_P")
+			{	
+				foreach(CRF_Inventory_Item item : gearConfig.m_DefaultFactionGear.m_DefaultMedicMedicalItems)
 					AddInventoryItem(item.m_sItemPrefab, item.m_iItemCount, spawnParams, inventory, inventoryManager, role);
-				}
 			}
-
+			
 			//What everyone gets
-			foreach (CRF_Inventory_Item item : gearConfig.m_DefaultFactionGear.m_DefaultInventoryItems)
-			{
+			foreach(CRF_Inventory_Item item : gearConfig.m_DefaultFactionGear.m_DefaultInventoryItems)
 				AddInventoryItem(item.m_sItemPrefab, item.m_iItemCount, spawnParams, inventory, inventoryManager, role, gearConfig.m_DefaultFactionGear.m_bEnableMedicFrags);
-			}
-		} else
+		} else 
 			Print(string.Format("CRF GEAR SCRIPT ERROR: NO DEFAULT GEAR SET: %1", gearScriptResourceName), LogLevel.ERROR);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	protected void UpdateClothingSlot(array<ResourceName> clothingArray, string clothingStr, string role, EntitySpawnParams spawnParams, SCR_CharacterInventoryStorageComponent inventory, SCR_InventoryStorageManagerComponent inventoryManager)
 	{
-		if (clothingArray.IsEmpty() || clothingStr.IsEmpty())
+		if(clothingArray.IsEmpty() || clothingStr.IsEmpty())
 			return;
-
+		
 		int slotInt = ConvertClothingStringToInt(clothingStr);
-
-		if (slotInt == -1)
+		
+		if(slotInt == -1)
 			return;
-
+		
 		array<IEntity> removedItems = {};
 		IEntity previousClothing = inventory.Get(slotInt);
 		ResourceName clothing = clothingArray.GetRandomElement();
-
+		
 		if (previousClothing != null)
 		{
 			BaseInventoryStorageComponent oldStorage = BaseInventoryStorageComponent.Cast(previousClothing.FindComponent(BaseInventoryStorageComponent));
-			if (oldStorage)
+			if(oldStorage)
 			{
 				array<IEntity> outItems = {};
 				oldStorage.GetAll(outItems);
-				foreach (IEntity item : outItems)
+				foreach(IEntity item : outItems)
 				{
-					if (!item || !InventoryItemComponent.Cast(item.FindComponent(InventoryItemComponent)) || SCR_EquipmentStorageComponent.Cast(item.FindComponent(SCR_EquipmentStorageComponent)) || SCR_UniversalInventoryStorageComponent.Cast(item.FindComponent(SCR_UniversalInventoryStorageComponent)) || BaseInventoryStorageComponent.Cast(item.FindComponent(BaseInventoryStorageComponent)))
+					if(!item || !InventoryItemComponent.Cast(item.FindComponent(InventoryItemComponent)) || SCR_EquipmentStorageComponent.Cast(item.FindComponent(SCR_EquipmentStorageComponent)) ||  SCR_UniversalInventoryStorageComponent.Cast(item.FindComponent(SCR_UniversalInventoryStorageComponent)) || BaseInventoryStorageComponent.Cast(item.FindComponent(BaseInventoryStorageComponent)))
 						continue;
-
+					
 					inventoryManager.TryRemoveItemFromStorage(item, oldStorage);
 					removedItems.Insert(item);
 				}
 			};
-
+			
 			inventoryManager.TryRemoveItemFromStorage(previousClothing, inventory);
 			SCR_EntityHelper.DeleteEntityAndChildren(previousClothing);
 		};
-
-		if (!clothing.IsEmpty())
+		
+		if(!clothing.IsEmpty())
 		{
-			IEntity resourceSpawned = GetGame().SpawnEntityPrefab(Resource.Load(clothing), GetGame().GetWorld(), spawnParams);
+			ref IEntity resourceSpawned = GetGame().SpawnEntityPrefab(Resource.Load(clothing), GetGame().GetWorld(), spawnParams);
 			inventoryManager.TryReplaceItem(resourceSpawned, inventory, slotInt);
-
+			
 			if (!inventoryManager.Contains(resourceSpawned))
 			{
 				Print("--------------------------------------------------------------------------------", LogLevel.ERROR);
@@ -487,50 +491,48 @@ class CRF_GamemodeComponent : SCR_BaseGameModeComponent
 				SCR_EntityHelper.DeleteEntityAndChildren(resourceSpawned);
 			};
 		}
-
-		foreach (IEntity oldItem : removedItems)
-		{
+		
+		foreach(IEntity oldItem : removedItems)
 			InsertInventoryItem(oldItem, inventory, inventoryManager, role);
-		}
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	protected void AddInventoryItem(ResourceName item, int itemAmmount, EntitySpawnParams spawnParams, SCR_CharacterInventoryStorageComponent inventory, SCR_InventoryStorageManagerComponent inventoryManager, string role = "", bool enableMedicFrags = false, bool isAssistant = false)
-	{
-		if (item.IsEmpty() || itemAmmount <= 0)
+	{	
+		if(item.IsEmpty() || itemAmmount <= 0)
 			return;
-
-		for (int i = 1; i <= itemAmmount; i++)
+		
+		for(int i = 1; i <= itemAmmount; i++)
 		{
-			IEntity resourceSpawned = GetGame().SpawnEntityPrefab(Resource.Load(item), GetGame().GetWorld(), spawnParams);
-
-			if (!resourceSpawned)
+			ref IEntity resourceSpawned = GetGame().SpawnEntityPrefab(Resource.Load(item), GetGame().GetWorld(), spawnParams);
+			
+			if(!resourceSpawned)
 				continue;
-
+			
 			bool isThrowable = (WeaponComponent.Cast(resourceSpawned.FindComponent(WeaponComponent)) && WEAPON_TYPES_THROWABLE.Contains(WeaponComponent.Cast(resourceSpawned.FindComponent(WeaponComponent)).GetWeaponType()));
-
-			if (!enableMedicFrags && (role == "_Medic_P" || role == "_MO_P") && (isThrowable && WeaponComponent.Cast(resourceSpawned.FindComponent(WeaponComponent)).GetWeaponType() == EWeaponType.WT_FRAGGRENADE))
+			
+			if(!enableMedicFrags && (role == "_Medic_P" || role == "_MO_P") && (isThrowable && WeaponComponent.Cast(resourceSpawned.FindComponent(WeaponComponent)).GetWeaponType() == EWeaponType.WT_FRAGGRENADE))
 			{
 				SCR_EntityHelper.DeleteEntityAndChildren(resourceSpawned);
 				continue;
 			};
-
-			if (inventoryManager.CanInsertItem(resourceSpawned, EStoragePurpose.PURPOSE_EQUIPMENT_ATTACHMENT))
+			
+			if(inventoryManager.CanInsertItem(resourceSpawned, EStoragePurpose.PURPOSE_EQUIPMENT_ATTACHMENT))
 			{
 				BaseInventoryStorageComponent storageComp = inventoryManager.FindStorageForItem(resourceSpawned, EStoragePurpose.PURPOSE_EQUIPMENT_ATTACHMENT);
 				inventoryManager.EquipAny(storageComp, resourceSpawned, -1);
 				continue;
 			};
-
+			
 			InsertInventoryItem(resourceSpawned, inventory, inventoryManager, role, isAssistant, isThrowable);
-
-			if (isThrowable)
+			
+			if(isThrowable)
 			{
 				CharacterGrenadeSlotComponent grenadeSlot = CharacterGrenadeSlotComponent.Cast(inventoryManager.GetOwner().FindComponent(CharacterGrenadeSlotComponent));
-
-				if (grenadeSlot && !grenadeSlot.GetWeaponEntity())
+				
+				if(grenadeSlot && !grenadeSlot.GetWeaponEntity())
 				{
-					if (WeaponComponent.Cast(resourceSpawned.FindComponent(WeaponComponent)).GetWeaponType() == EWeaponType.WT_FRAGGRENADE)
+					if(WeaponComponent.Cast(resourceSpawned.FindComponent(WeaponComponent)).GetWeaponType() == EWeaponType.WT_FRAGGRENADE)
 					{
 						grenadeSlot.SetWeapon(resourceSpawned);
 					} else {
@@ -541,38 +543,38 @@ class CRF_GamemodeComponent : SCR_BaseGameModeComponent
 			};
 		}
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	protected void InsertInventoryItem(IEntity item, SCR_CharacterInventoryStorageComponent inventory, SCR_InventoryStorageManagerComponent inventoryManager, string role = "", bool isAssistant = false, bool isThrowable = false)
 	{
-		if (!item)
+		if(!item) 
 			return;
-
+		
 		TIntArray clothingIDs = FilterItemToClothing(item, role, isAssistant, isThrowable);
-
+		
 		// Try and insert into select clothing at first
-		foreach (int clothingID : clothingIDs)
-		{
+		foreach(int clothingID : clothingIDs)
+		{			
 			IEntity clothing = inventory.Get(clothingID);
 
-			if (!clothing || inventoryManager.Contains(item))
+			if(!clothing || inventoryManager.Contains(item))
 				continue;
-
+				
 			BaseInventoryStorageComponent clothingStorage = BaseInventoryStorageComponent.Cast(clothing.FindComponent(BaseInventoryStorageComponent));
-
-			if (!clothingStorage)
+			
+			if(!clothingStorage)
 				continue;
-
+			
 			bool successfulInsert = inventoryManager.TryInsertItemInStorage(item, clothingStorage);
-
-			if (!successfulInsert)
+			
+			if(!successfulInsert)
 				inventoryManager.InsertItemCRF(item, clothingStorage, null, null, false);
 		};
-
+			
 		// if we cant do select clothing, just slap it in wherever
-		if (!inventoryManager.Contains(item))
+		if(!inventoryManager.Contains(item))
 			inventoryManager.TryInsertItem(item);
-
+			
 		if (!inventoryManager.Contains(item) || !InventoryItemComponent.Cast(item.FindComponent(InventoryItemComponent)))
 		{
 			Print("--------------------------------------------------------------------------------", LogLevel.ERROR);
@@ -584,64 +586,64 @@ class CRF_GamemodeComponent : SCR_BaseGameModeComponent
 			SCR_EntityHelper.DeleteEntityAndChildren(item);
 		};
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	protected void AddWeapons(EntitySpawnParams spawnParams, SCR_CharacterInventoryStorageComponent inventory, SCR_InventoryStorageManagerComponent inventoryManager, CRF_GearScriptConfig gearConfig, string weaponType, string atType, bool givePistol)
-	{
-		CRF_Spec_Weapon_Class specialWeaponToSpawnContainer;
-		CRF_Weapon_Class weaponToSpawnContainer;
-
+	{	
+		ref CRF_Spec_Weapon_Class specialWeaponToSpawnContainer;
+		ref CRF_Weapon_Class weaponToSpawnContainer;
+		
 		//First Primary
-		if (weaponType != "")
+		if(weaponType != "")
 		{
-			switch (weaponType)
+			switch(weaponType)
 			{
-				case "Rifle" : {weaponToSpawnContainer = SelectRandomWeapon(gearConfig.m_FactionWeapons.m_Rifle); break; }
-				case "RifleUGL" : {weaponToSpawnContainer = SelectRandomWeapon(gearConfig.m_FactionWeapons.m_RifleUGL); break; }
-				case "Carbine" : {weaponToSpawnContainer = SelectRandomWeapon(gearConfig.m_FactionWeapons.m_Carbine); break; }
-				case "AR" : {specialWeaponToSpawnContainer = gearConfig.m_FactionWeapons.m_AR; break; }
-				case "MMG" : {specialWeaponToSpawnContainer = gearConfig.m_FactionWeapons.m_MMG; break; }
-				case "HMG" : {specialWeaponToSpawnContainer = gearConfig.m_FactionWeapons.m_HMG; break; }
-				case "Sniper" : {weaponToSpawnContainer = gearConfig.m_FactionWeapons.m_Sniper; break; }
+				case "Rifle"    : {weaponToSpawnContainer = SelectRandomWeapon(gearConfig.m_FactionWeapons.m_Rifle);    break;}
+				case "RifleUGL" : {weaponToSpawnContainer = SelectRandomWeapon(gearConfig.m_FactionWeapons.m_RifleUGL); break;}
+				case "Carbine"  : {weaponToSpawnContainer = SelectRandomWeapon(gearConfig.m_FactionWeapons.m_Carbine);  break;}
+				case "AR"       : {specialWeaponToSpawnContainer = gearConfig.m_FactionWeapons.m_AR;                    break;}
+				case "MMG"      : {specialWeaponToSpawnContainer = gearConfig.m_FactionWeapons.m_MMG;                   break;}
+				case "HMG"      : {specialWeaponToSpawnContainer = gearConfig.m_FactionWeapons.m_HMG;                   break;}
+				case "Sniper"   : {weaponToSpawnContainer = gearConfig.m_FactionWeapons.m_Sniper;                       break;}
 			}
-
-			if (weaponToSpawnContainer && weaponToSpawnContainer.m_Weapon)
+			
+			if(weaponToSpawnContainer && weaponToSpawnContainer.m_Weapon)
 				SpawnWeapon(weaponToSpawnContainer, spawnParams, inventory, inventoryManager);
-
-			if (specialWeaponToSpawnContainer && specialWeaponToSpawnContainer.m_Weapon)
+			
+			if(specialWeaponToSpawnContainer && specialWeaponToSpawnContainer.m_Weapon)
 				SpawnSpecialWeapon(specialWeaponToSpawnContainer, spawnParams, inventory, inventoryManager);
 		}
-
+		
 		//Second Primary
-		if (atType != "")
+		if(atType != "")
 		{
-			switch (atType)
+			switch(atType)
 			{
-				case "AT" : {specialWeaponToSpawnContainer = gearConfig.m_FactionWeapons.m_AT; break; }
-				case "MAT" : {specialWeaponToSpawnContainer = gearConfig.m_FactionWeapons.m_MAT; break; }
-				case "HAT" : {specialWeaponToSpawnContainer = gearConfig.m_FactionWeapons.m_HAT; break; }
-				case "AA" : {specialWeaponToSpawnContainer = gearConfig.m_FactionWeapons.m_AA; break; }
+				case "AT"  : {specialWeaponToSpawnContainer = gearConfig.m_FactionWeapons.m_AT;  break;}
+				case "MAT" : {specialWeaponToSpawnContainer = gearConfig.m_FactionWeapons.m_MAT; break;}
+				case "HAT" : {specialWeaponToSpawnContainer = gearConfig.m_FactionWeapons.m_HAT; break;}	
+				case "AA"  : {specialWeaponToSpawnContainer = gearConfig.m_FactionWeapons.m_AA;  break;}
 			}
-
-			if (specialWeaponToSpawnContainer || specialWeaponToSpawnContainer.m_Weapon)
+			
+			if(specialWeaponToSpawnContainer || specialWeaponToSpawnContainer.m_Weapon)	
 				SpawnSpecialWeapon(specialWeaponToSpawnContainer, spawnParams, inventory, inventoryManager);
 		}
-
+		
 		//Pistol
-		if (givePistol)
+		if(givePistol)
 		{
-			weaponToSpawnContainer = SelectRandomWeapon(gearConfig.m_FactionWeapons.m_Pistol);
-
-			if (weaponToSpawnContainer && weaponToSpawnContainer.m_Weapon)
+			weaponToSpawnContainer = SelectRandomWeapon(gearConfig.m_FactionWeapons.m_Pistol);  
+			
+			if(weaponToSpawnContainer && weaponToSpawnContainer.m_Weapon)
 				SpawnWeapon(weaponToSpawnContainer, spawnParams, inventory, inventoryManager);
 		}
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	protected void SpawnWeapon(CRF_Weapon_Class weaponToSpawnContainer, EntitySpawnParams spawnParams, SCR_CharacterInventoryStorageComponent inventory, SCR_InventoryStorageManagerComponent inventoryManager)
-	{
+	{				
 		bool successfulSpawn = inventoryManager.TrySpawnPrefabToStorage(weaponToSpawnContainer.m_Weapon, null, -1, EStoragePurpose.PURPOSE_WEAPON_PROXY);
-
+		
 		if (!successfulSpawn)
 		{
 			Print("--------------------------------------------------------------------------------", LogLevel.ERROR);
@@ -652,20 +654,18 @@ class CRF_GamemodeComponent : SCR_BaseGameModeComponent
 			Print("--------------------------------------------------------------------------------", LogLevel.ERROR);
 			return;
 		};
-
-		foreach (ref CRF_Magazine_Class magazine : weaponToSpawnContainer.m_MagazineArray)
-		{
+		
+		foreach(ref CRF_Magazine_Class magazine : weaponToSpawnContainer.m_MagazineArray)
 			AddInventoryItem(magazine.m_Magazine, magazine.m_MagazineCount, spawnParams, inventory, inventoryManager);
-		}
-
+		
 		GetGame().GetCallqueue().CallLater(AddAttachments, 1000, false, weaponToSpawnContainer.m_Weapon, weaponToSpawnContainer.m_Attachments, spawnParams, inventoryManager);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	protected void SpawnSpecialWeapon(CRF_Spec_Weapon_Class specialWeaponToSpawnContainer, EntitySpawnParams spawnParams, SCR_CharacterInventoryStorageComponent inventory, SCR_InventoryStorageManagerComponent inventoryManager)
-	{
+	{				
 		bool successfulSpawn = inventoryManager.TrySpawnPrefabToStorage(specialWeaponToSpawnContainer.m_Weapon, null, -1, EStoragePurpose.PURPOSE_WEAPON_PROXY);
-
+		
 		if (!successfulSpawn)
 		{
 			Print("--------------------------------------------------------------------------------", LogLevel.ERROR);
@@ -676,28 +676,26 @@ class CRF_GamemodeComponent : SCR_BaseGameModeComponent
 			Print("--------------------------------------------------------------------------------", LogLevel.ERROR);
 			return;
 		};
-
-		foreach (ref CRF_Spec_Magazine_Class specialMagazine : specialWeaponToSpawnContainer.m_MagazineArray)
-		{
+		
+		foreach(ref CRF_Spec_Magazine_Class specialMagazine : specialWeaponToSpawnContainer.m_MagazineArray)
 			AddInventoryItem(specialMagazine.m_Magazine, specialMagazine.m_MagazineCount, spawnParams, inventory, inventoryManager);
-		}
-
+			
 		GetGame().GetCallqueue().CallLater(AddAttachments, 1000, false, specialWeaponToSpawnContainer.m_Weapon, specialWeaponToSpawnContainer.m_Attachments, spawnParams, inventoryManager);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	protected void AddAttachments(ResourceName weaponToSpawnContainer, array<ResourceName> weaponsAttachments, EntitySpawnParams spawnParams, SCR_InventoryStorageManagerComponent inventoryManager)
-	{
+	{			
 		BaseWeaponManagerComponent weaponManager = ChimeraCharacter.Cast(inventoryManager.GetOwner()).GetCharacterController().GetWeaponManagerComponent();
-
-		if (!weaponManager || !weaponsAttachments || weaponsAttachments.IsEmpty())
+				
+		if(!weaponManager || !weaponsAttachments || weaponsAttachments.IsEmpty())
 			return;
-
+		
 		IEntity weapon;
 		array<IEntity> outWeapons = {};
 		weaponManager.GetWeaponsList(outWeapons);
-
-		foreach (IEntity weaponToCheck : outWeapons)
+		
+		foreach(IEntity weaponToCheck : outWeapons)
 		{
 			if (weaponToCheck.GetPrefabData().GetPrefabName() == weaponToSpawnContainer)
 			{
@@ -705,33 +703,33 @@ class CRF_GamemodeComponent : SCR_BaseGameModeComponent
 				break;
 			}
 		}
-
-		if (!weapon)
+		
+		if(!weapon)
 			return;
 
 		array<AttachmentSlotComponent> attatchmentSlotArray = {};
 		BaseWeaponComponent.Cast(weapon.FindComponent(BaseWeaponComponent)).GetAttachments(attatchmentSlotArray);
-
-		foreach (ResourceName attachment : weaponsAttachments)
+		
+		foreach(ResourceName attachment : weaponsAttachments)
 		{
-			AttachmentSlotComponent verifyAttachmentSlot = null;
+			AttachmentSlotComponent verifyAttachmentSlot = null;		
 			IEntity attachmentSpawned = GetGame().SpawnEntityPrefab(Resource.Load(attachment), GetGame().GetWorld(), spawnParams);
 			inventoryManager.TryInsertItem(attachmentSpawned, EStoragePurpose.PURPOSE_ATTACHMENT_PROXY);
-
-			foreach (AttachmentSlotComponent attachmentSlot : attatchmentSlotArray)
-			{
-				if (attachmentSlot.CanSetAttachment(attachmentSpawned))
+			
+			foreach(AttachmentSlotComponent attachmentSlot : attatchmentSlotArray)
+			{	
+				if(attachmentSlot.CanSetAttachment(attachmentSpawned))
 				{
-					if (attachmentSlot.GetAttachedEntity() != attachmentSpawned)
+					if(attachmentSlot.GetAttachedEntity() != attachmentSpawned)
 						delete attachmentSlot.GetAttachedEntity();
-
+						
 					attachmentSlot.SetAttachment(attachmentSpawned);
 					verifyAttachmentSlot = attachmentSlot;
 					break;
 				};
 			}
-
-			if (!verifyAttachmentSlot)
+					
+			if(!verifyAttachmentSlot) 
 			{
 				Print("--------------------------------------------------------------------------------", LogLevel.ERROR);
 				Print(string.Format("CRF GEAR SCRIPT ERROR: UNABLE TO INSERT ATTACHMENT: %1", attachment), LogLevel.ERROR);
@@ -743,242 +741,226 @@ class CRF_GamemodeComponent : SCR_BaseGameModeComponent
 			};
 		}
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	protected void UpdateLeadershipCustomGear(array<ref CRF_Leadership_Custom_Gear> customGearArray, string role, EntitySpawnParams spawnParams, SCR_CharacterInventoryStorageComponent inventory, SCR_InventoryStorageManagerComponent inventoryManager)
 	{
-		switch (role)
+		switch(role)
 		{
-			case "_COY_P" : {role = "Company Commander"; break; }
-			case "_PL_P" : {role = "Platoon Leader"; break; }
-			case "_MO_P" : {role = "Medical Officer"; break; }
-			case "_SL_P" : {role = "Squad Lead"; break; }
-			case "_FO_P" : {role = "Forward Observer"; break; }
-			case "_JTAC_P" : {role = "JTAC"; break; }
-			case "_VehLead_P" : {role = "Vehicle Lead"; break; }
-			case "_IndirectLead_P" : {role = "Indirect Lead"; break; }
-			case "_LogiLead_P" : {role = "Logi Lead"; break; }
-			case "_1SG_P" : {role = "First Sergeant"; break; }
-			case "_PSG_P" : {role = "Platoon Sergeant"; break; }
-		}
-
-		foreach (ref CRF_Leadership_Custom_Gear customGear : customGearArray)
-		{
-			if (customGear.m_sRoleToOverride != role)
+			case "_COY_P"          : {role = "Company Commander"; break;}
+			case "_PL_P"           : {role = "Platoon Leader";    break;}
+			case "_MO_P"           : {role = "Medical Officer";   break;}
+			case "_SL_P"           : {role = "Squad Lead";        break;}
+			case "_FO_P"           : {role = "Forward Observer";  break;}
+			case "_JTAC_P"         : {role = "JTAC";              break;}
+			case "_VehLead_P"      : {role = "Vehicle Lead";      break;}
+			case "_IndirectLead_P" : {role = "Indirect Lead";     break;}
+			case "_LogiLead_P"     : {role = "Logi Lead";         break;}
+			case "_1SG_P"          : {role = "First Sergeant";    break;}
+			case "_PSG_P"          : {role = "Platoon Sergeant";  break;}
+		}	
+		
+		foreach(ref CRF_Leadership_Custom_Gear customGear : customGearArray)
+		{	
+			if(customGear.m_sRoleToOverride != role)
 				continue;
-
-			foreach (CRF_Clothing clothing : customGear.m_CustomClothing)
-			{
+				
+			foreach(CRF_Clothing clothing : customGear.m_CustomClothing)
 				UpdateClothingSlot(clothing.m_ClothingPrefabs, clothing.m_sClothingType, role, spawnParams, inventory, inventoryManager);
-			}
-
-			foreach (CRF_Inventory_Item item : customGear.m_AdditionalInventoryItems)
-			{
+					
+			foreach(CRF_Inventory_Item item : customGear.m_AdditionalInventoryItems)
 				AddInventoryItem(item.m_sItemPrefab, item.m_iItemCount, spawnParams, inventory, inventoryManager, role);
-			}
 		}
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	protected void UpdateSquadLevelCustomGear(array<ref CRF_Squad_Level_Custom_Gear> customGearArray, string role, EntitySpawnParams spawnParams, SCR_CharacterInventoryStorageComponent inventory, SCR_InventoryStorageManagerComponent inventoryManager)
 	{
-		switch (role)
+		switch(role)
 		{
-			case "_TL_P" : {role = "Team Lead"; break; }
-			case "_Gren_P" : {role = "Grenadier"; break; }
-			case "_RTO_P" : {role = "Radio Telephone Operator"; break; }
-			case "_Rifleman_P" : {role = "Rifleman"; break; }
-			case "_Demo_P" : {role = "Rifleman Demo"; break; }
-			case "_AT_P" : {role = "Rifleman AntiTank"; break; }
-			case "_AAT_P" : {role = "Assistant Rifleman AntiTank"; break; }
-			case "_AR_P" : {role = "Automatic Rifleman"; break; }
-			case "_AAR_P" : {role = "Assistant Automatic Rifleman"; break; }
-			case "_Medic_P" : {role = "Medic"; break; }
+			case "_TL_P"       : {role = "Team Lead";                    break;}
+			case "_Gren_P"     : {role = "Grenadier";                    break;}
+			case "_RTO_P"      : {role = "Radio Telephone Operator";     break;}
+			case "_Rifleman_P" : {role = "Rifleman";                     break;}
+			case "_Demo_P"     : {role = "Rifleman Demo";                break;}
+			case "_AT_P"       : {role = "Rifleman AntiTank";            break;}
+			case "_AAT_P"      : {role = "Assistant Rifleman AntiTank";  break;}
+			case "_AR_P"       : {role = "Automatic Rifleman";           break;}
+			case "_AAR_P"      : {role = "Assistant Automatic Rifleman"; break;}
+			case "_Medic_P"    : {role = "Medic";                        break;}
 		}
-
-		foreach (ref CRF_Squad_Level_Custom_Gear customGear : customGearArray)
-		{
-			if (customGear.m_sRoleToOverride != role)
+		
+		foreach(ref CRF_Squad_Level_Custom_Gear customGear : customGearArray)
+		{		
+			if(customGear.m_sRoleToOverride != role)
 				continue;
-
-			foreach (CRF_Clothing clothing : customGear.m_CustomClothing)
-			{
+				
+			foreach(CRF_Clothing clothing : customGear.m_CustomClothing)
 				UpdateClothingSlot(clothing.m_ClothingPrefabs, clothing.m_sClothingType, role, spawnParams, inventory, inventoryManager);
-			}
-
-			foreach (CRF_Inventory_Item item : customGear.m_AdditionalInventoryItems)
-			{
+					
+			foreach(CRF_Inventory_Item item : customGear.m_AdditionalInventoryItems)
 				AddInventoryItem(item.m_sItemPrefab, item.m_iItemCount, spawnParams, inventory, inventoryManager, role);
-			}
 		}
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	protected void UpdateInfantrySpecialtiesCustomGear(array<ref CRF_Infantry_Specialties_Custom_Gear> customGearArray, string role, EntitySpawnParams spawnParams, SCR_CharacterInventoryStorageComponent inventory, SCR_InventoryStorageManagerComponent inventoryManager)
 	{
-		switch (role)
+		switch(role)
 		{
-			case "_HAT_P" : {role = "Heavy AntiTank"; break; }
-			case "_AHAT_P" : {role = "Assistant Heavy AntiTank"; break; }
-			case "_MAT_P" : {role = "Medium AntiTank"; break; }
-			case "_AMAT_P" : {role = "Assistant Medium AntiTank"; break; }
-			case "_HMG_P" : {role = "Heavy MachineGun"; break; }
-			case "_AHMG_P" : {role = "Assistant Heavy MachineGun"; break; }
-			case "_MMG_P" : {role = "Medium MachineGun"; break; }
-			case "_AMMG_P" : {role = "Assistant Medium MachineGun"; break; }
-			case "_AA_P" : {role = "Anit-Air"; break; }
-			case "_AAA_P" : {role = "Assistant Anit-Air"; break; }
-			case "_Sniper_P" : {role = "Sniper"; break; }
-			case "_Spotter_P" : {role = "Spotter"; break; }
-			case "_DroneOp_P" : {role = "Drone Operator"; break; }
+			case "_HAT_P"     : {role = "Heavy AntiTank";              break;}
+			case "_AHAT_P"    : {role = "Assistant Heavy AntiTank";    break;}
+			case "_MAT_P"     : {role = "Medium AntiTank";             break;}
+			case "_AMAT_P"    : {role = "Assistant Medium AntiTank";   break;}
+			case "_HMG_P"     : {role = "Heavy MachineGun";            break;}
+			case "_AHMG_P"    : {role = "Assistant Heavy MachineGun";  break;}
+			case "_MMG_P"     : {role = "Medium MachineGun";           break;}
+			case "_AMMG_P"    : {role = "Assistant Medium MachineGun"; break;}
+			case "_AA_P"      : {role = "Anit-Air";                    break;}
+			case "_AAA_P"     : {role = "Assistant Anit-Air";          break;}
+			case "_Sniper_P"  : {role = "Sniper";                      break;}
+			case "_Spotter_P" : {role = "Spotter";                     break;}
+			case "_DroneOp_P" : {role = "Drone Operator";              break;}
 		}
-
-		foreach (ref CRF_Infantry_Specialties_Custom_Gear customGear : customGearArray)
-		{
-			if (customGear.m_sRoleToOverride != role)
+		
+		foreach(ref CRF_Infantry_Specialties_Custom_Gear customGear : customGearArray)
+		{	
+			if(customGear.m_sRoleToOverride != role)
 				continue;
-
-			foreach (CRF_Clothing clothing : customGear.m_CustomClothing)
-			{
+				
+			foreach(CRF_Clothing clothing : customGear.m_CustomClothing)
 				UpdateClothingSlot(clothing.m_ClothingPrefabs, clothing.m_sClothingType, role, spawnParams, inventory, inventoryManager);
-			}
-
-			foreach (CRF_Inventory_Item item : customGear.m_AdditionalInventoryItems)
-			{
+					
+			foreach(CRF_Inventory_Item item : customGear.m_AdditionalInventoryItems)
 				AddInventoryItem(item.m_sItemPrefab, item.m_iItemCount, spawnParams, inventory, inventoryManager, role);
-			}
 		}
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	protected void UpdateVehicleSpecialtiesCustomGear(array<ref CRF_Vehicle_Specialties_Custom_Gear> customGearArray, string role, EntitySpawnParams spawnParams, SCR_CharacterInventoryStorageComponent inventory, SCR_InventoryStorageManagerComponent inventoryManager)
 	{
-		switch (role)
+		switch(role)
 		{
-			case "_VehDriver_P" : {role = "Vehicle Driver"; break; }
-			case "_VehGunner_P" : {role = "Vehicle Gunner"; break; }
-			case "_VehLoader_P" : {role = "Vehicle Loader"; break; }
-			case "_Pilot_P" : {role = "Pilot"; break; }
-			case "_CrewChief_P" : {role = "Crew Chief"; break; }
-			case "_LogiRunner_P" : {role = "Logi Runner"; break; }
-			case "_IndirectGunner_P" : {role = "Indirect Gunner"; break; }
-			case "_IndirectLoader_P" : {role = "Indirect Loader"; break; }
+			case "_VehDriver_P"      : {role = "Vehicle Driver";  break;}
+			case "_VehGunner_P"      : {role = "Vehicle Gunner";  break;}
+			case "_VehLoader_P"      : {role = "Vehicle Loader";  break;}
+			case "_Pilot_P"          : {role = "Pilot";           break;}
+			case "_CrewChief_P"      : {role = "Crew Chief";      break;}
+			case "_LogiRunner_P"     : {role = "Logi Runner";     break;}
+			case "_IndirectGunner_P" : {role = "Indirect Gunner"; break;}
+			case "_IndirectLoader_P" : {role = "Indirect Loader"; break;}
 		}
-
-		foreach (ref CRF_Vehicle_Specialties_Custom_Gear customGear : customGearArray)
+		
+		foreach(ref CRF_Vehicle_Specialties_Custom_Gear customGear : customGearArray)
 		{
-			if (customGear.m_sRoleToOverride != role)
+			if(customGear.m_sRoleToOverride != role)
 				continue;
-
-			foreach (CRF_Clothing clothing : customGear.m_CustomClothing)
-			{
+				
+			foreach(CRF_Clothing clothing : customGear.m_CustomClothing)
 				UpdateClothingSlot(clothing.m_ClothingPrefabs, clothing.m_sClothingType, role, spawnParams, inventory, inventoryManager);
-			}
-
-			foreach (CRF_Inventory_Item item : customGear.m_AdditionalInventoryItems)
-			{
+					
+			foreach(CRF_Inventory_Item item : customGear.m_AdditionalInventoryItems)
 				AddInventoryItem(item.m_sItemPrefab, item.m_iItemCount, spawnParams, inventory, inventoryManager, role);
-			}
 		}
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	int ConvertClothingStringToInt(string clothingStr)
 	{
 		int slotInt = -1;
-
+		
 		// All the arrays belong to us
-		switch (clothingStr)
+		switch(clothingStr)
 		{
-			case "HEADGEAR" : {slotInt = HEADGEAR; break; }
-			case "SHIRT" : {slotInt = SHIRT; break; }
-			case "ARMOREDVEST" : {slotInt = ARMOREDVEST; break; }
-			case "PANTS" : {slotInt = PANTS; break; }
-			case "BOOTS" : {slotInt = BOOTS; break; }
-			case "BACKPACK" : {slotInt = BACKPACK; break; }
-			case "VEST" : {slotInt = VEST; break; }
-			case "HANDWEAR" : {slotInt = HANDWEAR; break; }
-			case "HEAD" : {slotInt = HEAD; break; }
-			case "EYES" : {slotInt = EYES; break; }
-			case "EARS" : {slotInt = EARS; break; }
-			case "FACE" : {slotInt = FACE; break; }
-			case "NECK" : {slotInt = NECK; break; }
-			case "EXTRA1" : {slotInt = EXTRA1; break; }
-			case "EXTRA2" : {slotInt = EXTRA2; break; }
-			case "WAIST" : {slotInt = WAIST; break; }
-			case "EXTRA3" : {slotInt = EXTRA3; break; }
-			case "EXTRA4" : {slotInt = EXTRA4; break; }
+			case "HEADGEAR"     : {slotInt = HEADGEAR;    break;}
+			case "SHIRT"        : {slotInt = SHIRT;       break;}
+			case "ARMOREDVEST"  : {slotInt = ARMOREDVEST; break;}
+			case "PANTS"        : {slotInt = PANTS;       break;}
+			case "BOOTS"        : {slotInt = BOOTS;       break;}
+			case "BACKPACK"     : {slotInt = BACKPACK;    break;}
+			case "VEST"         : {slotInt = VEST;        break;}
+			case "HANDWEAR"     : {slotInt = HANDWEAR;    break;}
+			case "HEAD"         : {slotInt = HEAD;        break;}
+			case "EYES"         : {slotInt = EYES;        break;}
+			case "EARS"         : {slotInt = EARS;        break;}
+			case "FACE"         : {slotInt = FACE;        break;}
+			case "NECK"         : {slotInt = NECK;        break;}
+			case "EXTRA1"       : {slotInt = EXTRA1;      break;}
+			case "EXTRA2"       : {slotInt = EXTRA2;      break;}
+			case "WAIST"        : {slotInt = WAIST;       break;}
+			case "EXTRA3"       : {slotInt = EXTRA3;      break;}
+			case "EXTRA4"       : {slotInt = EXTRA4;      break;}
 		};
-
+		
 		return slotInt;
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	protected CRF_Weapon_Class SelectRandomWeapon(array<ref CRF_Weapon_Class> weaponArray)
 	{
-		if (!weaponArray || weaponArray.IsEmpty())
-			return null;
-
-		CRF_Weapon_Class weaponToSpawnContainer = weaponArray.GetRandomElement();
-
-		if (!weaponToSpawnContainer)
-			return null;
-
+		if(!weaponArray || weaponArray.IsEmpty())
+			return null; 
+								
+		ref CRF_Weapon_Class weaponToSpawnContainer = weaponArray.GetRandomElement();
+								
+		if(!weaponToSpawnContainer)
+			return null; 
+								
 		return weaponToSpawnContainer;
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	TIntArray FilterItemToClothing(IEntity item, string role = "", bool isAssistant = false, bool isThrowable = false)
 	{
-		array<int> clothingIDs = {};
-
+		ref array<int> clothingIDs = {};
+		
 		// Any magazine
-		if (MagazineComponent.Cast(item.FindComponent(MagazineComponent)) || InventoryMagazineComponent.Cast(item.FindComponent(InventoryMagazineComponent)))
+		if(MagazineComponent.Cast(item.FindComponent(MagazineComponent)) || InventoryMagazineComponent.Cast(item.FindComponent(InventoryMagazineComponent)))
 			clothingIDs = {VEST, ARMOREDVEST, BACKPACK, PANTS, SHIRT};
 		else // Any Non-magazine
 			clothingIDs = {SHIRT, PANTS, VEST, ARMOREDVEST, BACKPACK};
-
+			
 		// Any medical item
-		if ((role == "_Medic_P" || role == "_MO_P") && SCR_ConsumableItemComponent.Cast(item.FindComponent(SCR_ConsumableItemComponent)))
+		if((role == "_Medic_P" || role == "_MO_P") && SCR_ConsumableItemComponent.Cast(item.FindComponent(SCR_ConsumableItemComponent)))
 			clothingIDs = {BACKPACK, VEST, ARMOREDVEST};
-
+		
 		// Any pistol ammo
-		if ((InventoryMagazineComponent.Cast(item.FindComponent(InventoryMagazineComponent)) && InventoryMagazineComponent.Cast(item.FindComponent(InventoryMagazineComponent)).GetAttributes().GetCommonType() == ECommonItemType.RHS_PISTOL_AMMO) || isThrowable)
+		if((InventoryMagazineComponent.Cast(item.FindComponent(InventoryMagazineComponent)) && InventoryMagazineComponent.Cast(item.FindComponent(InventoryMagazineComponent)).GetAttributes().GetCommonType() == ECommonItemType.RHS_PISTOL_AMMO) || isThrowable)
 			clothingIDs = {PANTS, VEST, ARMOREDVEST, BACKPACK};
-
+		
 		// Any radio
-		if (BaseRadioComponent.Cast(item.FindComponent(BaseRadioComponent)))
+		if(BaseRadioComponent.Cast(item.FindComponent(BaseRadioComponent)))
 			clothingIDs = {PANTS, SHIRT, VEST, ARMOREDVEST, BACKPACK};
-
+		
 		// Any Assistant Mags
-		if (isAssistant && MagazineComponent.Cast(item.FindComponent(MagazineComponent)))
+		if(isAssistant && MagazineComponent.Cast(item.FindComponent(MagazineComponent)))
 			clothingIDs = {BACKPACK, VEST, ARMOREDVEST};
-
+		
 		// Check if item is explosives related
 		SCR_DetonatorGadgetComponent detonator = SCR_DetonatorGadgetComponent.Cast(item.FindComponent(SCR_DetonatorGadgetComponent));
 		SCR_ExplosiveChargeComponent explosives = SCR_ExplosiveChargeComponent.Cast(item.FindComponent(SCR_ExplosiveChargeComponent));
 		SCR_MineWeaponComponent mine = SCR_MineWeaponComponent.Cast(item.FindComponent(SCR_MineWeaponComponent));
 		SCR_RepairSupportStationComponent engTool = SCR_RepairSupportStationComponent.Cast(item.FindComponent(SCR_RepairSupportStationComponent));
 		SCR_HealSupportStationComponent medTool = SCR_HealSupportStationComponent.Cast(item.FindComponent(SCR_HealSupportStationComponent));
-		if (detonator || explosives || mine || engTool || medTool)
+		if(detonator || explosives || mine || engTool || medTool)
 			clothingIDs = {BACKPACK, VEST, ARMOREDVEST};
-
+		
 		return clothingIDs;
-	}
-
-	//------------------------------------------------------------------------------------------------
-	//------------------------------------------------------------------------------------------------
-	//------------------------------------------------------------------------------------------------
+	}	
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// Admin Menu Functions/Variables
-	//------------------------------------------------------------------------------------------------
-	//------------------------------------------------------------------------------------------------
-	//------------------------------------------------------------------------------------------------
-
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	
 	private Widget m_wSavedHintWidget;
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// Admin Messaging
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void AddMsgAction()
 	{
 		SCR_ChatPanelManager chatPanelManager = SCR_ChatPanelManager.GetInstance();
@@ -991,35 +973,35 @@ class CRF_GamemodeComponent : SCR_BaseGameModeComponent
 		ChatCommandInvoker invoker4 = chatPanelManager.GetCommandInvoker("reply");
 		invoker4.Insert(ReplyAdminMessage_Callback);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SendAdminMessage_Callback(SCR_ChatPanel panel, string data)
 	{
 		CRF_ClientComponent.GetInstance().SendAdminMessage(data);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void ReplyAdminMessage_Callback(SCR_ChatPanel panel, string data)
 	{
-		if (!SCR_Global.IsAdmin())
+		if(!SCR_Global.IsAdmin())
 			return;
-
+		
 		CRF_ClientComponent.GetInstance().ReplyAdminMessage(data, true);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SendAdminMessage(string data)
 	{
 		Rpc(RpcAsk_SendAdminMessage, data);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Broadcast)]
 	void RpcAsk_SendAdminMessage(string data)
 	{
-		if (!SCR_Global.IsAdmin())
+		if(!SCR_Global.IsAdmin())
 			return;
-
+		
 		PlayerController pc = GetGame().GetPlayerController();
 		if (!pc)
 			return;
@@ -1028,260 +1010,260 @@ class CRF_GamemodeComponent : SCR_BaseGameModeComponent
 			return;
 		chatComponent.ShowMessage(data);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void ReplyAdminMessage(string data, int playerID, bool logAction)
 	{
 		Rpc(RpcAsk_ReplyAdminMessage, data, playerID, logAction);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Broadcast)]
 	void RpcAsk_ReplyAdminMessage(string data, int playerID, bool logAction)
 	{
 		if (logAction)
 			LogAdminAction(string.Format("Reply to %1: %2", GetGame().GetPlayerManager().GetPlayerName(playerID), data), playerID, false);
 
-		if (GetGame().GetPlayerController().GetPlayerId() != playerID)
+		if(GetGame().GetPlayerController().GetPlayerId() != playerID)
 			return;
-
+		
 		PlayerController pc = GetGame().GetPlayerController();
 		if (!pc)
 			return;
 		SCR_ChatComponent chatComponent = SCR_ChatComponent.Cast(pc.FindComponent(SCR_ChatComponent));
 		if (!chatComponent)
 			return;
-
+		
 		chatComponent.ShowMessage(string.Format("Admin: %1", data));
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// Respawn
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SpawnOnGroupServer(int playerId, vector spawnLocation, int groupID, bool logAction)
 	{
-		if (RplSession.Mode() == RplMode.Client)
+		if(RplSession.Mode() == RplMode.Client)
 			return;
-
+		
 		CRF_Gamemode.GetInstance().RespawnPlayer(playerId, spawnLocation, groupID);
-
+		
 		if (logAction)
 			LogAdminAction(string.Format("%1 was respawned to %2", GetGame().GetPlayerManager().GetPlayerName(playerId), SCR_GroupsManagerComponent.GetInstance().FindGroup(groupID).m_faction), playerId, true);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SendGroupIDToPlayer(int requestedId, int requesterID)
 	{
 		CRF_Gamemode gm = CRF_Gamemode.GetInstance();
-
-		if (gm.m_aSlots.Find(requestedId) == -1)
+		
+		if(gm.m_aSlots.Find(requestedId) == -1)
 			return;
-
+		
 		RplId groupID = gm.m_aActivePlayerGroupsIDs.Get(gm.m_aGroupRplIDs.Find(gm.m_aPlayerGroupIDs.Get(gm.m_aSlots.Find(requestedId))));
 		SCR_AIGroup playerGroup = SCR_AIGroup.Cast(RplComponent.Cast(Replication.FindItem(groupID)).GetEntity());
-		if (playerGroup)
+		if(playerGroup)
 		{
 			Rpc(RpcDo_SendGroupIDToPlayer, requesterID, playerGroup.GetGroupID());
 			RpcDo_SendGroupIDToPlayer(requesterID, playerGroup.GetGroupID());
 		};
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Broadcast)]
 	void RpcDo_SendGroupIDToPlayer(int requesterID, int groupId)
 	{
-		if (SCR_PlayerController.GetLocalPlayerId() != requesterID || groupId == -1)
+		if(SCR_PlayerController.GetLocalPlayerId() != requesterID || groupId == -1)
 			return;
-
+		
 		MenuBase topMenu = GetGame().GetMenuManager().GetTopMenu();
 		CRF_AdminMenu adminMenu = CRF_AdminMenu.Cast(topMenu);
-
-		if (adminMenu)
+		
+		if(adminMenu)
 			adminMenu.UpdateSpawnGroup(groupId);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// Gear
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SetPlayerGear(int playerID, ResourceName prefab, bool logAction)
-	{
+	{	
 		IEntity entity = GetGame().GetPlayerManager().GetPlayerControlledEntity(playerID);
-
+		
 		GetGame().GetCallqueue().CallLater(SetupAddGearToEntity, m_RNG.RandInt(250, 1000), false, entity, prefab);
 		SetPlayerGearScriptsMapValue(prefab, playerID, "GSR"); // GSR = Gear Script Resource
-
+		
 		if (logAction)
 			LogAdminAction(string.Format("%1's gear was set to %2", GetGame().GetPlayerManager().GetPlayerName(playerID), prefab.Substring(prefab.LastIndexOf("/") + 1, prefab.LastIndexOf(".") - prefab.LastIndexOf("/") - 1)), playerID, true);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void AddItem(int playerID, string prefab, bool logAction)
 	{
-		if (playerID == 0 || prefab.IsEmpty())
+		if(playerID == 0 || prefab.IsEmpty())
 			return;
-
+		
 		IEntity entity = GetGame().GetPlayerManager().GetPlayerControlledEntity(playerID);
 		SCR_InventoryStorageManagerComponent entityInventoryManager = SCR_InventoryStorageManagerComponent.Cast(entity.FindComponent(SCR_InventoryStorageManagerComponent));
 		EntitySpawnParams spawnParams = new EntitySpawnParams();
 		spawnParams.TransformMode = ETransformMode.WORLD;
-		spawnParams.Transform[3] = entity.GetOrigin();
-		IEntity resourceSpawned = GetGame().SpawnEntityPrefab(Resource.Load(prefab), GetGame().GetWorld(), spawnParams);
-		if (!entityInventoryManager.TryInsertItem(resourceSpawned))
+        spawnParams.Transform[3] = entity.GetOrigin();
+		ref IEntity resourceSpawned = GetGame().SpawnEntityPrefab(Resource.Load(prefab), GetGame().GetWorld(), spawnParams);
+		if(!entityInventoryManager.TryInsertItem(resourceSpawned))
 			delete resourceSpawned;
-
+		
 		if (logAction)
 			LogAdminAction(string.Format("%2 was added to %1's inventory", GetGame().GetPlayerManager().GetPlayerName(playerID), prefab.Substring(prefab.LastIndexOf("/") + 1, prefab.LastIndexOf(".") - prefab.LastIndexOf("/") - 1)), playerID, true);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// Teleport
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void TeleportPlayers(int playerID1, int playerID2, bool logAction)
 	{
 		Rpc(Rpc_TeleportPlayers, playerID1, playerID2, logAction);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Broadcast)]
 	void Rpc_TeleportPlayers(int playerID1, int playerID2, bool logAction)
 	{
-		if (SCR_PlayerController.GetLocalPlayerId() != playerID1)
+		if(SCR_PlayerController.GetLocalPlayerId() != playerID1)
 			return;
-
+		
 		IEntity entity2 = GetGame().GetPlayerManager().GetPlayerControlledEntity(playerID2);
 		EntitySpawnParams spawnParams = new EntitySpawnParams();
-		spawnParams.TransformMode = ETransformMode.WORLD;
+	    spawnParams.TransformMode = ETransformMode.WORLD;
 		vector teleportLocation = vector.Zero;
 		SCR_WorldTools.FindEmptyTerrainPosition(teleportLocation, entity2.GetOrigin(), 10);
-		spawnParams.Transform[3] = teleportLocation;
-
+	    spawnParams.Transform[3] = teleportLocation;
+	
 		SCR_Global.TeleportPlayer(playerID1, teleportLocation);
-
+		
 		if (logAction)
 			LogAdminAction(string.Format("%1 was teleported to %2", GetGame().GetPlayerManager().GetPlayerName(playerID1), GetGame().GetPlayerManager().GetPlayerName(playerID2)), playerID1, true);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// Hints
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SendHintAll(string data)
 	{
 		Rpc(Rpc_SendHintAll, data);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Broadcast)]
 	void Rpc_SendHintAll(string data)
 	{
 		SendAdminHint(data);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SendHintPlayer(string data, int playerID)
 	{
 		Rpc(Rpc_SendHintPlayer, data, playerID);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Broadcast)]
 	void Rpc_SendHintPlayer(string data, int playerID)
 	{
-		if (playerID == 0 || SCR_PlayerController.GetLocalPlayerId() != playerID)
+		if(playerID == 0 || SCR_PlayerController.GetLocalPlayerId() != playerID)
 			return;
-
+		
 		SendAdminHint(data);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SendHintFaction(string data, string factionKey)
 	{
 		Rpc(Rpc_SendHintFaction, data, factionKey);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Broadcast)]
 	void Rpc_SendHintFaction(string data, string factionKey)
 	{
-		if (factionKey.IsEmpty() && !SCR_FactionManager.SGetLocalPlayerFaction() && (SCR_Faction.Cast(SCR_FactionManager.SGetLocalPlayerFaction()).GetFactionKey() != factionKey))
+		if(factionKey.IsEmpty() && !SCR_FactionManager.SGetLocalPlayerFaction() && (SCR_Faction.Cast(SCR_FactionManager.SGetLocalPlayerFaction()).GetFactionKey() != factionKey))
 			return;
-
+		
 		SendAdminHint(data);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SendAdminHint(string data)
 	{
 		Widget widget;
 		widget = GetGame().GetWorkspace().CreateWidgets("{43FC66BA3D85E9C7}UI/layouts/Hint/hint.layout");
-
+		
 		if (!widget)
 			return;
-
-		if (m_wSavedHintWidget)
+		
+		if(m_wSavedHintWidget)
 			delete m_wSavedHintWidget;
-
+		
 		m_wSavedHintWidget = widget;
-
+		
 		CRF_Hint hint = CRF_Hint.Cast(widget.FindHandler(CRF_Hint));
 		hint.ShowHint(data, 8000);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// Heal
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void HealPlayer(int playerID, bool logAction)
 	{
 		IEntity PlayerEntity = GetGame().GetPlayerManager().GetPlayerControlledEntity(playerID);
-
+			
 		SCR_DamageManagerComponent damageComponent = SCR_DamageManagerComponent.Cast(PlayerEntity.FindComponent(SCR_DamageManagerComponent));
 		if (!damageComponent)
 			return;
-
+		
 		damageComponent.FullHeal();
 		damageComponent.SetHealthScaled(1);
-
+		
 		if (logAction)
 			LogAdminAction(string.Format("%1's was healed", GetGame().GetPlayerManager().GetPlayerName(playerID)), playerID, true);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void HealPlayerVehicle(int playerID, bool logAction)
 	{
 		IEntity PlayerEntity = GetGame().GetPlayerManager().GetPlayerControlledEntity(playerID);
-
+		
 		IEntity VehicleEntity = SCR_CompartmentAccessComponent.GetVehicleIn(PlayerEntity);
 		if (!VehicleEntity)
 			return;
-
+			
 		SCR_DamageManagerComponent damageComponent = SCR_DamageManagerComponent.Cast(VehicleEntity.FindComponent(SCR_DamageManagerComponent));
 		if (!damageComponent)
 			return;
-
+		
 		damageComponent.FullHeal();
 		damageComponent.SetHealthScaled(1);
-
+		
 		if (logAction)
 			LogAdminAction(string.Format("%1's vehicle was repaired", GetGame().GetPlayerManager().GetPlayerName(playerID)), playerID, true);
 	}
 
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// Log Admin Actions
 	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------	void SendAdminMessage(string data)
 	void LogAdminAction(string data, int playerID, bool sendToPlayer)
 	{
 		Rpc(RpcAsk_LogAdminAction, data, playerID, sendToPlayer);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Broadcast)]
 	void RpcAsk_LogAdminAction(string data, int playerID, bool sendToPlayer)
 	{
 		if (sendToPlayer)
 		{
-			if (GetGame().GetPlayerController().GetPlayerId() != playerID && !SCR_Global.IsAdmin())
+			if(GetGame().GetPlayerController().GetPlayerId() != playerID && !SCR_Global.IsAdmin())
 				return;
 		} else {
-			if (!SCR_Global.IsAdmin())
+			if(!SCR_Global.IsAdmin())
 				return;
 		}
 
@@ -1293,222 +1275,209 @@ class CRF_GamemodeComponent : SCR_BaseGameModeComponent
 			return;
 		chatComponent.ShowMessage(data);
 	}
-
-	//------------------------------------------------------------------------------------------------
-	//------------------------------------------------------------------------------------------------
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// Safestart Functions/Variables
-	//------------------------------------------------------------------------------------------------
-	//------------------------------------------------------------------------------------------------
-	//------------------------------------------------------------------------------------------------
-
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	
 	[RplProp(onRplName: "OnSafeStartChange")]
-	protected bool m_bSafeStartEnabled = false;
+	protected bool m_SafeStartEnabled = false;
 	ref ScriptInvoker m_OnSafeStartChange = new ScriptInvoker();
-
+	
 	[RplProp()]
 	protected string m_sServerWorldTime;
-
+	
 	[RplProp()]
 	protected ref array<string> m_aFactionsStatusArray;
-	protected ref array<SCR_Faction> m_aPlayedFactionsArray = {};
-
+	protected ref array<SCR_Faction> m_aPlayedFactionsArray = new array<SCR_Faction> ;
+	
 	[RplProp(onRplName: "ShowMessage")]
 	protected string m_sMessageContent;
 	protected string m_sStoredMessageContent;
-
+	
 	[RplProp()]
 	protected bool m_bKillRedundantUnitsBool;
-
+	
 	protected int m_iTimeSafeStartBegan;
 	protected int m_iTimeMissionEnds;
 	protected int m_iSafeStartTimeRemaining;
-
+	
 	protected bool m_bBluforReady = false;
 	protected bool m_bOpforReady = false;
 	protected bool m_bIndforReady = false;
 	protected bool m_bCivReady = false;
-
+	
 	protected bool m_bAdminForcedReady = false;
-
+	
 	protected int m_iPlayedFactionsCount;
-	protected ref map<IEntity, bool> m_mPlayersWithEHsMap = new map<IEntity, bool>();
-
+	protected ref map<IEntity,bool> m_mPlayersWithEHsMap = new map<IEntity,bool>;
+	
+	protected int m_mPlayablesCount = 0;
+	
 	protected SCR_PopUpNotification m_PopUpNotification = null;
 
 	bool m_bHUDVisible = true;
 	CRF_LoggingServerComponent m_Logging;
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// Ready Up functions
-	//------------------------------------------------------------------------------------------------
-
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void UpdateHUDVisible()
-	{
+	{	
 		m_bHUDVisible = !m_bHUDVisible;
 	};
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	TStringArray GetWhosReady() {
 		return m_aFactionsStatusArray;
 	}
-
-	//------------------------------------------------------------------------------------------------
-	protected void UpdatePlayedFactions()
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	protected void UpdatePlayedFactions() 
 	{
 		SCR_FactionManager factionManager = SCR_FactionManager.Cast(GetGame().GetFactionManager());
-
-		SCR_SortedArray<SCR_Faction> outFaction = new SCR_SortedArray<SCR_Faction>();
+		
+		SCR_SortedArray<SCR_Faction> outFaction = new SCR_SortedArray<SCR_Faction>;
 		factionManager.GetSortedFactionsList(outFaction);
-
-		if (!outFaction || outFaction.IsEmpty())
-			return;
-
-		array<SCR_Faction> outArray = {};
+		
+		if (!outFaction || outFaction.IsEmpty()) return;
+		
+		array<SCR_Faction> outArray = new array<SCR_Faction>;
 		outFaction.ToArray(outArray);
-
+		
 		m_aPlayedFactionsArray.Clear();
 		string bluforString = "#Coal_SS_No_Faction";
-		string opforString = "#Coal_SS_No_Faction";
+		string opforString = "#Coal_SS_No_Faction"; 
 		string indforString = "#Coal_SS_No_Faction";
 		string civString = "#Coal_SS_No_Faction";
 
-		foreach (SCR_Faction faction : outArray)
-		{
-			if (faction.GetPlayerCount() == 0 || (faction.GetFactionKey() != "BLUFOR" && faction.GetFactionKey() != "OPFOR" && faction.GetFactionKey() != "INDFOR" && faction.GetFactionKey() != "CIV"))
+		foreach(SCR_Faction faction : outArray) {
+			if (faction.GetPlayerCount() == 0 || (faction.GetFactionKey() != "BLUFOR" && faction.GetFactionKey() != "OPFOR" && faction.GetFactionKey() != "INDFOR" && faction.GetFactionKey() != "CIV")) 
 				continue;
-
+			
 			m_aPlayedFactionsArray.Insert(faction);
-
+			
 			switch (true) {
-				case(!m_bBluforReady && faction.GetFactionKey() == "BLUFOR") : {bluforString = "#Coal_SS_Faction_Not_Ready"; break; };
-				case(m_bBluforReady && faction.GetFactionKey() == "BLUFOR") : {bluforString = "#Coal_SS_Faction_Ready"; break; };
-				case(!m_bOpforReady && faction.GetFactionKey() == "OPFOR") : {opforString = "#Coal_SS_Faction_Not_Ready"; break; };
-				case(m_bOpforReady && faction.GetFactionKey() == "OPFOR") : {opforString = "#Coal_SS_Faction_Ready"; break; };
-				case(!m_bIndforReady && faction.GetFactionKey() == "INDFOR") : {indforString = "#Coal_SS_Faction_Not_Ready"; break; };
-				case(m_bIndforReady && faction.GetFactionKey() == "INDFOR") : {indforString = "#Coal_SS_Faction_Ready"; break; };
-				case(!m_bCivReady && faction.GetFactionKey() == "CIV") : {civString = "#Coal_SS_Faction_Not_Ready"; 			break; };
-				case(m_bCivReady && faction.GetFactionKey() == "CIV") : {civString = "#Coal_SS_Faction_Ready"; 			break; };
+				case(!m_bBluforReady && faction.GetFactionKey() == "BLUFOR") : {bluforString = "#Coal_SS_Faction_Not_Ready"; break;};
+				case(m_bBluforReady && faction.GetFactionKey() == "BLUFOR")  : {bluforString = "#Coal_SS_Faction_Ready";     break;};
+				case(!m_bOpforReady && faction.GetFactionKey() == "OPFOR")  : {opforString = "#Coal_SS_Faction_Not_Ready";  break;};
+				case(m_bOpforReady && faction.GetFactionKey() == "OPFOR")   : {opforString = "#Coal_SS_Faction_Ready";      break;};
+				case(!m_bIndforReady && faction.GetFactionKey() == "INDFOR") : {indforString = "#Coal_SS_Faction_Not_Ready"; break;};
+				case(m_bIndforReady && faction.GetFactionKey() == "INDFOR")  : {indforString = "#Coal_SS_Faction_Ready";     break;};
+				case(!m_bCivReady && faction.GetFactionKey() == "CIV") : {civString = "#Coal_SS_Faction_Not_Ready"; 			break;};
+				case(m_bCivReady && faction.GetFactionKey() == "CIV")  : {civString = "#Coal_SS_Faction_Ready";     			break;};
 			};
 		};
-
+		
 		m_aFactionsStatusArray = {bluforString, opforString, indforString, civString};
 		m_iPlayedFactionsCount = 0;
-
+		
 		foreach (string factionString : m_aFactionsStatusArray)
 		{
 			if (factionString == "#Coal_SS_No_Faction")
 				continue;
-
+			
 			m_iPlayedFactionsCount = m_iPlayedFactionsCount + 1;
 		}
-
+		
 		Replication.BumpMe();
 	}
-
+	
 	//Call from server
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void ToggleSideReady(FactionKey setReady, string playerName, bool adminForced) {
-		if (!GetSafestartStatus())
-			return;
-
+		if (!GetSafestartStatus()) return;
+		
 		// If it's an admin-forced action
 		if (adminForced)
 		{
-			if (m_bAdminForcedReady)
+			if(m_bAdminForcedReady) 
 			{
 				m_bBluforReady = false;
 				m_bOpforReady = false;
 				m_bIndforReady = false;
 				m_bCivReady = false;
 				m_bAdminForcedReady = false;
-
+			
 				m_sMessageContent = string.Format("An Admin (%1) Has Force Unreadied All Sides!", playerName);
 				Replication.BumpMe();
 				ShowMessage();
 				return;
 			};
-
+		
 			m_bBluforReady = true;
 			m_bOpforReady = true;
 			m_bIndforReady = true;
 			m_bCivReady = true;
 			m_bAdminForcedReady = true;
-
+			
 			m_sMessageContent = string.Format("An Admin (%1) Has Force Readied All Sides!", playerName);
 			Replication.BumpMe();
 			ShowMessage();
 			return;
 		}
-
-		if (m_bAdminForcedReady)
+		
+		if(m_bAdminForcedReady) 
 			return;
-
+			
 		switch (setReady)
 		{
 			case("BLUFOR") : {
-				m_bBluforReady = !m_bBluforReady;
-				if (m_bBluforReady)
-					m_sMessageContent = string.Format("#Coal_SS_Faction_Readied_Blufor - %1", playerName);
-				else
-					m_sMessageContent = string.Format("#Coal_SS_Faction_Unreadied_Blufor - %1", playerName);
+				m_bBluforReady = !m_bBluforReady; 
+				if (m_bBluforReady) m_sMessageContent = string.Format("#Coal_SS_Faction_Readied_Blufor - %1", playerName);
+				if (!m_bBluforReady) m_sMessageContent = string.Format("#Coal_SS_Faction_Unreadied_Blufor - %1", playerName);
 				break;
 			};
-			case("OPFOR") : {
+			case("OPFOR")  : {
 				m_bOpforReady = !m_bOpforReady;
-				if (m_bOpforReady)
-					m_sMessageContent = string.Format("#Coal_SS_Faction_Readied_Opfor - %1", playerName);
-				else
-					m_sMessageContent = string.Format("#Coal_SS_Faction_Unreadied_Opfor - %1", playerName);
+				if (m_bOpforReady) m_sMessageContent = string.Format("#Coal_SS_Faction_Readied_Opfor - %1", playerName);
+				if (!m_bOpforReady) m_sMessageContent = string.Format("#Coal_SS_Faction_Unreadied_Opfor - %1", playerName);
 				break;
 			};
 			case("INDFOR") : {
-				m_bIndforReady = !m_bIndforReady;
-				if (m_bIndforReady)
-					m_sMessageContent = string.Format("#Coal_SS_Faction_Readied_Indfor - %1", playerName);
-				else
-					m_sMessageContent = string.Format("#Coal_SS_Faction_Unreadied_Indfor - %1", playerName);
+				m_bIndforReady = !m_bIndforReady; 
+				if (m_bIndforReady) m_sMessageContent = string.Format("#Coal_SS_Faction_Readied_Indfor - %1", playerName);
+				if (!m_bIndforReady) m_sMessageContent = string.Format("#Coal_SS_Faction_Unreadied_Indfor - %1", playerName);
 				break;
 			};
 			case("CIV") : {
-				m_bCivReady = !m_bCivReady;
-				if (m_bCivReady)
-					m_sMessageContent = string.Format("#Coal_SS_Faction_Readied_Civ - %1", playerName);
-				else
-					m_sMessageContent = string.Format("#Coal_SS_Faction_Unreadied_Civ - %1", playerName);
+				m_bCivReady = !m_bCivReady; 
+				if (m_bCivReady) m_sMessageContent = string.Format("#Coal_SS_Faction_Readied_Civ - %1", playerName);
+				if (!m_bCivReady) m_sMessageContent = string.Format("#Coal_SS_Faction_Unreadied_Civ - %1", playerName);
 				break;
 			};
 		};
 		Replication.BumpMe();
 		ShowMessage();
 	}
-
+	
 	//Call from server
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	protected void CheckStartCountDown()
 	{
 		int factionsReadyCount = 0;
-		foreach (string factionCheckReadyString : m_aFactionsStatusArray)
-		{
-			if (factionCheckReadyString != "#Coal_SS_Faction_Ready")
+		foreach(string factionCheckReadyString : m_aFactionsStatusArray) {
+			if (factionCheckReadyString != "#Coal_SS_Faction_Ready") 
 				continue;
 			factionsReadyCount = factionsReadyCount + 1;
 		};
-
-		if (factionsReadyCount == 0 && m_iPlayedFactionsCount == 0 || factionsReadyCount != m_iPlayedFactionsCount && m_iSafeStartTimeRemaining == 35)
-			return;
-
-		if (factionsReadyCount != m_iPlayedFactionsCount && m_iSafeStartTimeRemaining != 35)
-		{
+		
+		if (factionsReadyCount == 0 && m_iPlayedFactionsCount == 0 || factionsReadyCount != m_iPlayedFactionsCount && m_iSafeStartTimeRemaining == 35) return;
+				
+		if (factionsReadyCount != m_iPlayedFactionsCount && m_iSafeStartTimeRemaining != 35) {
 			m_sMessageContent = "#Coal_SS_Countdown_Cancelled";
 			Replication.BumpMe();
 			m_iSafeStartTimeRemaining = 35;
 			return;
 		};
-
-		if (factionsReadyCount == m_iPlayedFactionsCount)
-		{
+		
+		if (factionsReadyCount == m_iPlayedFactionsCount) {
 			m_iSafeStartTimeRemaining = m_iSafeStartTimeRemaining - 5;
 			m_sMessageContent = string.Format("#Coal_SS_Countdown_Started %1 Seconds!", m_iSafeStartTimeRemaining);
 			if (m_iSafeStartTimeRemaining == 0) {
@@ -1519,56 +1488,53 @@ class CRF_GamemodeComponent : SCR_BaseGameModeComponent
 		Replication.BumpMe();
 		ShowMessage();
 	};
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// SafeStart functions
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	string GetServerWorldTime()
 	{
 		return m_sServerWorldTime;
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	bool GetSafestartStatus()
 	{
-		return m_bSafeStartEnabled;
+		return m_SafeStartEnabled;
 	}
-
-	//------------------------------------------------------------------------------------------------
-	void OnSafeStartChange()
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	void OnSafeStartChange() 
 	{
-		m_OnSafeStartChange.Invoke(m_bSafeStartEnabled);
+		m_OnSafeStartChange.Invoke(m_SafeStartEnabled);
 	}
-
+	
 	//Call from server
-	//------------------------------------------------------------------------------------------------
-	protected void ToggleSafeStartServer(bool status)
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+	protected void ToggleSafeStartServer(bool status) 
 	{
-		if (status)
-		{ // Turn on safestart
-			if (m_bSafeStartEnabled)
-				return;
-
+		if (status) { // Turn on safestart
+			if (m_SafeStartEnabled) return;
+			
 			m_iTimeSafeStartBegan = GetGame().GetWorld().GetWorldTime();
-			m_bSafeStartEnabled = true;
+			m_SafeStartEnabled = true;
 			m_iSafeStartTimeRemaining = 35;
-
+			
 			GetGame().GetCallqueue().Remove(UpdateMissionEndTimer);
 			GetGame().GetCallqueue().Remove(CheckPlayersAlive);
-
+			
 			GetGame().GetCallqueue().CallLater(CheckStartCountDown, 5000, true);
 			GetGame().GetCallqueue().CallLater(UpdateServerWorldTime, 1000, true);
 			GetGame().GetCallqueue().CallLater(ActivateSafeStartEHs, 5000, true);
 			GetGame().GetCallqueue().CallLater(UpdatePlayedFactions, 1000, true);
-
-			Replication.BumpMe();//Broadcast m_bSafeStartEnabled change
-
+			
+			Replication.BumpMe();//Broadcast m_SafeStartEnabled change
+			
 		} else { // Turn off safestart
-			if (!m_bSafeStartEnabled)
-				return;
-
+			if (!m_SafeStartEnabled) return;	
+			
 			UpdatePlayedFactions();
-
+			
 			DeleteEmptySlots();
 			m_bKillRedundantUnitsBool = true;
 			m_bAdminForcedReady = false;
@@ -1576,40 +1542,40 @@ class CRF_GamemodeComponent : SCR_BaseGameModeComponent
 			m_bOpforReady = false;
 			m_bIndforReady = false;
 			m_bCivReady = false;
-
+			
 			GetGame().GetCallqueue().Remove(CheckStartCountDown);
 			GetGame().GetCallqueue().Remove(UpdateServerWorldTime);
 			GetGame().GetCallqueue().Remove(ActivateSafeStartEHs);
 			GetGame().GetCallqueue().Remove(UpdatePlayedFactions);
-
+			
 			GetGame().GetCallqueue().CallLater(CheckPlayersAlive, 5000, true);
-
+			
 			if (CRF_Gamemode.GetInstance().m_iTimeLimitMinutes > 0) {
 				m_iTimeMissionEnds = GetGame().GetWorld().GetWorldTime() + (CRF_Gamemode.GetInstance().m_iTimeLimitMinutes * 60000);
 				GetGame().GetCallqueue().CallLater(UpdateMissionEndTimer, 1000, true);
 			} else {
 				m_sServerWorldTime = "N/A";
 			};
-
+			
 			Replication.BumpMe();//Broadcast change
-
+			
 			DisableSafeStartEHs();
-
-			// Send notification message
+			
+			// Send notification message 
 			if (m_Logging)
 				m_Logging.GameStarted();
-
-			// Use CallLater to delay the call for the removal of EHs so the changes so m_bSafeStartEnabled can propagate.
+			
+			// Use CallLater to delay the call for the removal of EHs so the changes so m_SafeStartEnabled can propagate.
 			GetGame().GetCallqueue().CallLater(DisableSafeStartEHs, 1500);
-
+			
 			// Even longer delay just in case there's any edge cases we didnt anticipate.
 			GetGame().GetCallqueue().CallLater(DisableSafeStartEHs, 12500);
-
+			
 			GetGame().GetCallqueue().CallLater(DelayChangeSafeStartDisabled, 250);
-
+			
 			// Update logging component since game is now live
 			CRF_MDB_LoggingServerComponent logCom = CRF_MDB_LoggingServerComponent.GetInstance();
-			if (logCom)
+			if(logCom)
 			{
 				logCom.m_iPlayerCount = GetGame().GetPlayerManager().GetPlayerCount();
 				SCR_FactionManager scrFM = SCR_FactionManager.Cast(GetGame().GetFactionManager());
@@ -1620,63 +1586,60 @@ class CRF_GamemodeComponent : SCR_BaseGameModeComponent
 			};
 		}
 	};
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void DelayChangeSafeStartDisabled() {
-		m_bSafeStartEnabled = false;
-		Replication.BumpMe();//Broadcast m_bSafeStartEnabled change
+		m_SafeStartEnabled = false;
+		Replication.BumpMe();//Broadcast m_SafeStartEnabled change
 	};
-
+	
 	//Call from server
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void UpdateServerWorldTime()
 	{
 		float currentTime = GetGame().GetWorld().GetWorldTime();
 		float millis = m_iTimeSafeStartBegan - currentTime;
-		int totalSeconds = (millis * 0.001);
-
+  		int totalSeconds = (millis / 1000);
+		
 		m_sServerWorldTime = SCR_FormatHelper.FormatTime(totalSeconds);
-
+		
 		Replication.BumpMe();
 	};
-
+	
 	//Call from server
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void UpdateMissionEndTimer()
 	{
 		float currentTime = GetGame().GetWorld().GetWorldTime();
 		float millis = m_iTimeMissionEnds - currentTime;
-		int totalSeconds = (millis * 0.001);
-
+  		int totalSeconds = (millis / 1000);
+		
 		m_sServerWorldTime = SCR_FormatHelper.FormatTime(totalSeconds);
-
+		
 		if (totalSeconds == 0) {
 			GetGame().GetCallqueue().Remove(UpdateMissionEndTimer);
 			m_sServerWorldTime = "Mission Time Expired!";
 		};
-
+		
 		Replication.BumpMe();
 	};
-
+	
 	// Why are these two methods done this way? It should just be one wtf
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void DeleteEmptySlots()
 	{
-		if (CRF_Gamemode.GetInstance().m_bDeleteJIPSlots)
-			if (m_bSafeStartEnabled)
+		if(CRF_Gamemode.GetInstance().m_bDeleteJIPSlots) 
+			if (m_SafeStartEnabled) 
 				GetGame().GetCallqueue().CallLater(DeleteEmptySlotsSlowly, 125, true);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void DeleteEmptySlotsSlowly()
 	{
 		CRF_Gamemode gamemode = CRF_Gamemode.GetInstance();
-		if (gamemode.m_bDeleteJIPSlots && !gamemode.m_bRespawnEnabled)
-		{
-			for (int i = 0; i < gamemode.m_aEntitySlots.Count(); i++)
-			{
-				if (gamemode.m_aSlots.Get(i) == 0 || gamemode.m_aSlots.Get(i) == -1)
-				{
+		if (gamemode.m_bDeleteJIPSlots && !gamemode.m_bRespawnEnabled) {
+			for (int i = 0; i < gamemode.m_aEntitySlots.Count(); i++) {
+				if (gamemode.m_aSlots.Get(i) == 0 || gamemode.m_aSlots.Get(i) == -1) {
 					//Print("Removing Entity");
 					gamemode.RemovePlayableEntity(gamemode.m_aEntitySlots.Get(i));
 					return;
@@ -1684,21 +1647,21 @@ class CRF_GamemodeComponent : SCR_BaseGameModeComponent
 			}
 			GetGame().GetCallqueue().Remove(DeleteEmptySlotsSlowly);
 		}
-
+		
 	}
-
+	
 	// Called from server to all clients
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void ShowMessage()
-	{
+	{	
 		if (m_sMessageContent == m_sStoredMessageContent)
 			return;
-
+		
 		m_PopUpNotification = SCR_PopUpNotification.GetInstance();
-
+		
 		m_sStoredMessageContent = m_sMessageContent;
-
-		if (m_sMessageContent == "All Blufor Players Have Been Eliminated!" || m_sMessageContent == "All Opfor Players Have Been Eliminated!" || m_sMessageContent == "All Indfor Players Have Been Eliminated!" || m_sMessageContent == "All Civilian Players Have Been Eliminated!")
+		
+		if (m_sMessageContent == "All Blufor Players Have Been Eliminated!" || m_sMessageContent == "All Opfor Players Have Been Eliminated!" || m_sMessageContent == "All Indfor Players Have Been Eliminated!"  || m_sMessageContent == "All Civilian Players Have Been Eliminated!") 
 		{
 			m_PopUpNotification.PopupMsg(m_sMessageContent, 20);
 			return;
@@ -1709,50 +1672,49 @@ class CRF_GamemodeComponent : SCR_BaseGameModeComponent
 		else
 			m_PopUpNotification.PopupMsg(m_sMessageContent, 2.5, "#Coal_SS_Countdown_Started_Subtext");
 	};
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void CheckPlayersAlive()
 	{
-		foreach (SCR_Faction faction : m_aPlayedFactionsArray)
-		{
+		foreach(SCR_Faction faction : m_aPlayedFactionsArray) {
 			switch (true) {
-				case(faction.GetFactionKey() == "BLUFOR" && faction.GetPlayerCount() == 0 && m_aFactionsStatusArray[0] != "#Coal_SS_No_Faction") : { m_sMessageContent = "All Blufor Players Have Been Eliminated!"; break; };
-				case(faction.GetFactionKey() == "OPFOR" && faction.GetPlayerCount() == 0 && m_aFactionsStatusArray[1] != "#Coal_SS_No_Faction") : { m_sMessageContent = "All Opfor Players Have Been Eliminated!"; break; };
-				case(faction.GetFactionKey() == "INDFOR" && faction.GetPlayerCount() == 0 && m_aFactionsStatusArray[2] != "#Coal_SS_No_Faction") : { m_sMessageContent = "All Indfor Players Have Been Eliminated!"; break; };
-				case(faction.GetFactionKey() == "CIV" && faction.GetPlayerCount() == 0 && m_aFactionsStatusArray[3] != "#Coal_SS_No_Faction") : { m_sMessageContent = "All Civilian Players Have Been Eliminated!"; break; };
+				case(faction.GetFactionKey() == "BLUFOR" && faction.GetPlayerCount() == 0 && m_aFactionsStatusArray[0] != "#Coal_SS_No_Faction") : { m_sMessageContent = "All Blufor Players Have Been Eliminated!"; break;};
+				case(faction.GetFactionKey() == "OPFOR" && faction.GetPlayerCount() == 0 && m_aFactionsStatusArray[1] != "#Coal_SS_No_Faction") : { m_sMessageContent = "All Opfor Players Have Been Eliminated!";  break;};
+				case(faction.GetFactionKey() == "INDFOR" && faction.GetPlayerCount() == 0 && m_aFactionsStatusArray[2] != "#Coal_SS_No_Faction") : { m_sMessageContent = "All Indfor Players Have Been Eliminated!";  break;};
+				case(faction.GetFactionKey() == "CIV" && faction.GetPlayerCount() == 0 && m_aFactionsStatusArray[3] != "#Coal_SS_No_Faction") : { m_sMessageContent = "All Civilian Players Have Been Eliminated!";  break;};
 			};
 		};
-
+		
 		Replication.BumpMe();
 		ShowMessage();
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// SafeStart EHs
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	protected void ActivateSafeStartEHs()
-	{
+	{	
 		array<int> outPlayers = {};
 		GetGame().GetPlayerManager().GetPlayers(outPlayers);
-
+		
 		foreach (int playerID : outPlayers)
 		{
 			IEntity controlledEntity = GetGame().GetPlayerManager().GetPlayerControlledEntity(playerID);
-			if (!controlledEntity)
+			if (!controlledEntity) 
 				continue;
-
+			
 			SCR_CharacterDamageManagerComponent.Cast(controlledEntity.FindComponent(SCR_CharacterDamageManagerComponent)).EnableDamageHandling(false);
-
+			
 			EventHandlerManagerComponent eventHandler = EventHandlerManagerComponent.Cast(controlledEntity.FindComponent(EventHandlerManagerComponent));
-			if (!eventHandler)
+			if (!eventHandler) 
 				continue;
-
+		
 			CharacterControllerComponent charComp = CharacterControllerComponent.Cast(controlledEntity.FindComponent(CharacterControllerComponent));
-			if (!charComp)
+			if (!charComp) 
 				continue;
-
+			
 			bool alreadyHasEventHandlers = m_mPlayersWithEHsMap.Get(controlledEntity);
-
+		
 			if (!alreadyHasEventHandlers) {
 				charComp.SetSafety(true, true);
 				eventHandler.RegisterScriptHandler("OnProjectileShot", this, OnWeaponFired);
@@ -1761,49 +1723,49 @@ class CRF_GamemodeComponent : SCR_BaseGameModeComponent
 			};
 		};
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	protected void DisableSafeStartEHs()
-	{
+	{	
 		for (int i = 0; i < m_mPlayersWithEHsMap.Count(); i++)
 		{
 			IEntity controlledEntity = m_mPlayersWithEHsMap.GetKey(i);
-
-			if (!controlledEntity)
+			
+			if(!controlledEntity)
 				continue;
-
+			
 			SCR_CharacterDamageManagerComponent.Cast(controlledEntity.FindComponent(SCR_CharacterDamageManagerComponent)).EnableDamageHandling(true);
-
+			
 			CharacterControllerComponent charComp = CharacterControllerComponent.Cast(controlledEntity.FindComponent(CharacterControllerComponent));
-			if (!charComp)
+			if (!charComp) 
 				continue;
-
+			
 			charComp.SetSafety(false, false);
-
+			
 			EventHandlerManagerComponent eventHandler = EventHandlerManagerComponent.Cast(controlledEntity.FindComponent(EventHandlerManagerComponent));
-			if (!eventHandler)
+			if (!eventHandler) 
 				continue;
-
+			
 			eventHandler.RemoveScriptHandler("OnProjectileShot", this, OnWeaponFired);
 			eventHandler.RemoveScriptHandler("OnGrenadeThrown", this, OnGrenadeThrown);
-
+			
 			m_mPlayersWithEHsMap.Set(controlledEntity, false);
 		};
 	};
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	protected void OnWeaponFired(int playerID, BaseWeaponComponent weapon, IEntity entity)
-	{
+	{		
 		// Get projectile and delete it
 		delete entity;
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	protected void OnGrenadeThrown(int playerID, BaseWeaponComponent weapon, IEntity entity)
 	{
 		if (!weapon)
 			return;
-
+		
 		// Get grenade and delete it
 		delete entity;
 	}

--- a/scripts/Game/Systems/CRF_PlayableCharacter.c
+++ b/scripts/Game/Systems/CRF_PlayableCharacter.c
@@ -1,4 +1,4 @@
-class CRF_PlayableCharacterClass : ScriptComponentClass
+class CRF_PlayableCharacterClass: ScriptComponentClass
 {
 }
 
@@ -12,53 +12,54 @@ class CRF_PlayableCharacter : ScriptComponent
 	protected bool m_bIsLeaderOrMedic;
 	[Attribute()]
 	protected bool m_bIsSpecialty;
-
+	
 	protected bool m_bIsSpectator = false;
 	protected bool m_bIsHidden = false;
 	protected SCR_PlayerController m_PlayerController;
 	protected bool m_bInitTime = false;
-
-	//------------------------------------------------------------------------------------------------
+	protected float m_bTimeSliceLimit = 0;
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	bool IsPlayable()
 	{
 		return m_bIsPlayable;
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	string GetName()
 	{
 		return m_sName;
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	bool IsLeader()
 	{
 		return m_bIsLeaderOrMedic;
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	bool IsSpecialty()
 	{
 		return m_bIsSpecialty;
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SetInitTime()
 	{
 		m_bInitTime = true;
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	override void OnPostInit(IEntity owner)
 	{
 		super.OnPostInit(owner);
-
+		
 		if (!GetGame().InPlayMode())
 			return;
-
+		
 		if (CRF_Gamemode.GetInstance().m_GamemodeState == CRF_GamemodeState.GAME && CRF_Gamemode.GetInstance().EnableAIInGameState && owner.GetPrefabData().GetPrefabName() != "{59886ECB7BBAF5BC}Prefabs/Characters/CRF_InitialEntity.et")
 			m_bIsPlayable = false;
-
+		
 		GetGame().GetCallqueue().CallLater(SetInitTime, 5000, false);
 
 		if (m_bIsPlayable)
@@ -66,27 +67,27 @@ class CRF_PlayableCharacter : ScriptComponent
 			GetGame().GetCallqueue().CallLater(SetInitialEntity, 500, false, owner);
 			GetGame().GetCallqueue().CallLater(DisableAI, 0, false, owner);
 		}
-
+		
 		m_PlayerController = SCR_PlayerController.Cast(GetGame().GetPlayerController());
-
+		
 		if (owner.GetPrefabData().GetPrefabName() == "{59886ECB7BBAF5BC}Prefabs/Characters/CRF_InitialEntity.et")
 		{
-			m_bIsSpectator = true;
+			m_bIsSpectator = true;	
 			SetEventMask(owner, EntityEvent.FIXEDFRAME);
 		};
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	override void EOnFixedFrame(IEntity owner, float timeSlice)
 	{
 		super.EOnFixedFrame(owner, timeslice);
-
+		
 		if (!owner || !GetGame().InPlayMode() || !m_bIsPlayable)
 		{
 			ClearEventMask(owner, EntityEvent.FIXEDFRAME);
 			return;
 		};
-
+				
 		#ifdef WORKBENCH
 		if (!EntityUtils.IsPlayer(owner) && SCR_PossessingManagerComponent.GetInstance().GetIdFromMainEntity(owner) == 0 && m_bInitTime)
 		{
@@ -105,7 +106,7 @@ class CRF_PlayableCharacter : ScriptComponent
 
 		if (m_PlayerController.GetLocalControlledEntity() == owner)
 		{
-			if (m_PlayerController.m_eCamera && CRF_Gamemode.GetInstance().m_GamemodeState == CRF_GamemodeState.GAME)
+			if (m_PlayerController.m_eCamera && CRF_Gamemode.GetInstance().m_GamemodeState == CRF_GamemodeState.GAME) 
 			{
 				vector mat[4];
 				m_PlayerController.m_eCamera.GetTransform(mat);
@@ -118,12 +119,12 @@ class CRF_PlayableCharacter : ScriptComponent
 				mat[2] = vector.Forward;
 				mat[3][1] = 10000;
 				m_PlayerController.UpdateEntityPos(mat);
-
-				if (m_PlayerController.m_eCamera)
+				
+				if(m_PlayerController.m_eCamera)
 					m_PlayerController.m_eCamera.SetWorldTransform(mat);
 			};
 		};
-
+		
 		Physics physics = owner.GetPhysics();
 		if (physics)
 		{
@@ -133,24 +134,24 @@ class CRF_PlayableCharacter : ScriptComponent
 			physics.SetMass(0);
 			physics.SetDamping(1, 1);
 		};
-	}
-
-	//------------------------------------------------------------------------------------------------
+	} 
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void DisableAI(IEntity owner)
 	{
 		if (AIControlComponent.Cast(owner.FindComponent(AIControlComponent)).GetAIAgent())
 			AIControlComponent.Cast(owner.FindComponent(AIControlComponent)).GetAIAgent().DeactivateAI();
 		GetGame().GetCallqueue().CallLater(DisableAIWrap, 0, false, owner)
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void DisableAIWrap(IEntity owner)
 	{
 		if (AIControlComponent.Cast(owner.FindComponent(AIControlComponent)).GetAIAgent())
 			AIControlComponent.Cast(owner.FindComponent(AIControlComponent)).GetAIAgent().DeactivateAI();
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SetInitialEntity(IEntity owner)
 	{
 		//Logs entity on server and disables AI
@@ -166,19 +167,19 @@ class CRF_PlayableCharacter : ScriptComponent
 				CRF_Gamemode.GetInstance().AddPlayableEntity(owner);
 		}
 		#endif
-
+		
 		//Sets location and all the physics BS on all machines
 		if (m_bIsSpectator)
 		{
-			owner.SetOrigin("0 10000 0");
+			owner.SetOrigin("0 10000 0");	
 			HideEntity(owner);
 		};
 	}
 
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void HideEntity(IEntity owner)
 	{
-		if (!m_bIsHidden)
+		if(!m_bIsHidden)
 		{
 			Physics physics = owner.GetPhysics();
 			if (physics)
@@ -187,7 +188,7 @@ class CRF_PlayableCharacter : ScriptComponent
 				physics.EnableGravity(false);
 				physics.ChangeSimulationState(SimulationState.NONE);
 				physics.SetInteractionLayer(EPhysicsLayerDefs.CharNoCollide);
-				for (int i = 0; i <= physics.GetNumGeoms(); i++)
+				for(int i = 0; i <= physics.GetNumGeoms(); i++)
 				{
 					physics.SetGeomInteractionLayer(i, EPhysicsLayerDefs.CharNoCollide);
 				}
@@ -195,12 +196,12 @@ class CRF_PlayableCharacter : ScriptComponent
 			};
 		};
 	}
-
+	
 	/*
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void UnHideEntity(IEntity owner)
 	{
-		if (m_bIsHidden)
+		if(m_bIsHidden)
 		{
 			Physics physics = owner.GetPhysics();
 			if (physics)
@@ -209,7 +210,7 @@ class CRF_PlayableCharacter : ScriptComponent
 				physics.EnableGravity(true);
 				physics.ChangeSimulationState(SimulationState.SIMULATION);
 				physics.SetInteractionLayer(EPhysicsLayerDefs.Character);
-				for (int i = 0; i <= physics.GetNumGeoms(); i++)
+				for(int i = 0; i <= physics.GetNumGeoms(); i++)
 				{
 					physics.SetGeomInteractionLayer(i, EPhysicsLayerDefs.Character);
 				}

--- a/scripts/Game/Systems/VanillaOverrides/CRF_SCR_PlayerController.c
+++ b/scripts/Game/Systems/VanillaOverrides/CRF_SCR_PlayerController.c
@@ -2,18 +2,18 @@ modded class SCR_PlayerController
 {
 	//Stores local camera entity to delete whenever you take over a player
 	IEntity m_eCamera;
-
+	
 	protected bool m_bActivated = false;
 	int m_iFPS = 0;
 	int m_iAudioSetting;
 	private vector m_vStoredCameraPos[4];
 
 	//Adds action lisener to open menu in game
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	override protected void UpdateLocalPlayerController()
 	{
 		super.UpdateLocalPlayerController();
-
+		
 		m_bIsLocalPlayerController = this == GetGame().GetPlayerController();
 		if (!m_bIsLocalPlayerController)
 			return;
@@ -25,81 +25,81 @@ modded class SCR_PlayerController
 
 		GetGame().GetInputManager().AddActionListener("CRF_OpenLobby", EActionTrigger.PRESSED, OpenSlottingMenu);
 		GetGame().GetInputManager().AddActionListener("CRF_SpecNVG", EActionTrigger.DOWN, ToggleNVGs);
-
+		
 		PlayerJoined();
 	}
-
+	
 	// Toggle Spec NVG
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void ToggleNVGs()
 	{
 		m_bActivated = !m_bActivated;
-
-		if (m_bActivated)
+		
+		if(m_bActivated)
 			SCR_ScreenEffectsManager.GetScreenEffectsDisplay().RHS_SetHDR("{0AD0A1ADEBCF893F}Assets/Items/Equipment/NVG/pvs14/data/SpecNVGFilm.emat", true);
 		else
 			SCR_ScreenEffectsManager.GetScreenEffectsDisplay().RHS_SetHDR("{765A5E642D09A4B8}Common/Postprocess/HDR_Vanila.emat", false);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	override void OnControlledEntityChanged(IEntity from, IEntity to)
 	{
 		GetGame().GetInputManager().RemoveActionListener("SpecNVG", EActionTrigger.DOWN, ToggleNVGs);
-		if (m_bActivated)
+		if(m_bActivated)
 			SCR_ScreenEffectsManager.GetScreenEffectsDisplay().RHS_SetHDR("{765A5E642D09A4B8}Common/Postprocess/HDR_Vanila.emat", false);
-
+		
 		m_bActivated = false;
-
+		
 		super.OnControlledEntityChanged(from, to);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	override void DisconnectFromGame()
 	{
 		super.DisconnectFromGame();
-
+		
 		ResetSettingsToStoredValues();
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void UpdateStoredCameraPos(vector cameraPosToStore[4])
 	{
 		m_vStoredCameraPos = cameraPosToStore;
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SpecCameraInit(vector cameraPos[4])
 	{
-		if (m_eCamera)
+		if(m_eCamera)
 			delete m_eCamera;
-
-		if (SCR_EditorManagerEntity.GetInstance().IsOpened())
+		
+		if(SCR_EditorManagerEntity.GetInstance().IsOpened())
 			return;
-
-		if (cameraPos[3] != vector.Zero && cameraPos[3] != CRF_Gamemode.GetInstance().m_vGenericSpawn[3])
+		
+		if(cameraPos[3] != vector.Zero && cameraPos[3] != CRF_Gamemode.GetInstance().m_vGenericSpawn[3])
 			m_vStoredCameraPos = cameraPos;
-
-		if (m_vStoredCameraPos[3] != vector.Zero && cameraPos[3] == CRF_Gamemode.GetInstance().m_vGenericSpawn[3])
+		
+		if(m_vStoredCameraPos[3] != vector.Zero && cameraPos[3] == CRF_Gamemode.GetInstance().m_vGenericSpawn[3])
 			cameraPos = m_vStoredCameraPos;
-
-		if (cameraPos[3] == vector.Zero || cameraPos[3] == "0 10000 0" || cameraPos[3][0] < 1 || cameraPos[3][2] < 1)
+		
+		if(cameraPos[3] == vector.Zero || cameraPos[3] == "0 10000 0" || cameraPos[3][0] < 1 || cameraPos[3][2] < 1)
 			cameraPos = CRF_Gamemode.GetInstance().m_vGenericSpawn;
-
+		
 		EntitySpawnParams cameraSpawnParams = new EntitySpawnParams();
 		cameraSpawnParams.TransformMode = ETransformMode.WORLD;
 		cameraSpawnParams.Transform = cameraPos;
-
+		
 		m_eCamera = GetGame().SpawnEntityPrefab(Resource.Load("{E1FF38EC8894C5F3}Prefabs/Editor/Camera/ManualCameraSpectate.et"), GetGame().GetWorld(), cameraSpawnParams);
 		vector mat = m_eCamera.GetAngles();
 		m_eCamera.SetAngles(Vector(mat[0], mat[1], 0));
-
+		
 		CheckVONRegister();
-		if (CRF_Gamemode.GetInstance().m_GamemodeState == CRF_GamemodeState.GAME)
+		if(CRF_Gamemode.GetInstance().m_GamemodeState == CRF_GamemodeState.GAME)
 			GetGame().GetMenuManager().OpenMenu(ChimeraMenuPreset.CRF_SpectatorMenu);
 		GetGame().GetCameraManager().SetCamera(CameraBase.Cast(m_eCamera));
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void PlayerJoined()
 	{
 		if (GetPlayerId() == 0)
@@ -107,7 +107,7 @@ modded class SCR_PlayerController
 			GetGame().GetCallqueue().CallLater(PlayerJoined, 100, false);
 			return;
 		}
-
+		
 		if (CRF_Gamemode.GetInstance().m_aSlots.Find(GetPlayerId()) == -1)
 		{
 			CRF_ClientComponent.GetInstance().RequestSpectator(GetPlayerId());
@@ -119,27 +119,27 @@ modded class SCR_PlayerController
 			GetGame().GetCallqueue().CallLater(EnterGame, 500, false, GetPlayerId());
 		};
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	// Ask server to respawn player after timer ends
 	void RespawnPlayer(int playerId, vector spawnLocation = vector.Zero)
 	{
-		Rpc(RpcDo_RespawnPlayer, playerId, spawnLocation)
+		Rpc(RpcDo_RespawnPlayer, playerId, spawnLocation)	
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcDo_RespawnPlayer(int playerID, vector spawnLocation)
 	{
 		CRF_Gamemode.GetInstance().RespawnPlayer(playerID, spawnLocation);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void UpdateEntityPos(vector cameraPos[4])
 	{
 		//Rpc(RpcDo_UpdateCameraPos, entityID, cameraPos);
 		IEntity player = GetGame().GetPlayerController().GetControlledEntity();
-
+		
 		//~ Align to terrain if not a character
 		if (!ChimeraCharacter.Cast(player))
 			SCR_TerrainHelper.OrientToTerrain(cameraPos);
@@ -157,183 +157,174 @@ modded class SCR_PlayerController
 			phys.SetAngularVelocity(vector.Zero);
 		}
 	}
-
+	
 	//Communicates to server that the player is talking
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SetTalking(bool input, int playerID)
 	{
 		Rpc(RpcDo_SetTalking, input, playerID);
 	}
-
+	
 	//Communicates to server that the player is talking
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcDo_SetTalking(bool input, int playerID)
 	{
-		if (input)
+		if(input)
 			CRF_Gamemode.GetInstance().SetPlayerTalking(playerID);
 		else
 			CRF_Gamemode.GetInstance().RemovePlayerTalking(playerID);
 	}
-
+	
 	//Communicates to server to advance state
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void AdvanceGamemodeState()
 	{
 		Rpc(RpcDo_AdvanceGamemodeState);
 	}
-
+	
 	//Communicates to server to advance state
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcDo_AdvanceGamemodeState()
 	{
 		CRF_Gamemode.GetInstance().AdvanceGamemodeState();
 	}
-
+	
 	//Communicates to server to set slot
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SetSlot(int index, int playerID)
 	{
 		Rpc(RpcDo_SetSlot, index, playerID);
 	}
-
+	
 	//Communicates to server to set slot
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcDo_SetSlot(int index, int playerID)
 	{
 		CRF_Gamemode.GetInstance().SetSlot(index, playerID);
 	}
-
+	
 	//Communicates to server to set group locked
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SetGroupLocked(int index, bool input)
 	{
 		Rpc(RpcDo_SetGroupLocked, index, input);
 	}
-
+	
 	//Communicates to server to set group locked
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcDo_SetGroupLocked(int index, bool input)
 	{
 		CRF_Gamemode.GetInstance().SetGroupLockedStatus(index, input);
 	}
-
+	
 	//Called to enter the game, decides if you will go into spectator on the client
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void EnterGame(int playerID)
 	{
 		//Call to server to enter slot and or get put into a initial entity to spectate
-		if (m_eCamera)
+		if(m_eCamera)
 			delete m_eCamera;
-
+		
 		GetGame().GetMenuManager().CloseMenuByPreset(ChimeraMenuPreset.CRF_PreviewMenu);
 		GetGame().GetMenuManager().CloseMenuByPreset(ChimeraMenuPreset.CRF_SlottingMenu);
 		GetGame().GetMenuManager().CloseMenuByPreset(ChimeraMenuPreset.CRF_SpectatorMenu);
 		GetGame().GetMenuManager().CloseMenuByPreset(ChimeraMenuPreset.CRF_AARMenu);
 		GetGame().GetMenuManager().CloseMenuByPreset(ChimeraMenuPreset.CRF_RespawnMenu);
-
-		if (CRF_Gamemode.GetInstance().m_aSlots.Find(playerID) == -1)
+		
+		if(CRF_Gamemode.GetInstance().m_aSlots.Find(playerID) == -1)
 			CRF_ClientComponent.GetInstance().RequestSpectator(playerID);
-
+		
 		Rpc(RpcDo_EnterGame, playerID);
-
+		
 		ResetSettingsToStoredValues();
-
+		
 		GetGame().GetCallqueue().CallLater(SetupRadioFrequency, 1000, false);
 	}
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void ResetSettingsToStoredValues()
 	{
 		BaseContainer video = GetGame().GetEngineUserSettings().GetModule("VideoUserSettings");
 		video.Set("MaxFps", m_iFPS);
 		GetGame().UserSettingsChanged();
-
-		if (m_iAudioSetting == 0)
+		
+		if(m_iAudioSetting == 0)
 			AudioSystem.SetMasterVolume(AudioSystem.SFX, 100);
 		else
 			AudioSystem.SetMasterVolume(AudioSystem.SFX, m_iAudioSetting);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void SetupRadioFrequency()
-	{
+	{	
 		// Get player's radio
 		IEntity entity = GetMainEntity();
 		if (entity.GetPrefabData().GetPrefabName() == "{59886ECB7BBAF5BC}Prefabs/Characters/CRF_InitialEntity.et")
 			return;
-		array<IEntity> items = {};
+		ref array<IEntity> items = {};
 		SCR_InventoryStorageManagerComponent.Cast(entity.FindComponent(SCR_InventoryStorageManagerComponent)).GetItems(items);
 		IEntity radioEntity;
-		foreach (IEntity item : items)
+		foreach(IEntity item: items)
 		{
-			if (item.FindComponent(BaseRadioComponent))
-			{
+			if(item.FindComponent(BaseRadioComponent))
 				radioEntity = item;
-				break;
-			}
 		}
-
+		
 		if (!radioEntity)
 			return;
-
+		
 		BaseRadioComponent radio = BaseRadioComponent.Cast(radioEntity.FindComponent(BaseRadioComponent));
-		BaseTransceiver grpTsv = radio.GetTransceiver(0);
+		BaseTransceiver tsv = radio.GetTransceiver(0);
 
 		// Set Player's Freq to whatever group they are in
 		SCR_GroupsManagerComponent m_GroupManager = SCR_GroupsManagerComponent.GetInstance();
 		if (!m_GroupManager)
 			return;
-
+		
 		SCR_AIGroup group = m_GroupManager.GetPlayerGroup(GetPlayerId());
 		PlayerController pc = GetGame().GetPlayerController();
 		if (pc)
 		{
 			RadioHandlerComponent rhc = RadioHandlerComponent.Cast(pc.FindComponent(RadioHandlerComponent));
 			if (rhc)
-				rhc.SetFrequency(grpTsv, group.GetRadioFrequency());
+				rhc.SetFrequency(tsv, group.GetRadioFrequency());
 		}
-
+		
 		SCR_VoNComponent von = SCR_VoNComponent.Cast(entity.FindComponent(SCR_VoNComponent));
-
-		von.SetTransmitRadio(grpTsv);
-
-		BaseTransceiver pltTsv = radio.GetTransceiver(1);
-
-		if (pltTsv)
-			von.SetTransmitRadio(pltTsv);
+		von.SetTransmitRadio(tsv);
 	}
-
+	
 	//Communicates to server to enter slot and or get put into a initial entity to spectate
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcDo_EnterGame(int playerID)
 	{
 		CRF_Gamemode.GetInstance().EnterGame(playerID);
 	}
 
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------	
 	void RequestToJoinChannel(int channel, int requestId)
 	{
 		Rpc(RpcDo_RequestToJoinChannel, channel, requestId);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcDo_RequestToJoinChannel(int channel, int requestId)
 	{
 		CRF_Gamemode.GetInstance().RequestToJoinChannel(channel, requestId);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void CheckVONRegister()
 	{
 		Rpc(RpcDo_CheckVONRegister, GetLocalPlayerId());
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcDo_CheckVONRegister(int playerId)
 	{
@@ -344,86 +335,86 @@ modded class SCR_PlayerController
 			gamemode.AddPlayerToChannel(playerId, 1, false);
 		}
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void CreateChannel()
 	{
 		Rpc(RpcDo_CreateChannel, GetPlayerId());
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcDo_CreateChannel(int playerId)
 	{
 		CRF_Gamemode.GetInstance().CreateChannel(GetGame().GetPlayerManager().GetPlayerName(playerId) + "'s Channel", playerId);
 	}
-
+	
 	//Opens the slotting menu for players in game
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void OpenSlottingMenu(float value = 0.0, EActionTrigger reason = 0)
 	{
-		if (value != 1)
+		if(value != 1)
 			return;
-
+		
 		MenuBase topMenu = GetGame().GetMenuManager().GetTopMenu();
-		if (topMenu)
-			if (topMenu.IsInherited(CRF_PreviewMenuUI) || topMenu.IsInherited(CRF_SlottingMenuUI))
+		if(topMenu)
+			if(topMenu.IsInherited(CRF_PreviewMenuUI) || topMenu.IsInherited(CRF_SlottingMenuUI))
 				return;
-			else if (topMenu.IsInherited(CRF_SpectatorMenuUI))
+			else if(topMenu.IsInherited(CRF_SpectatorMenuUI))
 				GetGame().GetMenuManager().CloseMenu(topMenu);
-
+		
 		GetGame().GetMenuManager().OpenMenu(ChimeraMenuPreset.CRF_SlottingMenu);
-		if (CRF_Gamemode.GetInstance().m_GamemodeState != CRF_GamemodeState.GAME)
+		if(CRF_Gamemode.GetInstance().m_GamemodeState != CRF_GamemodeState.GAME)
 		{
 			BaseContainer video = GetGame().GetEngineUserSettings().GetModule("VideoUserSettings");
-			if (m_iFPS)
+			if(m_iFPS)
 				video.Get("MaxFps", m_iFPS);
 			video.Set("MaxFps", 30);
 			GetGame().UserSettingsChanged();
-			if (m_iAudioSetting)
+			if(m_iAudioSetting)
 				m_iAudioSetting = AudioSystem.GetMasterVolume(AudioSystem.SFX);
 			AudioSystem.SetMasterVolume(AudioSystem.SFX, 0);
 		}
 	}
-
+	
 	//Communicates to server to advance the slotting phase
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void AdvanceSlottingPhase()
 	{
 		Rpc(RpcDo_AdvanceSlottingPhase);
 	}
-
+	
 	//Communicates to server to advance the slotting phase
-	//------------------------------------------------------------------------------------------------
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcDo_AdvanceSlottingPhase()
 	{
 		CRF_Gamemode.GetInstance().AdvanceSlottingState();
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void JoinChannel(int playerId, int channel)
 	{
 		Rpc(RpcDo_JoinChannel, playerId, channel);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcDo_JoinChannel(int playerId, int channel)
 	{
 		CRF_Gamemode.GetInstance().AddPlayerToChannel(playerId, channel, false);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	void Accept(int playerId, int channel)
 	{
 		Rpc(RpcDo_Accept, playerId, channel);
 	}
-
-	//------------------------------------------------------------------------------------------------
+	
+	//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
 	void RpcDo_Accept(int playerId, int channel)
 	{
-		CRF_Gamemode.GetInstance().AddPlayerToChannel(playerId, channel, false);
+		CRF_Gamemode.GetInstance().AddPlayerToChannel(playerId, channel, false); 
 	}
 }


### PR DESCRIPTION
Makes it so when squad leader (on slotting screen) enters a squad without a squad leader (in game) it will assign them to squad leader (In game). So no more squad leaders asking to be promoted during briefing & when the squad leader dies it will assign squad leader to the next team lead instead of just the next person in the list.

Fixes #529 