### PR TITLE
Changes to allow for building, BLUFOR & OPFOR only

### DIFF
--- a/Prefabs/Vehicles/Wheeled/M923A1/M923A1_engineer_BLUFOR.et
+++ b/Prefabs/Vehicles/Wheeled/M923A1/M923A1_engineer_BLUFOR.et
@@ -1,0 +1,64 @@
+Vehicle : "{9A0D72816DFFDB7F}Prefabs/Vehicles/Wheeled/M923A1/M923A1.et" {
+ ID "BBCBA43A9778AE21"
+ components {
+  SCR_EditableVehicleComponent "{50DEB7C26B5EB312}" {
+   m_UIInfo SCR_EditableVehicleUIInfo "{5298E609432D192D}" {
+    Name "#AR-Vehicle_M923A1_Engineer_Name"
+    Icon "{9EBE212C91B36BBE}UI/Textures/Editor/EditableEntities/Vehicles/EditableEntity_Vehicle_Truck.edds"
+    IconSetName ""
+    m_Image "{96ABBE2BFC2979A3}UI/Textures/EditorPreviews/Vehicles/Wheeled/M923A1/M923A1_engineer.edds"
+    m_sFaction "US"
+    m_aAuthoredLabels + {
+     240 210
+    }
+    m_aAutoLabels +{
+    }
+    m_EntityBudgetCost {
+     SCR_EntityBudgetValue "{5EDC86E4AF8908B6}" {
+      m_Value 260
+     }
+    }
+    m_aOccupantFillCompartmentTypes +{
+    }
+    m_aPassengerEntityBudgetCost {
+     SCR_EntityBudgetValue "{5A5EA70BBF190672}" {
+      m_BudgetType AI
+      m_Value 10
+     }
+    }
+   }
+  }
+  SCR_VehicleFactionAffiliationComponent "{5882CBD9AC741CEC}" {
+   "faction affiliation" "BLUFOR"
+  }
+  SCR_VehiclePerceivableComponent "{566CD04B8A6107DD}" {
+   "Additional aim points" {
+    AimPoint "{5A44DB098ADDB55E}" : "{94ED6806120FB600}Prefabs/Vehicles/Core/Configs/AimPoints/AimPoint_Hull_Truck.conf" {
+     AimPointPosition PointInfo "{5A44DB148C16BF03}" {
+      Offset 0 2.25 -2.25
+     }
+    }
+   }
+  }
+  SCR_WheeledDamageManagerComponent "{141326E9FD94FE40}" {
+   m_fVehicleDestroyDamage 17524
+  }
+  SlotManagerComponent "{55BCE45E438E4CFF}" {
+   Slots {
+    RegisteringComponentSlotInfo EngineerBox {
+     MergePhysics 1
+     Prefab "{93D8DE7315B905ED}Prefabs/Vehicles/Wheeled/M923A1/VehParts/M923A1_engineer_box_test.et"
+     RegisterActions 1
+     RegisterDamage 1
+     RegisterCompartments 1
+     RegisterLights 1
+    }
+    RegisteringComponentSlotInfo EngineerDecal {
+     Prefab "{E0B008F5B9622BF2}Prefabs/Vehicles/Wheeled/M923A1/VehParts/M923A1_enginner_decal.et"
+     InheritParentSkeleton 1
+     RegisterDamage 1
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M923A1/M923A1_engineer_BLUFOR.et.meta
+++ b/Prefabs/Vehicles/Wheeled/M923A1/M923A1_engineer_BLUFOR.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{C4ED6708B5B79777}Prefabs/Vehicles/Wheeled/M923A1/M923A1_engineer_test.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M923A1/VehParts/M923A1_engineer_box_test.et
+++ b/Prefabs/Vehicles/Wheeled/M923A1/VehParts/M923A1_engineer_box_test.et
@@ -1,0 +1,45 @@
+GenericEntity : "{0CD6E71D33E1CCD0}Prefabs/Vehicles/Core/Vehicle_EngineerBox_Base.et" {
+ ID "4B42E71698F5739C"
+ components {
+  BaseLightManagerComponent "{5CC4F3413F3F1AE2}" : "{5A73DE5A36EF3B6E}Prefabs/Vehicles/Wheeled/M923A1/M923A1_cargo_BaseLightManager.ct" {
+  }
+  MeshObject "{4B42E716914465B9}" {
+   Object "{48C4BA0B4E41763D}Assets/Vehicles/Wheeled/M923A1/M923A1_Cargo.xob"
+  }
+  SCR_CampaignBuildingProviderComponent "{5DF54421B01A7FF8}" {
+   m_bUserActionActivationOnly 0
+   m_iRank RENEGADE
+   m_aAvailableTraits {
+    0 0 108
+   }
+  }
+  SCR_DamageManagerComponent "{3EBB276D48AFFF41}" {
+   "Additional hit zones" {
+    SCR_DestructibleHitzone EngineerBox {
+     m_pDestructionHandler SCR_DestructionBaseHandler "{5C77025948537C40}" {
+      m_sWreckModel "{A98B342A8B226409}Assets/Vehicles/Wheeled/M923A1/M923A1_Cargo_Wreck.xob"
+     }
+    }
+   }
+  }
+  SlotManagerComponent "{64F52C1673613887}" {
+   Slots {
+    RegisteringComponentSlotInfo Canvas {
+     MergePhysics 1
+     Prefab "{88F41100B0152A06}Prefabs/Vehicles/Wheeled/M923A1/M923A1_canvas_closed.et"
+     RegisterDamage 1
+    }
+   }
+  }
+  ActionsManagerComponent "{5DE2DEF324F763D7}" {
+   ActionContexts {
+    UserActionContext "{5DE2DEF320BD8480}" {
+     Position PointInfo "{5DE2DEF0E5CEF861}" {
+      Offset 0 1.6411 -4.4683
+      Angles 0 -180 0
+     }
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M923A1/VehParts/M923A1_engineer_box_test.et.meta
+++ b/Prefabs/Vehicles/Wheeled/M923A1/VehParts/M923A1_engineer_box_test.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{93D8DE7315B905ED}Prefabs/Vehicles/Wheeled/M923A1/VehParts/M923A1_engineer_box_test.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/Ural4320/Ural4320_engineer_OPFOR.et
+++ b/Prefabs/Vehicles/Wheeled/Ural4320/Ural4320_engineer_OPFOR.et
@@ -1,0 +1,64 @@
+Vehicle : "{4597626AF36C0858}Prefabs/Vehicles/Wheeled/Ural4320/Ural4320.et" {
+ ID "0000000000000001"
+ components {
+  SCR_EditableVehicleComponent "{50DEB7C26B5EB312}" {
+   m_UIInfo SCR_EditableVehicleUIInfo "{5298E609432D192D}" {
+    Name "#AR-Vehicle_Ural4320_Engineer_Name"
+    Icon "{9EBE212C91B36BBE}UI/Textures/Editor/EditableEntities/Vehicles/EditableEntity_Vehicle_Truck.edds"
+    m_Image "{3FBEA815D47B4382}UI/Textures/EditorPreviews/Vehicles/Wheeled/Ural4320/Ural4320_engineer.edds"
+    m_sFaction "USSR"
+    m_aAuthoredLabels + {
+     240 210
+    }
+    m_aAutoLabels +{
+    }
+    m_EntityBudgetCost {
+     SCR_EntityBudgetValue "{5EDC86E4AF8908B6}" {
+      m_Value 260
+     }
+    }
+    m_bEditorPlaceAsOneGroup 1
+    m_aOccupantFillCompartmentTypes +{
+    }
+   }
+  }
+  SCR_UniversalInventoryStorageComponent "{5916C58171230A92}" {
+   MaxCumulativeVolume 100000
+  }
+  SCR_VehicleFactionAffiliationComponent "{5882CBD9AC741CEC}" {
+   "faction affiliation" "OPFOR"
+  }
+  SCR_WheeledDamageManagerComponent "{141326E9FD94FE40}" {
+   m_fVehicleDestroyDamage 17524
+  }
+  SlotManagerComponent "{55BCE45E438E4CFF}" {
+   Slots {
+    RegisteringComponentSlotInfo EngineerBox {
+     MergePhysics 1
+     Prefab "{9DA0DF978E8F5886}Prefabs/Vehicles/Wheeled/Ural4320/VehParts/Ural4320_engineer_box_OPFOR.et"
+     RegisterActions 1
+     RegisterDamage 1
+     RegisterControllers 1
+     RegisterCompartments 1
+     RegisterLights 1
+    }
+    RegisteringComponentSlotInfo EnginnerDecal {
+     Prefab "{4E696814A573AE51}Prefabs/Vehicles/Wheeled/Ural4320/VehParts/Ural4320_enginner_decal.et"
+     InheritParentSkeleton 1
+    }
+   }
+  }
+  ActionsManagerComponent "{C97BE5489221AE18}" {
+   ActionContexts {
+    UserActionContext "{64F918715F88AE0B}" {
+     ContextName "cargo_open"
+     Position PointInfo "{64F918715F88AE11}" {
+      Offset 0 1.8 -3.9
+     }
+    }
+   }
+  }
+ }
+ coords 114.386 1.001 200.475
+ m_eVehicleType SUPPLY_TRUCK
+}

--- a/Prefabs/Vehicles/Wheeled/Ural4320/Ural4320_engineer_OPFOR.et.meta
+++ b/Prefabs/Vehicles/Wheeled/Ural4320/Ural4320_engineer_OPFOR.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{1328D98FC897D948}Prefabs/Vehicles/Wheeled/Ural4320/Ural4320_engineer_OPFOR.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/Ural4320/VehParts/Ural4320_engineer_box_OPFOR.et
+++ b/Prefabs/Vehicles/Wheeled/Ural4320/VehParts/Ural4320_engineer_box_OPFOR.et
@@ -1,0 +1,45 @@
+GenericEntity : "{0CD6E71D33E1CCD0}Prefabs/Vehicles/Core/Vehicle_EngineerBox_Base.et" {
+ ID "4B42E71698F5739C"
+ components {
+  BaseLightManagerComponent "{5CC4F34111D9C32F}" : "{4B199B19018562C6}Prefabs/Vehicles/Wheeled/Ural4320/VehParts/Ural4320_cargo_BaseLightManager.ct" {
+  }
+  MeshObject "{4B42E716914465B9}" {
+   Object "{25E0A2F2CC535076}Assets/Vehicles/Wheeled/Ural4320/Ural_4320_cargo.xob"
+  }
+  SCR_CampaignBuildingProviderComponent "{5DF54421B01A7FF8}" {
+   m_bUserActionActivationOnly 0
+   m_aAvailableTraits {
+    0 0 108
+   }
+  }
+  SCR_DamageManagerComponent "{3EBB276D48AFFF41}" {
+   "Additional hit zones" {
+    SCR_DestructibleHitzone EngineerBox {
+     m_pDestructionHandler SCR_DestructionBaseHandler "{5C77025948537C40}" {
+      m_sWreckModel "{4A34B288E4056C0D}Assets/Vehicles/Wheeled/Ural4320/Ural_4320_cargo_wreck.xob"
+     }
+    }
+   }
+  }
+  SlotManagerComponent "{64F91871ABAAFAE9}" {
+   Slots {
+    RegisteringComponentSlotInfo Canvas {
+     Prefab "{96C3B0980A16D7E3}Prefabs/Vehicles/Wheeled/Ural4320/VehParts/Ural4320_canvas_closed.et"
+     RegisterDamage 1
+    }
+   }
+  }
+  ActionsManagerComponent "{5DE2DEF324F763D7}" {
+   ActionContexts {
+    UserActionContext "{5DE2DEF320BD8480}" {
+     UIInfo SCR_ActionContextUIInfo "{6132AA92E8ED05A3}" : "{7CD00B230573CAC6}Prefabs/Vehicles/Core/Configs/Actions/ActionUIInfo/SCR_ActionContextUIInfo.conf" {
+     }
+     Position PointInfo "{5DE2DEF0E5CEF861}" {
+      Offset 0 1.5779 -3.8782
+      Angles 0 180 0
+     }
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/Ural4320/VehParts/Ural4320_engineer_box_OPFOR.et.meta
+++ b/Prefabs/Vehicles/Wheeled/Ural4320/VehParts/Ural4320_engineer_box_OPFOR.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{9DA0DF978E8F5886}Prefabs/Vehicles/Wheeled/Ural4320/VehParts/Ural4320_engineer_box_OPFOR.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/scripts/Game/Systems/Building/CampaignBuildingManagerConfig.ct
+++ b/scripts/Game/Systems/Building/CampaignBuildingManagerConfig.ct
@@ -1,0 +1,9 @@
+SCR_CampaignBuildingManagerComponent {
+ m_sFreeRoamBuildingClientTrigger "{5E191CEAF4B95816}Prefabs/MP/FreeRoamBuildingClientTrigger.et"
+ m_BudgetType CAMPAIGN
+ m_iCompositionRefundPercentage 100
+ m_OutlineManager SCR_CampaignBuildingCompositionOutlineManager "{5D7A73031D9A11E1}" : "{96A8B496A076F1C0}Scripts/Game/Building/CampaignBuildingCompositionOutline.conf" {
+ }
+ m_sPrefabsToBuildResource "{D2527D9AA5B4A33E}Configs/Editor/PlaceableEntities/Compositions/Compositions_FreeRoamBuilding.conf"
+ m_sPrefabToHoldSupplyOnRefund "{4BBE0A784C01900E}Prefabs/Props/Military/SupplyBox/SupplyCrate/SupplyCrate_01/SupplyCrate_01_FreeRoamBuilding.et"
+}

--- a/scripts/Game/Systems/Building/CampaignBuildingManagerConfig.ct.meta
+++ b/scripts/Game/Systems/Building/CampaignBuildingManagerConfig.ct.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{B04F8219B3B35F87}scripts/Game/Systems/Building/CampaignBuildingManagerConfig.ct"
+ Configurations {
+  ComponentTemplateResourceClass PC {
+  }
+  ComponentTemplateResourceClass XBOX_ONE : PC {
+  }
+  ComponentTemplateResourceClass XBOX_SERIES : PC {
+  }
+  ComponentTemplateResourceClass PS4 : PC {
+  }
+  ComponentTemplateResourceClass PS5 : PC {
+  }
+  ComponentTemplateResourceClass HEADLESS : PC {
+  }
+  ComponentTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/scripts/Game/Systems/VanillaOverrides/CRF_SCR_EditorManagerEntity.c
+++ b/scripts/Game/Systems/VanillaOverrides/CRF_SCR_EditorManagerEntity.c
@@ -3,7 +3,13 @@ modded class SCR_EditorManagerEntity
 	
 	override bool CanOpen()
 	{
-		if (GetCurrentMode() == EEditorMode.PHOTO && SCR_PlayerController.GetLocalControlledEntity().GetPrefabData().GetPrefabName() == "{59886ECB7BBAF5BC}Prefabs/Characters/CRF_InitialEntity.et")
+		if (GetCurrentMode() == EEditorMode.BUILDING)
+		{
+			SetIsLimited(true);
+			return true;
+		}
+		
+		if ((GetCurrentMode() == EEditorMode.PHOTO) && SCR_PlayerController.GetLocalControlledEntity().GetPrefabData().GetPrefabName() == "{59886ECB7BBAF5BC}Prefabs/Characters/CRF_InitialEntity.et")
 		{
 			SetIsLimited(false);
 			return true;


### PR DESCRIPTION
The work flow to get building enabled is to add the SCR_CampaignBuildingManagerComponent, and the SCR_CompositionSlotManagerComponent to the lobby object. Then, drag the CampaignBuildingManagerConfig onto the SCR_CampaignBuildingManagerComponent to apply settings. There are engineering truck prefabs for BLUFOR and OPFOR only right now, and you must use these for building. In addition, these trucks will need a source of supply to enable construction. In the future, a building list needs to be compiled for the INDFOR factions as the FIA vanilla faction doesn't have trait_MILITARY buildable components. 

Changes
- Changes the CRF_SCR_EditorManagerEntity script to check if the menu request is a building menu, and open it. 
- Creates a config file for the campaign building component
- Sets up prefab engineering trucks for OPFOR & BLUFOR