### PR TITLE
New Mission- Harry S&D Spanish Moss

### DIFF
--- a/Configs/Gearscripts/Standard/80s/CRF_GS_USSR80s.conf
+++ b/Configs/Gearscripts/Standard/80s/CRF_GS_USSR80s.conf
@@ -133,6 +133,16 @@ CRF_GearScriptConfig {
     }
    }
   }
+  m_HMG CRF_Spec_Weapon_Class "{652B55034F4BB0C2}" {
+   m_Weapon "{FA0E25CE35EE945F}Prefabs/Weapons/Rifles/AKS74U/Rifle_AKS74UN.et"
+   m_MagazineArray {
+    CRF_Spec_Magazine_Class "{652B55034C6CF038}" {
+     m_Magazine "{0A84AA5A3884176F}Prefabs/Weapons/Magazines/Magazine_545x39_AK_30rnd_Last_5Tracer.et"
+     m_MagazineCount 3
+     m_AssistantMagazineCount 0
+    }
+   }
+  }
   m_AT CRF_Spec_Weapon_Class "{629D042DD805C5DF}" {
    m_Weapon "{7A82FE978603F137}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7.et"
    m_MagazineArray {
@@ -357,7 +367,7 @@ CRF_GearScriptConfig {
     }
    }
    CRF_Role_Custom_Gear "{64FF602CA7F3E3CC}" {
-   m_Role MEDIC
+    m_Role MEDIC
     m_Clothing {
      CRF_Clothing "{64FF602C803B5F60}" {
       m_iClothingType BACKPACK
@@ -450,7 +460,7 @@ CRF_GearScriptConfig {
      CRF_Clothing "{64FF602D555CC606}" {
       m_iClothingType BACKPACK
       m_ClothingPrefabs {
-       "{41A9C55B61F375F0}Prefabs/Items/Equipment/Backpacks/Backpack_Kolobok.et"
+       "{7611D0DAE5796941}Prefabs/Items/Equipment/Backpacks/Backpack_USSR_Bipod.et"
       }
      }
     }
@@ -643,6 +653,17 @@ CRF_GearScriptConfig {
      CRF_Inventory_Item "{64FF6026EE406EBB}" {
       m_sItemPrefab "{2E5BFBBBC0AD79CE}Prefabs/Weapons/Explosives/Explosive_Satchels/OPFOR_Satchel.et"
       m_iItemCount 3
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{652B5503AAD16CBC}" {
+    m_Role HEAVY_MACHINEGUN
+    m_Clothing {
+     CRF_Clothing "{652B5503ADCD024A}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{177B1CD9D9A93A5A}Prefabs/Items/Equipment/Backpacks/NSV/Backpack_NSV_Weapon_MoreAmmo.et"
+      }
      }
     }
    }

--- a/Missions/Harry_SD118_SpanishMoss.conf
+++ b/Missions/Harry_SD118_SpanishMoss.conf
@@ -1,0 +1,13 @@
+SCR_MissionHeader {
+ World "{F2D768E47B22CFC5}Worlds/COALobby/Gulfcoast/Harry_TVT_SpanishMoss.ent"
+ m_sName "CRF S&D118 Spanish Moss"
+ m_sAuthor "Harry"
+ m_sDescription "Blufor looks for bomb sites in the Gulf.S"
+ m_sIcon "{B7385DA4504BD4D5}CRF Images/crflogo.edds"
+ m_sLoadingScreen "{B7385DA4504BD4D5}CRF Images/crflogo.edds"
+ m_sPreviewImage "{B7385DA4504BD4D5}CRF Images/crflogo.edds"
+ m_sGameMode "Search & Destroy"
+ m_iPlayerCount 128
+ m_iStartingHours 12
+ m_iMapMarkerLimitPerPlayer 120
+}

--- a/Missions/Harry_SD118_SpanishMoss.conf.meta
+++ b/Missions/Harry_SD118_SpanishMoss.conf.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{147CCD65BE13890F}Missions/Harry_SD118_SpanishMoss.conf"
+ Configurations {
+  CONFResourceClass PC {
+  }
+  CONFResourceClass XBOX_ONE : PC {
+  }
+  CONFResourceClass XBOX_SERIES : PC {
+  }
+  CONFResourceClass PS4 : PC {
+  }
+  CONFResourceClass PS5 : PC {
+  }
+  CONFResourceClass HEADLESS : PC {
+  }
+  CONFResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Items/Equipment/Backpacks/NSV/Backpack_NSV_Weapon_MoreAmmo.et
+++ b/Prefabs/Items/Equipment/Backpacks/NSV/Backpack_NSV_Weapon_MoreAmmo.et
@@ -1,0 +1,66 @@
+GenericEntity : "{09D6A1C9543E4A95}Prefabs/Items/Core/Backpack_Base.et" {
+ ID "511E9C6ADE70F798"
+ components {
+  MeshObject "{511E9C6ADE70F7BD}" {
+   Object "{F63FB77CF5C853D7}Assets/Items/Equipment/Backpacks/Backpack_Kolobok/Backpack_Kolobok_item.xob"
+  }
+  SCR_UniversalInventoryStorageComponent "{5222CB03A40528FA}" {
+   Attributes SCR_ItemAttributeCollection "{5222CB039E9715D1}" {
+    ItemDisplayName UIInfo "{5222CB03904B414C}" {
+     Name "NSV SPP Weapon Backpack"
+     Description ""
+    }
+    ItemPhysAttributes ItemPhysicalAttributes PhysicalAttributes {
+     Weight 1
+     SizeSetupStrategy Manual
+     ItemDimensions 20 20 20
+     ItemVolume 8001
+    }
+    CustomAttributes {
+     PreviewRenderAttributes "{52BCBDD2B54658EC}" {
+      PreviewModel "{63131CE6ACC7038F}Assets/Items/Equipment/Backpacks/Backpack_Kolobok/Backpack_Kolobok.xob"
+     }
+    }
+   }
+   UseCapacityCoefficient 0
+   CapacityCoefficient 1.26
+   MaxCumulativeVolume 0
+   MaxItemSize 20 20 20
+   m_fMaxWeight 0
+  }
+  StaticWeaponBagComponent "{652B55038A5D469D}" {
+   m_rWeaponPrefab "{488E5E574B366197}Prefabs/Weapons/Tripods/6T7/Tripod_6T7_NSV_More_Ammo.et"
+  }
+  BaseLoadoutClothComponent "{511E9C6ADE70F7BB}" {
+   WornModel "{63131CE6ACC7038F}Assets/Items/Equipment/Backpacks/Backpack_Kolobok/Backpack_Kolobok.xob"
+   ItemModel "{F63FB77CF5C853D7}Assets/Items/Equipment/Backpacks/Backpack_Kolobok/Backpack_Kolobok_item.xob"
+   SoundInt 830
+   DeflatedModel "{612FEDC4900077AB}Assets/Items/Equipment/Backpacks/Backpack_Kolobok/Backpack_Kolobok_Inflated.xob"
+   AreaTypeWhenModelChange {
+    LoadoutArmoredVestSlotArea "{652B55038A5D46A6}" {
+    }
+   }
+  }
+  ActionsManagerComponent "{511E9C6ADE70F786}" {
+   ActionContexts {
+    UserActionContext "{511E9C6ADE70F788}" {
+     Position PointInfo "{511E9C6ADE70F78D}" {
+      Offset 0 0.1281 0.0436
+     }
+    }
+   }
+   additionalActions {
+    AssembleWeaponAction "{652B55038A5D46A8}" {
+     ParentContextList {
+      "default"
+     }
+     UIInfo UIInfo "{652B55038A5D46B5}" {
+      Name "Assemble Weapon"
+     }
+     Duration 5
+     "Sort Priority" 3
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Items/Equipment/Backpacks/NSV/Backpack_NSV_Weapon_MoreAmmo.et.meta
+++ b/Prefabs/Items/Equipment/Backpacks/NSV/Backpack_NSV_Weapon_MoreAmmo.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{177B1CD9D9A93A5A}Prefabs/Items/Equipment/Backpacks/NSV/Backpack_NSV_Weapon_MoreAmmo.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Tripods/6T7/Tripod_6T7_NSV_More_Ammo.et
+++ b/Prefabs/Weapons/Tripods/6T7/Tripod_6T7_NSV_More_Ammo.et
@@ -1,0 +1,46 @@
+Turret : "{29F0CC704A582154}Prefabs/Weapons/Tripods/6T7/Tripod_6T7_NSV.et" {
+ ID "52D30EFBEBC74642"
+ components {
+  SCR_UniversalInventoryStorageComponent "{570EACF4F2F94F1B}" {
+   InitialStorageSlots {
+    InventoryStorageSlot Magazine_4 {
+     Prefab "{843D9B182BCD2765}Prefabs/Weapons/Magazines/NSV/Box_127x108_NSV_50rnd_4AP_1APIT.et"
+    }
+    InventoryStorageSlot Magazine_5 {
+     Prefab "{843D9B182BCD2765}Prefabs/Weapons/Magazines/NSV/Box_127x108_NSV_50rnd_4AP_1APIT.et"
+    }
+    InventoryStorageSlot Magazine_6 {
+     Prefab "{843D9B182BCD2765}Prefabs/Weapons/Magazines/NSV/Box_127x108_NSV_50rnd_4AP_1APIT.et"
+    }
+   }
+  }
+  StaticWeaponComponent "{652B5503ECA3B579}" {
+   m_rWeaponBagPrefab "{B4C47869B0B37699}Prefabs/Items/Equipment/Backpacks/NSV/Backpack_NSV_Weapon.et"
+   m_rBipodBagPrefab "{7611D0DAE5796941}Prefabs/Items/Equipment/Backpacks/Backpack_USSR_Bipod.et"
+  }
+  ActionsManagerComponent "{51ACD09C7181BA0B}" {
+   additionalActions {
+    MoveWeaponAction "{652B5503ECA3B515}" {
+     ParentContextList {
+      "default"
+     }
+     UIInfo UIInfo "{652B5503ECA3B511}" {
+      Name "Move Weapon"
+     }
+     Duration 5
+     "Sort Priority" 3
+    }
+    DisassembleWeaponAction "{652B5503ECA3B51F}" {
+     ParentContextList {
+      "default"
+     }
+     UIInfo UIInfo "{652B5503ECA3B51E}" {
+      Name "Disassemble Weapon"
+     }
+     Duration 5
+     "Sort Priority" 4
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Weapons/Tripods/6T7/Tripod_6T7_NSV_More_Ammo.et.meta
+++ b/Prefabs/Weapons/Tripods/6T7/Tripod_6T7_NSV_More_Ammo.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{488E5E574B366197}Prefabs/Weapons/Tripods/6T7/Tripod_6T7_NSV_More_Ammo.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Worlds/COALobby/Gulfcoast/Harry_TVT_SpanishMoss.ent
+++ b/Worlds/COALobby/Gulfcoast/Harry_TVT_SpanishMoss.ent
@@ -1,0 +1,3 @@
+SubScene {
+ Parent "{47E9A6ECDBA6930E}Worlds/Gulfcoast Islands.ent"
+}

--- a/Worlds/COALobby/Gulfcoast/Harry_TVT_SpanishMoss.ent.meta
+++ b/Worlds/COALobby/Gulfcoast/Harry_TVT_SpanishMoss.ent.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{F2D768E47B22CFC5}Worlds/COALobby/Gulfcoast/Harry_TVT_SpanishMoss.ent"
+ Configurations {
+  ENTResourceClass PC {
+  }
+  ENTResourceClass XBOX_ONE : PC {
+  }
+  ENTResourceClass XBOX_SERIES : PC {
+  }
+  ENTResourceClass PS4 : PC {
+  }
+  ENTResourceClass PS5 : PC {
+  }
+  ENTResourceClass HEADLESS : PC {
+  }
+  ENTResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Worlds/COALobby/Gulfcoast/Harry_TVT_SpanishMoss_Layers/aaInit.layer
+++ b/Worlds/COALobby/Gulfcoast/Harry_TVT_SpanishMoss_Layers/aaInit.layer
@@ -1,0 +1,565 @@
+SCR_AIWorld : "{E0A05C76552E7F58}Prefabs/AI/SCR_AIWorld.et" {
+ coords 14209.004 477.148 4192.526
+}
+CRF_Gamemode CRF_Lobby1 : "{6A996BBFCEB37E78}Prefabs/MP/Modes/Lobby/CRF_Lobby.et" {
+ components {
+  CRF_MDB_LoggingServerComponent "{645540DB0DEFDC76}" {
+   Enabled 0
+  }
+  CRF_SearchAndDestroyGameModeComponent "{652B550D75FDCFE2}" {
+   hideMapMarkers 1
+  }
+  SCR_AdditionalGameModeSettingsComponent "{6170E11C3C452ACC}" {
+   m_bEnableTeamKillPunishment 0
+  }
+  SCR_CampaignBuildingManagerComponent "{652B480ABAEE7155}" : "{B04F8219B3B35F87}scripts/Game/Systems/Components/Building/CampaignBuildingManagerConfig.ct" {
+  }
+  SCR_CompositionSlotManagerComponent "{652B480A831A1AD9}" {
+  }
+  SCR_DataCollectorComponent "{5ADE83EE64329989}" {
+   m_aModules {
+    SCR_DataCollectorCrimesModule "{5D9C706AD14AF695}" {
+    }
+   }
+  }
+  SCR_GameModeHealthSettings "{5A22E11F9ACBB1DF}" {
+   m_fDOTScale 0.5
+   m_fRegenScale 0.75
+   m_bPermitUnconsciousVON 0
+   m_fRegenerationDelay 30
+   m_fRegenerationScale 0.6
+  }
+  SCR_InitWeatherComponent "{64427EEC0AFF43EE}" {
+   m_sInitialStartingWeatherId "Cloudy"
+  }
+  SCR_NametagConfigComponent "{571AA9E54FC9210D}" {
+   m_sConfigPath "{09F7AAA14A642683}Configs/NameTags/NametagFriendlies.conf"
+  }
+  SCR_NightModeGameModeComponent "{5D50E84688D5A408}" {
+   m_bAllowGlobalNightMode 1
+  }
+  SCR_NotificationSenderComponent "{56FA84B04BE7D4C0}" {
+   m_iKillFeedType DISABLED
+  }
+  SCR_ReconnectComponent "{5A02809D5E8ABE42}" {
+   Enabled 0
+  }
+  SCR_RespawnSystemComponent "{56B2B4793051E7C9}" {
+   m_SpawnLogic SCR_SpawnLogic "{5D36888CC966608A}" {
+   }
+  }
+  SCR_TimeAndWeatherHandlerComponent "{64427EEC304DD9A0}" {
+   m_iStartingHours 1
+  }
+ }
+ coords 14225.293 461.417 4235.311
+ m_iTimeLimitMinutes 40
+ m_aMissionDescriptors {
+  CRF_MissionDescriptor "{632771FB5C619E1C}" {
+   m_sTitle "Welcome / How to Play"
+   m_sTextData "Welcome to a COALITION Session."\
+   ""\
+   "If this is your first time here, please join the discord:"\
+   "Escape -> Server Message -> Join Discord"\
+   ""\
+   "COALITION hosts one-life missions every Friday. Each session will have, at minimum, 3 missions a night."\
+   ""\
+   "Anyone can join the mission, but after a mission starts, join in progress (JIP) is disabled and you must wait until the next mission to take part."\
+   ""\
+   "If the mission has not started yet, please take time to familiarize yourself with the rest of the briefing and then hold U to select a slot."\
+   ""\
+   ""\
+   ""
+   m_bShowForAnyFaction 1
+  }
+  CRF_MissionDescriptor "{64425053BDE568A1}" {
+   m_sTitle "Custom Controls"
+   m_sTextData "Custom Controls (Keyboard/Controller)"\
+   ""\
+   "WHILE ALIVE:"\
+   "Hold U / Hold View - Open Lobby"\
+   "HOME / Menu + D-pad Right - Squad Settings"\
+   "CTRL + Home / Menu + D-pad Left - Personal Squad Settings"\
+   "F9 / Menu + D-pad Up - Toggle Side Ready"\
+   "LCtrl + Space / RB + A Button - Place Static Weapon"\
+   "LCtrl + X / RB + B Button - Cancel Static Weapon"\
+   ""\
+   "IN SPECTATOR:"\
+   "L / Y Button - Toggle spectator/alive chat"\
+   "N / 2x D-pad Right - Enable night vision "\
+   ""\
+   "CHAT COMMANDS:"\
+   "/a <message> - Message admins"
+   m_bShowForAnyFaction 1
+  }
+  CRF_MissionDescriptor "{644250503DF684C0}" {
+   m_sTextData "This is the search and destroy game mode, but an option to hide the universal bomb site markers has been added. Blufor must search for the bomb sites, while Opfor is aware of where they are and must defend them."\
+   ""\
+   "BLUFOR Composition: Motorized Inf"\
+   "BLUFOR Assets: LAV, AH-6M"\
+   ""\
+   "OPFOR Composition: Inf w/ Integrated AA"\
+   "OPFOR Assets: HMG, Construction Truck"\
+   ""\
+   "Time: 40 min"\
+   "Weather: Cloudy"
+  }
+  CRF_MissionDescriptor "{64425051F2E00216}" {
+   m_sTextData "Search for, and destroy both bomb sites."
+  }
+  CRF_MissionDescriptor "{64425051B9B5AF67}" {
+   m_sTextData "Defend both bomb sites."
+  }
+  CRF_MissionDescriptor "{644250519BE30999}" {
+   m_sTitle "INDFOR Objectives"
+   m_sTextData "If INDFOR is playable, add mission objectives in bullet point list. Add details for each if you feel necessary, but keep it concise."
+   m_aFactionKeys +{
+   }
+  }
+  CRF_MissionDescriptor "{6442505149CF6C93}" {
+   m_sTextData ""
+  }
+ }
+ m_iFactionOneRatio 3
+ m_sFactionOneKey "BLU"
+ m_iFactionTwoRatio 3
+ m_sFactionTwoKey "OPF"
+ {
+  SCR_FactionManager {
+   ID "632A77473B3CC3A8"
+   Factions {
+    SCR_Faction "{56DEAC40D2DBC8B1}" {
+     UIInfo SCR_FactionUIInfo "{528C961236B7DCD3}" {
+      Name "BLUFOR"
+      m_sNameUpper "BLUFOR"
+     }
+     "Identity of soldiers" FactionIdentity "{570D128F4022EF5A}" {
+      SocialIdentity SocialIdentity "{56E4EBD9F0C03530}" {
+       NamesConfig +{
+       }
+       AliasesConfig +{
+       }
+       SurnamesConfig +{
+       }
+      }
+     }
+     m_iOrder 10
+     m_CallsignInfo SCR_FactionCallsignInfo "{5DA0F2A6677ADA9E}" {
+      m_aSquadNames {
+       SCR_CallsignInfo "{55CCB792D10AD8F4}" {
+        m_sCallsign "1PLT"
+       }
+       SCR_CallsignInfo "{55CCB792D13759D8}" {
+        m_sCallsign "1-1"
+       }
+       SCR_CallsignInfo "{55CCB792D1218E95}" {
+        m_sCallsign "1-2"
+       }
+       SCR_CallsignInfo "{55CCB792D0C8B3CE}" {
+        m_sCallsign "1-3"
+       }
+      }
+      m_sCallsignGroupFormat "%3"
+     }
+    }
+    SCR_Faction "{56DEAC40D3C2E623}" {
+     UIInfo SCR_FactionUIInfo "{528C96127F8B6B08}" {
+      Name "OPFOR"
+      m_sNameUpper "OPFOR"
+     }
+     m_iOrder 9
+     m_CallsignInfo SCR_FactionCallsignInfo "{5DA0F2A67DFB8809}" {
+      m_bIsAssignedRandomly 0
+      m_aSquadNames {
+       SCR_CallsignInfo "{55CCB79287E901BC}" {
+        m_sCallsign "1PLT"
+       }
+       SCR_CallsignInfo "{55CCB79287936EBD}" {
+        m_sCallsign "1-1"
+       }
+       SCR_CallsignInfo "{55CCB79287BAFBD6}" {
+        m_sCallsign "1-2"
+       }
+       SCR_CallsignInfo "{55CCB79287A4D7B6}" {
+        m_sCallsign "1-3"
+       }
+      }
+      m_sCallsignGroupFormat "%3"
+     }
+    }
+    SCR_Faction "{56DEAC40D132400B}" {
+     UIInfo SCR_FactionUIInfo "{5570936866E0AD08}" {
+      Name "INDFOR"
+      Icon "{FB266CDD4502D60B}UI/Textures/Editor/EditableEntities/Factions/EditableEntity_Faction_Fia.edds"
+      m_sNameUpper "INDFOR"
+     }
+     m_iOrder 8
+     m_sFactionFlag "{FB266CDD4502D60B}UI/Textures/Editor/EditableEntities/Factions/EditableEntity_Faction_Fia.edds"
+     m_FactionFlagMaterial "{B7A02313829700F9}Assets/Props/Fabric/Flags/Data/Flag_1_2_Green.emat"
+     m_CallsignInfo SCR_FactionCallsignInfo "{60A6B21E18F28741}" {
+      m_bIsAssignedRandomly 0
+      m_aSquadNames {
+       SCR_CallsignInfo "{58B2B630FDD64B6D}" {
+        m_sCallsign "Cell Lead"
+       }
+       SCR_CallsignInfo "{58B2B630FDD64B53}" {
+        m_sCallsign "Cell 1"
+       }
+       SCR_CallsignInfo "{58B2B630FDD64B51}" {
+        m_sCallsign "Cell 2"
+       }
+       SCR_CallsignInfo "{58B2B630FDD64B50}" {
+        m_sCallsign "Cell 3"
+       }
+      }
+      m_sCallsignGroupFormat "%3"
+     }
+    }
+    SCR_Faction "{607AA5C7A94496DA}" {
+     UIInfo SCR_FactionUIInfo "{56B49118D8D0A9C5}" {
+      Icon "{C8565602E0F422C5}Images/UI/Zeus GearScript Factions/CIV_NATO.edds"
+     }
+     "Identity of soldiers" FactionIdentity "{60DCEDE56D10632C}" : "{7BE453211ACB5F01}Configs/Identities/FactionIdentity_COAL.conf" {
+     }
+     m_iOrder 7
+     m_sFactionFlag "{C8565602E0F422C5}Images/UI/Zeus GearScript Factions/CIV_NATO.edds"
+     m_FactionFlagMaterial "{936E6C67A71A9421}Assets/Props/Fabric/Flags/Data/Flag_2_3_White.emat"
+     m_CallsignInfo SCR_FactionCallsignInfo "{607A9A9E40D70F6E}" {
+      m_sCallsignGroupFormat "%3"
+     }
+     m_sFactionRadioEncryptionKey "chickenNuggets"
+    }
+    SCR_Faction "{5978B9CE6585BBE8}" {
+     UIInfo SCR_FactionUIInfo "{5977478D568C0938}" {
+      Name "OPFOR"
+      m_sNameUpper "OPFOR"
+     }
+     m_iOrder 6
+     m_CallsignInfo SCR_FactionCallsignInfo "{5977478D568C093C}" {
+      m_bIsAssignedRandomly 0
+      m_aSquadNames {
+       SCR_CallsignInfo "{5977478D568C092E}" {
+        m_sCallsign "1PLT"
+       }
+       SCR_CallsignInfo "{5977478D568C092D}" {
+        m_sCallsign "1-1"
+       }
+       SCR_CallsignInfo "{5977478D568D935E}" {
+        m_sCallsign "1-2"
+       }
+       SCR_CallsignInfo "{5977478D568D935F}" {
+        m_sCallsign "1-3"
+       }
+      }
+      m_sCallsignGroupFormat "%3"
+     }
+    }
+    SCR_Faction "{5CC8DE37E1FF0F7A}" {
+     UIInfo SCR_FactionUIInfo "{5CC8B5EDA0CDBD62}" {
+      Name "BLUFOR"
+      m_sNameUpper "BLUFOR"
+     }
+     m_iOrder 5
+     m_CallsignInfo SCR_FactionCallsignInfo "{5CC8BB97E017CDBC}" {
+      m_aSquadNames {
+       SCR_CallsignInfo "{55CCB792D10AD8F4}" {
+        m_sCallsign "1PLT"
+       }
+       SCR_CallsignInfo "{55CCB792D13759D8}" {
+        m_sCallsign "1-1"
+       }
+       SCR_CallsignInfo "{55CCB792D1218E95}" {
+        m_sCallsign "1-2"
+       }
+       SCR_CallsignInfo "{55CCB792D0C8B3CE}" {
+        m_sCallsign "1-3"
+       }
+      }
+      m_sCallsignGroupFormat "%3"
+     }
+    }
+    SCR_Faction "{623962205CE2B89C}" {
+     UIInfo SCR_FactionUIInfo "{62394AA4B52816D2}" {
+      Name "INDFOR"
+      m_sNameUpper "INDFOR"
+     }
+     m_iOrder 4
+     m_sFactionRadioEncryptionKey "candleSauce"
+    }
+    SCR_Faction "{61500924662B6062}" {
+     FactionKey "SPEC"
+     FactionColor 0.392 0.157 0.624 1
+     UIInfo SCR_FactionUIInfo "{615009275A4B9FE7}" {
+      Name "Spectator"
+      Icon "{BB790255945032F8}UI/data/Spec_Eye_BCR.edds"
+      m_sNameUpper "SPECTATOR"
+     }
+     "Identity of soldiers" FactionIdentity "{570D128F4022EF5A}" {
+      VisualIdentityArray {
+       VisualIdentity "{570CE64C784286B5}" {
+        Head "{2FC2A1CE68435471}Prefabs/Characters/Heads/Head_Invisible.et"
+        Body "{E25DCEC549E17067}Prefabs/Characters/Basebody/CharacterBasebody_Invisible.et"
+       }
+       VisualIdentity "{570CFDC06CAAD480}" {
+        Head "{2FC2A1CE68435471}Prefabs/Characters/Heads/Head_Invisible.et"
+        Body "{E25DCEC549E17067}Prefabs/Characters/Basebody/CharacterBasebody_Invisible.et"
+       }
+       VisualIdentity "{570CFDC05A2BFCE8}" {
+        Head "{2FC2A1CE68435471}Prefabs/Characters/Heads/Head_Invisible.et"
+        Body "{E25DCEC549E17067}Prefabs/Characters/Basebody/CharacterBasebody_Invisible.et"
+       }
+       VisualIdentity "{570CE64C790A3C7D}" {
+        Head "{2FC2A1CE68435471}Prefabs/Characters/Heads/Head_Invisible.et"
+        Body "{E25DCEC549E17067}Prefabs/Characters/Basebody/CharacterBasebody_Invisible.et"
+       }
+       VisualIdentity "{570CFDC037CCBCD3}" {
+        Head "{2FC2A1CE68435471}Prefabs/Characters/Heads/Head_Invisible.et"
+        Body "{E25DCEC549E17067}Prefabs/Characters/Basebody/CharacterBasebody_Invisible.et"
+       }
+       VisualIdentity "{570CFDC1C8B17A43}" {
+        Head "{2FC2A1CE68435471}Prefabs/Characters/Heads/Head_Invisible.et"
+        Body "{E25DCEC549E17067}Prefabs/Characters/Basebody/CharacterBasebody_Invisible.et"
+       }
+       VisualIdentity "{570EDB838B8AC563}" {
+        Head "{2FC2A1CE68435471}Prefabs/Characters/Heads/Head_Invisible.et"
+        Body "{E25DCEC549E17067}Prefabs/Characters/Basebody/CharacterBasebody_Invisible.et"
+       }
+       VisualIdentity "{588508C19AA51746}" {
+        Head "{2FC2A1CE68435471}Prefabs/Characters/Heads/Head_Invisible.et"
+        Body "{E25DCEC549E17067}Prefabs/Characters/Basebody/CharacterBasebody_Invisible.et"
+       }
+       VisualIdentity "{588508C199AD5966}" {
+        Head "{2FC2A1CE68435471}Prefabs/Characters/Heads/Head_Invisible.et"
+        Body "{E25DCEC549E17067}Prefabs/Characters/Basebody/CharacterBasebody_Invisible.et"
+       }
+      }
+     }
+     m_iOrder 3
+     m_OutlineFactionColor 0.392 0.157 0.624 1
+     m_NotificationFactionColor 0.392 0.157 0.624 1
+     m_NotificationTextFactionColor 0.392 0.157 0.624 1
+     m_bIsPlayable 0
+     m_bShowInWelcomeScreenIfNonPlayable 0
+     m_bIsMilitary 0
+     m_sFactionFlag "{BB790255945032F8}UI/data/Spec_Eye_BCR.edds"
+     m_FactionFlagMaterial "{E3BB2EF7F600DD28}Assets/Props/Fabric/Flags/Data/Flag_2_3_CIVILIAN.emat"
+     m_FactionLabel FACTION_CIV
+     m_aFriendlyFactionsIds +{
+     }
+     m_sFactionRadioEncryptionKey "Sandbox"
+     m_iFactionRadioFrequency 58000
+     m_aEntityCatalogs {
+      SCR_EntityCatalogMultiList "{607A9A9FE55EDF5F}" {
+       m_eEntityCatalogType ITEM
+      }
+      SCR_EntityCatalogMultiList "{607A9A9FFA54DFE9}" {
+       m_eEntityCatalogType CHARACTER
+      }
+      SCR_EntityCatalogMultiList "{61C8ED1193902596}" {
+       m_eEntityCatalogType VEHICLE
+      }
+      SCR_EntityCatalogMultiList "{61C8ED1182211903}" {
+       m_eEntityCatalogType GROUP
+      }
+      SCR_EntityCatalogMultiList "{607A9A9FFBDA2F92}" {
+       m_eEntityCatalogType WEAPONS_TRIPOD
+      }
+     }
+     m_sGroupFlagsImageSet "{D7E06968B5F9FC92}UI/Textures/GroupManagement/FlagIcons/GroupFlagsCivilian.imageset"
+     m_sGroupFlagsImageSetOutlines "{824ADD5E7A28B03E}UI/Textures/GroupManagement/FlagIcons/GroupFlagsCivilian-outline.imageset"
+     m_aFlagNames +{
+     }
+     m_sFactionBackground "{781301447441F404}UI/Textures/DeployMenu/Loadout-BG/Loadout_BG_Civilian.imageset"
+    }
+    SCR_Faction "{628B22E9B4056C88}" {
+     m_CallsignInfo SCR_FactionCallsignInfo "{5DA0F2A6677ADA9E}" {
+      m_aSquadNames {
+       SCR_CallsignInfo "{55CCB792D10AD8F4}" {
+        m_sCallsign "COY"
+       }
+       SCR_CallsignInfo "{55CCB792D13759D8}" {
+        m_sCallsign "Medical"
+       }
+       SCR_CallsignInfo "{55CCB792D1218E95}" {
+        m_sCallsign "1PLT"
+       }
+       SCR_CallsignInfo "{55CCB792D0C8B3CE}" {
+        m_sCallsign "1-1"
+       }
+       SCR_CallsignInfo "{652B551EE98F16AB}" {
+        m_sCallsign "1-2"
+       }
+       SCR_CallsignInfo "{652B551EE9EF735C}" {
+        m_sCallsign "1-3"
+       }
+       SCR_CallsignInfo "{652B551EE9C113C1}" {
+        m_sCallsign "2PLT"
+       }
+       SCR_CallsignInfo "{652B551EE820BD39}" {
+        m_sCallsign "2-1"
+       }
+       SCR_CallsignInfo "{652B551EE8027F73}" {
+        m_sCallsign "2-2"
+       }
+       SCR_CallsignInfo "{652B551EE8640E58}" {
+        m_sCallsign "2-3"
+       }
+       SCR_CallsignInfo "{652B551EE84683C0}" {
+        m_sCallsign "MMG"
+       }
+       SCR_CallsignInfo "{652B551EE858D6BE}" {
+        m_sCallsign "Engi Team"
+       }
+       SCR_CallsignInfo "{652B551EE8A235E6}" {
+        m_sCallsign "LAV"
+       }
+       SCR_CallsignInfo "{652B551EC6CDCC3B}" {
+        m_sCallsign "AH-6M"
+       }
+      }
+     }
+    }
+    SCR_Faction "{628C2D2BFC8C6447}" {
+     m_CallsignInfo SCR_FactionCallsignInfo "{5DA0F2A67DFB8809}" {
+      m_aSquadNames {
+       SCR_CallsignInfo "{55CCB79287E901BC}" {
+        m_sCallsign "1PLT"
+       }
+       SCR_CallsignInfo "{55CCB79287936EBD}" {
+        m_sCallsign "Medical"
+       }
+       SCR_CallsignInfo "{55CCB79287BAFBD6}" {
+        m_sCallsign "1-1"
+       }
+       SCR_CallsignInfo "{55CCB79287A4D7B6}" {
+        m_sCallsign "1-2"
+       }
+       SCR_CallsignInfo "{652B551ECEAE37B1}" {
+        m_sCallsign "1-3"
+       }
+       SCR_CallsignInfo "{652B551ED713CE4A}" {
+        m_sCallsign "1-4"
+       }
+       SCR_CallsignInfo "{652B551F3A82FE1B}" {
+        m_sCallsign "HMG Team"
+       }
+       SCR_CallsignInfo "{652B551F3F527449}" {
+        m_sCallsign "Engi Team"
+       }
+       SCR_CallsignInfo "{652B551F3C96B6C3}" {
+        m_sCallsign "Sniper"
+       }
+      }
+     }
+    }
+    SCR_Faction "{628CDE9209CA3FF9}" {
+     FactionKey "INDFOR"
+     FactionColor 0 0.44 0.078 1
+     UIInfo SCR_FactionUIInfo "{5570936866E0AD08}" {
+      Name "INDFOR"
+      Icon "{EFA0BA63504B1230}Images/UI/Zeus GearScript Factions/INDFOR_NATO.edds"
+      m_sNameUpper "INDFOR"
+     }
+     "Identity of soldiers" FactionIdentity "{62D8F84F08F0FEAC}" : "{7BE453211ACB5F01}Configs/Identities/FactionIdentity_COAL.conf" {
+     }
+     m_iOrder 2
+     m_OutlineFactionColor 0.001 0.082 0.023 1
+     m_NotificationFactionColor 0 0.44 0.078 1
+     m_NotificationTextFactionColor 0 0.296 0.055 1
+     m_bIsPlayable 0
+     m_sFactionFlag "{EFA0BA63504B1230}Images/UI/Zeus GearScript Factions/INDFOR_NATO.edds"
+     m_FactionFlagMaterial "{B7A02313829700F9}Assets/Props/Fabric/Flags/Data/Flag_1_2_Green.emat"
+     m_FactionLabel FACTION_FIA
+     m_CallsignInfo SCR_FactionCallsignInfo "{60A6B21E18F28741}" {
+      m_bIsAssignedRandomly 0
+      m_aCompanyNames {
+       SCR_CallsignInfo "{58B2B630FDD64B73}" {
+       }
+       SCR_CallsignInfo "{58B2B630FDD64B7A}" {
+       }
+       SCR_CallsignInfo "{58B2B630FDD64B78}" {
+       }
+       SCR_CallsignInfo "{58B2B630FDD64B7E}" {
+       }
+       SCR_CallsignInfo "{58B2B630FDD64B7C}" {
+       }
+       SCR_CallsignInfo "{58B2B630FDD64B63}" {
+       }
+       SCR_CallsignInfo "{58B2B630FDD64B61}" {
+       }
+       SCR_CallsignInfo "{58B2B630FDD64B67}" {
+       }
+      }
+      m_aPlatoonNames {
+       SCR_CallsignInfo "{58B2B630FDD64B65}" {
+       }
+       SCR_CallsignInfo "{58B2B630FDD64B6B}" {
+       }
+       SCR_CallsignInfo "{58B2B630FDD64B69}" {
+       }
+       SCR_CallsignInfo "{58B2B630FDD64B6F}" {
+       }
+       SCR_CallsignInfo "{61C8F1ACD8ABED54}" {
+       }
+       SCR_CallsignInfo "{61C8F1ACD8E1FFD7}" {
+       }
+       SCR_CallsignInfo "{61C8F1ACD8255922}" {
+       }
+       SCR_CallsignInfo "{61C8F1ACD876D68B}" {
+       }
+       SCR_CallsignInfo "{61C8F1AC8D5F6E16}" {
+       }
+      }
+      m_aSquadNames {
+       SCR_CallsignInfo "{58B2B630FDD64B6D}" {
+        m_sCallsign "Cell Lead"
+       }
+       SCR_CallsignInfo "{58B2B630FDD64B53}" {
+        m_sCallsign "Cell 1"
+       }
+       SCR_CallsignInfo "{58B2B630FDD64B51}" {
+        m_sCallsign "Cell 2"
+       }
+       SCR_CallsignInfo "{58B2B630FDD64B50}" {
+        m_sCallsign "Cell 3"
+       }
+       SCR_CallsignInfo "{61C8F1ACA9FDB12D}" {
+       }
+      }
+      m_sCallsignGroupFormat "%3"
+      m_sCallsignCharacterFormat "%1-%2%3%4"
+      m_sCallsignCharacterWithRoleFormat "%1-%2%3 %4"
+      m_aCharacterRoleCallsigns {
+       SCR_PlayerLeaderRoleCallsign "{5D9E9ECA7323CF3E}" {
+       }
+      }
+     }
+     m_sFactionRadioEncryptionKey "candleSauce"
+     m_iFactionRadioFrequency 52000
+     m_aEntityCatalogs {
+      SCR_EntityCatalogMultiList "{5C68A0EABE8B7B2A}" {
+       m_eEntityCatalogType ITEM
+      }
+      SCR_EntityCatalog "{62AD6CEE79E1F794}" {
+       m_eEntityCatalogType CHARACTER
+      }
+      SCR_EntityCatalog "{62AD6CEE7975FCA2}" {
+       m_eEntityCatalogType VEHICLE
+      }
+      SCR_EntityCatalog "{62AD6CEE7ECC0787}" {
+       m_eEntityCatalogType WEAPONS_TRIPOD
+      }
+      SCR_EntityCatalog "{62AD6CEE7DED463C}" {
+       m_eEntityCatalogType GROUP
+      }
+     }
+     m_sGroupFlagsImageSet "{301FC1A2A46D3E0D}UI/Textures/GroupManagement/FlagIcons/GroupFlagsIndfor.imageset"
+     m_sGroupFlagsImageSetOutlines "{C07D82625600BA21}UI/Textures/GroupManagement/FlagIcons/GroupFlagsIndfor-outline.imageset"
+     m_aFlagNames +{
+     }
+     m_sFactionBackground "{81BF3B1DCC106577}UI/Textures/DeployMenu/Loadout-BG/Loadout_BG_FIA.imageset"
+    }
+   }
+  }
+ }
+}

--- a/Worlds/COALobby/Gulfcoast/Harry_TVT_SpanishMoss_Layers/aaInit.layer
+++ b/Worlds/COALobby/Gulfcoast/Harry_TVT_SpanishMoss_Layers/aaInit.layer
@@ -7,6 +7,8 @@ CRF_Gamemode CRF_Lobby1 : "{6A996BBFCEB37E78}Prefabs/MP/Modes/Lobby/CRF_Lobby.et
    Enabled 0
   }
   CRF_SearchAndDestroyGameModeComponent "{652B550D75FDCFE2}" {
+   attackingSide "BLUFOR"
+   defendingSide "OPFOR"
    hideMapMarkers 1
   }
   SCR_AdditionalGameModeSettingsComponent "{6170E11C3C452ACC}" {
@@ -122,10 +124,10 @@ CRF_Gamemode CRF_Lobby1 : "{6A996BBFCEB37E78}Prefabs/MP/Modes/Lobby/CRF_Lobby.et
  }
  m_iFactionOneRatio 3
  m_sFactionOneKey "BLU"
- m_iFactionTwoRatio 3
+ m_iFactionTwoRatio 2
  m_sFactionTwoKey "OPF"
  {
-  SCR_FactionManager {
+  SCR_FactionManager "653D280F31759483" {
    ID "632A77473B3CC3A8"
    Factions {
     SCR_Faction "{56DEAC40D2DBC8B1}" {
@@ -135,11 +137,11 @@ CRF_Gamemode CRF_Lobby1 : "{6A996BBFCEB37E78}Prefabs/MP/Modes/Lobby/CRF_Lobby.et
      }
      "Identity of soldiers" FactionIdentity "{570D128F4022EF5A}" {
       SocialIdentity SocialIdentity "{56E4EBD9F0C03530}" {
-       NamesConfig +{
+       NamesConfig {
        }
-       AliasesConfig +{
+       AliasesConfig {
        }
-       SurnamesConfig +{
+       SurnamesConfig {
        }
       }
      }
@@ -344,7 +346,7 @@ CRF_Gamemode CRF_Lobby1 : "{6A996BBFCEB37E78}Prefabs/MP/Modes/Lobby/CRF_Lobby.et
      m_sFactionFlag "{BB790255945032F8}UI/data/Spec_Eye_BCR.edds"
      m_FactionFlagMaterial "{E3BB2EF7F600DD28}Assets/Props/Fabric/Flags/Data/Flag_2_3_CIVILIAN.emat"
      m_FactionLabel FACTION_CIV
-     m_aFriendlyFactionsIds +{
+     m_aFriendlyFactionsIds {
      }
      m_sFactionRadioEncryptionKey "Sandbox"
      m_iFactionRadioFrequency 58000
@@ -367,7 +369,7 @@ CRF_Gamemode CRF_Lobby1 : "{6A996BBFCEB37E78}Prefabs/MP/Modes/Lobby/CRF_Lobby.et
      }
      m_sGroupFlagsImageSet "{D7E06968B5F9FC92}UI/Textures/GroupManagement/FlagIcons/GroupFlagsCivilian.imageset"
      m_sGroupFlagsImageSetOutlines "{824ADD5E7A28B03E}UI/Textures/GroupManagement/FlagIcons/GroupFlagsCivilian-outline.imageset"
-     m_aFlagNames +{
+     m_aFlagNames {
      }
      m_sFactionBackground "{781301447441F404}UI/Textures/DeployMenu/Loadout-BG/Loadout_BG_Civilian.imageset"
     }
@@ -406,9 +408,6 @@ CRF_Gamemode CRF_Lobby1 : "{6A996BBFCEB37E78}Prefabs/MP/Modes/Lobby/CRF_Lobby.et
        }
        SCR_CallsignInfo "{652B551EE84683C0}" {
         m_sCallsign "MMG"
-       }
-       SCR_CallsignInfo "{652B551EE858D6BE}" {
-        m_sCallsign "Engi Team"
        }
        SCR_CallsignInfo "{652B551EE8A235E6}" {
         m_sCallsign "LAV"
@@ -555,7 +554,7 @@ CRF_Gamemode CRF_Lobby1 : "{6A996BBFCEB37E78}Prefabs/MP/Modes/Lobby/CRF_Lobby.et
      }
      m_sGroupFlagsImageSet "{301FC1A2A46D3E0D}UI/Textures/GroupManagement/FlagIcons/GroupFlagsIndfor.imageset"
      m_sGroupFlagsImageSetOutlines "{C07D82625600BA21}UI/Textures/GroupManagement/FlagIcons/GroupFlagsIndfor-outline.imageset"
-     m_aFlagNames +{
+     m_aFlagNames {
      }
      m_sFactionBackground "{81BF3B1DCC106577}UI/Textures/DeployMenu/Loadout-BG/Loadout_BG_FIA.imageset"
     }

--- a/Worlds/COALobby/Gulfcoast/Harry_TVT_SpanishMoss_Layers/assets.layer
+++ b/Worlds/COALobby/Gulfcoast/Harry_TVT_SpanishMoss_Layers/assets.layer
@@ -1,0 +1,166 @@
+$grp SCR_BaseTriggerEntity {
+ truck1 {
+  coords 14000.345 21.219 2576.006
+  angleY -92.475
+  userScript "	string ural = \"{16C1F16C9B053801}Prefabs/Vehicles/Wheeled/Ural4320/Ural4320_transport.et\";"\
+  "	string truck = \"{F1FBD0972FA5FE09}Prefabs/Vehicles/Wheeled/M923A1/M923A1_transport.et\";"\
+  "	"\
+  "	void spawnthings()"\
+  "	{"\
+  "		EntitySpawnParams spawnParams = new EntitySpawnParams();"\
+  "		spawnParams.TransformMode = ETransformMode.WORLD;"\
+  "		"\
+  "		for (int i = 1; i <= 4; i++) "\
+  "		{"\
+  "			string uralName = \"ural\" + i.ToString();"\
+  "			IEntity spawnural = GetGame().GetWorld().FindEntityByName(uralName);"\
+  "			"\
+  "			spawnParams.Transform[3] = spawnural.GetOrigin();"\
+  "			GetGame().SpawnEntityPrefab(Resource.Load(ural),GetGame().GetWorld(),spawnParams);"\
+  "		}"\
+  "		"\
+  "		for (int i = 1; i <= 4; i++) "\
+  "		{"\
+  "			string truckName = \"truck\" + i.ToString();"\
+  "			IEntity spawntruck = GetGame().GetWorld().FindEntityByName(truckName);"\
+  "			"\
+  "			spawnParams.Transform[3] = spawntruck.GetOrigin();"\
+  "			GetGame().SpawnEntityPrefab(Resource.Load(truck),GetGame().GetWorld(),spawnParams);"\
+  "		}"\
+  "	}"
+  EOnInit ""\
+  "		super.EOnInit(owner);"\
+  "		GetGame().GetCallqueue().CallLater(spawnthings, 3000, false);"\
+  "	"
+ }
+ truck2 {
+  coords 13986.96 21.219 2575.427
+  angleY -92.475
+ }
+ truck3 {
+  coords 13973.455 21.219 2574.844
+  angleY -92.475
+ }
+ truck4 {
+  coords 13958.09 21.219 2574.179
+  angleY -92.475
+ }
+ ural1 {
+  coords 14079.94 11.437 4311.55
+  angleY 86.512
+ }
+ ural2 {
+  coords 14079.434 11.437 4319.887
+  angleY 86.512
+ }
+ ural3 {
+  coords 14078.842 11.437 4329.573
+  angleY 86.512
+ }
+ ural4 {
+  coords 14078.118 11.437 4341.408
+  angleY 86.512
+ }
+}
+$grp SCR_VehicleSpawn {
+ engiTruck1 {
+  coords 14062.818 11.437 4354.06
+  angleY -3.436
+  m_rnPrefab "{1328D98FC897D948}Prefabs/Vehicles/Wheeled/Ural4320/Ural4320_engineer_OPFOR.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+ engiTruck2 {
+  coords 14050.041 11.437 4354.108
+  angleY -3.436
+  m_rnPrefab "{1328D98FC897D948}Prefabs/Vehicles/Wheeled/Ural4320/Ural4320_engineer_OPFOR.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+ opAmb {
+  coords 14019.36 11.437 4359.112
+  m_rnPrefab "{43C4AF1EEBD001CE}Prefabs/Vehicles/Wheeled/UAZ452/UAZ452_ambulance.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+ bluAmb {
+  coords 13981.262 21.435 2364.512
+  angleY 18.942
+  m_rnPrefab "{00C9BBE426F7D459}Prefabs/Vehicles/Wheeled/M998/M997_maxi_ambulance.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+ lav1 {
+  coords 13986.601 21.521 2378.277
+  angleY 28.613
+  m_rnPrefab "{0FBF8F010F81A4E5}Prefabs/Vehicles/Wheeled/LAV25/LAV25.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+ jeep1 {
+  coords 13946.832 21.219 2573.787
+  angleY 176.691
+  m_rnPrefab "{F649585ABB3706C4}Prefabs/Vehicles/Wheeled/M151A2/M151A2.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+ jeep2 {
+  coords 13938.979 21.219 2573.333
+  angleY 176.691
+  m_rnPrefab "{F649585ABB3706C4}Prefabs/Vehicles/Wheeled/M151A2/M151A2.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+ jeep3 {
+  coords 13929.099 21.219 2572.762
+  angleY 176.691
+  m_rnPrefab "{F649585ABB3706C4}Prefabs/Vehicles/Wheeled/M151A2/M151A2.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+ uaz1 {
+  coords 14024.487 11.437 4386.132
+  angleY 176.691
+  m_rnPrefab "{259EE7B78C51B624}Prefabs/Vehicles/Wheeled/UAZ469/UAZ469.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+ uaz2 {
+  coords 14031.419 11.437 4386.533
+  angleY 176.691
+  m_rnPrefab "{259EE7B78C51B624}Prefabs/Vehicles/Wheeled/UAZ469/UAZ469.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+ uaz3 {
+  coords 14039.635 11.437 4387.008
+  angleY 176.691
+  m_rnPrefab "{259EE7B78C51B624}Prefabs/Vehicles/Wheeled/UAZ469/UAZ469.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+}
+GenericEntity : "{190CC54D175F52CB}Prefabs/Props/Military/SupplyBox/SupplyShippingContainers/SupplyShippingContainers_01/SupplyShippingContainers_01_10ft.et" {
+ components {
+  SCR_ResourceComponent "{5D247A59598D71AE}" {
+   m_aContainers {
+    SCR_ResourceContainer "{5D3CDAE74F1A6127}" {
+     m_fResourceValueCurrent 4000
+     m_fResourceValueMax 4000
+    }
+   }
+  }
+ }
+ coords 14056.932 11.437 4353.253
+}
+StaticModelEntity : "{D4ABEC6A0DB2E253}PrefabsEditable/Auto/Compositions/Misc/SubCompositions/Utility/E_Helipad_Lights_US_01.et" {
+ coords 14080.866 0.901 2408.157
+ {
+  SCR_VehicleSpawn {
+   coords -0.441 0.405 -0.351
+   m_rnPrefab "{A317D959A4248173}Prefabs/Vehicles/Helicopters/AH6M/AH6M_GAU19.et"
+   respawnDelay 10000
+   firstSpawn 1
+  }
+ }
+}

--- a/Worlds/COALobby/Gulfcoast/Harry_TVT_SpanishMoss_Layers/blufor.layer
+++ b/Worlds/COALobby/Gulfcoast/Harry_TVT_SpanishMoss_Layers/blufor.layer
@@ -32,23 +32,12 @@ SCR_AIGroup : "{EE91BF23FBC94408}Prefabs/Groups/BLUFOR/Standard/Command/CRF_BLUF
              {
               SCR_AIGroup : "{2F07AC5EE3DE3921}Prefabs/Groups/BLUFOR/Standard/Support/CRF_BLUFOR_MMGTeam_p.et" {
                coords -0.706 0.382 -9.348
-               m_aUnitPrefabSlots {
-                "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{232780260F9004E6}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_MMG_P.et" "{0CF6A9358BCE5E57}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AMMG_P.et"
-               }
                {
-                SCR_AIGroup : "{FDF05DC2E670936E}Prefabs/Groups/BLUFOR/Standard/Support/CRF_BLUFOR_EngiTeam_p.et" {
-                 coords 0.867 0.363 -6.202
-                 m_aUnitPrefabSlots {
-                  "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{0C720583644340B9}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_ComEngi_P.et" "{0C720583644340B9}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_ComEngi_P.et"
-                 }
+                SCR_AIGroup : "{5804AD2759E17E13}Prefabs/Groups/BLUFOR/Standard/Vehicle/CRF_BLUFOR_3manCrew_p.et" {
+                 coords 1.382 2.129 -24.987
                  {
-                  SCR_AIGroup : "{679BC3454FEDD0EE}Prefabs/Groups/BLUFOR/Standard/Vehicle/CRF_BLUFOR_2manCrew_p.et" {
-                   coords -15.974 1.941 -18.849
-                   {
-                    SCR_AIGroup : "{ABEBD4386CA25E24}Prefabs/Groups/BLUFOR/Standard/Vehicle/CRF_BLUFOR_AirCrew_p.et" {
-                     coords -1.985 -0.935 10.635
-                    }
-                   }
+                  SCR_AIGroup : "{ABEBD4386CA25E24}Prefabs/Groups/BLUFOR/Standard/Vehicle/CRF_BLUFOR_AirCrew_p.et" {
+                   coords -18.474 -0.76 10.571
                   }
                  }
                 }

--- a/Worlds/COALobby/Gulfcoast/Harry_TVT_SpanishMoss_Layers/blufor.layer
+++ b/Worlds/COALobby/Gulfcoast/Harry_TVT_SpanishMoss_Layers/blufor.layer
@@ -1,0 +1,70 @@
+SCR_AIGroup : "{EE91BF23FBC94408}Prefabs/Groups/BLUFOR/Standard/Command/CRF_BLUFOR_Company_p.et" {
+ coords 13945.456 21.301 2541.375
+ {
+  SCR_AIGroup : "{D0B17EDF43465305}Prefabs/Groups/BLUFOR/Standard/Support/CRF_BLUFOR_MedicTeam_p.et" {
+   coords 25.512 1.576 -55.062
+   {
+    SCR_AIGroup : "{3D4D53B053964445}Prefabs/Groups/BLUFOR/Standard/Command/CRF_BLUFOR_Platoon_p.et" {
+     coords -21.794 -1.346 34.785
+     {
+      $grp SCR_AIGroup : "{9C45BAF40F909576}Prefabs/Groups/BLUFOR/Standard/Infantry/CRF_BLUFOR_RifleSquad_p.et" {
+       {
+        coords 20.713 -0.313 21.566
+       }
+       {
+        coords 20.713 -0.313 15.36
+       }
+       {
+        coords 20.713 -0.282 8.84
+        {
+         SCR_AIGroup : "{3D4D53B053964445}Prefabs/Groups/BLUFOR/Standard/Command/CRF_BLUFOR_Platoon_p.et" {
+          coords -18.578 0.963 -28.59
+          {
+           $grp SCR_AIGroup : "{9C45BAF40F909576}Prefabs/Groups/BLUFOR/Standard/Infantry/CRF_BLUFOR_RifleSquad_p.et" {
+            {
+             coords 18.579 -0.963 23.923
+            }
+            {
+             coords 18.579 -0.891 17.928
+            }
+            {
+             coords 18.579 -0.748 8.894
+             {
+              SCR_AIGroup : "{2F07AC5EE3DE3921}Prefabs/Groups/BLUFOR/Standard/Support/CRF_BLUFOR_MMGTeam_p.et" {
+               coords -0.706 0.382 -9.348
+               m_aUnitPrefabSlots {
+                "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{232780260F9004E6}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_MMG_P.et" "{0CF6A9358BCE5E57}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AMMG_P.et"
+               }
+               {
+                SCR_AIGroup : "{FDF05DC2E670936E}Prefabs/Groups/BLUFOR/Standard/Support/CRF_BLUFOR_EngiTeam_p.et" {
+                 coords 0.867 0.363 -6.202
+                 m_aUnitPrefabSlots {
+                  "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{0C720583644340B9}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_ComEngi_P.et" "{0C720583644340B9}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_ComEngi_P.et"
+                 }
+                 {
+                  SCR_AIGroup : "{679BC3454FEDD0EE}Prefabs/Groups/BLUFOR/Standard/Vehicle/CRF_BLUFOR_2manCrew_p.et" {
+                   coords -15.974 1.941 -18.849
+                   {
+                    SCR_AIGroup : "{ABEBD4386CA25E24}Prefabs/Groups/BLUFOR/Standard/Vehicle/CRF_BLUFOR_AirCrew_p.et" {
+                     coords -1.985 -0.935 10.635
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+          }
+         }
+        }
+       }
+      }
+     }
+    }
+   }
+  }
+ }
+}

--- a/Worlds/COALobby/Gulfcoast/Harry_TVT_SpanishMoss_Layers/mapMarkers.layer
+++ b/Worlds/COALobby/Gulfcoast/Harry_TVT_SpanishMoss_Layers/mapMarkers.layer
@@ -1,0 +1,167 @@
+$grp PS_ManualMarker : "{054125164E41BAB1}PrefabsEditable/Markers/BLUFORSafeStartBorderMarker.et" {
+ {
+  coords 14160.335 31.951 2714.065
+ }
+ {
+  coords 13960.335 31.951 2714.065
+ }
+ {
+  coords 14060.335 31.951 2714.065
+ }
+ {
+  coords 13860.335 31.951 2714.065
+ }
+}
+$grp PS_ManualMarker : "{7B677FB61E410D0D}PrefabsEditable/Markers/ObjectiveMarker.et" {
+ {
+  coords 14061.871 11.469 4330.616
+  m_MarkerColor 0.502 0 0 1
+  m_sDescription "Bomb Site A"
+  m_aVisibleForFactions {
+   "OPFOR"
+  }
+ }
+ {
+  coords 14288.505 2.719 4275.349
+  m_MarkerColor 0.502 0 0 1
+  m_sDescription "Bomb Site B"
+  m_aVisibleForFactions {
+   "OPFOR"
+  }
+ }
+}
+Tree : "{8F91FCAFE65FCDA6}Prefabs/Vegetation/Tree/t_carpinus_betulus/t_carpinus_betulus_3s.et" {
+ coords 14284.422 0.277 4295.988
+}
+$grp PS_ManualMarker : "{AE820D882CD0ACC4}PrefabsEditable/Markers/OPFORSafeStartBorderMarker.et" {
+ {
+  coords 13631.801 79.96 3794.624
+ }
+ {
+  coords 13831.801 79.96 3794.624
+ }
+ {
+  coords 14031.801 79.96 3794.624
+ }
+ {
+  coords 14231.801 79.96 3794.624
+ }
+ {
+  coords 14431.801 79.96 3794.624
+ }
+ {
+  coords 14631.801 79.96 3794.624
+ }
+ {
+  coords 14831.801 79.96 3794.624
+ }
+ {
+  coords 15031.801 79.96 3794.624
+ }
+}
+$grp PS_ManualMarker : "{BE9E1F90BFFBB48A}PrefabsEditable/Markers/GameZoneMarker.et" {
+ {
+  coords 13516.962 60.865 2033.188
+  angleY 0
+ }
+ {
+  coords 13716.962 60.865 2033.188
+  angleY 0
+ }
+ {
+  coords 13916.962 60.865 2033.188
+  angleY 0
+ }
+ {
+  coords 14116.962 60.865 2033.188
+  angleY 0
+ }
+ {
+  coords 14316.962 60.865 2033.188
+  angleY 0
+ }
+ {
+  coords 14516.962 60.865 2033.188
+  angleY 0
+ }
+ {
+  coords 14716.962 60.865 2033.188
+  angleY 0
+ }
+ {
+  coords 14916.962 60.865 2033.188
+  angleY 0
+ }
+ {
+  coords 13516.962 60.865 2233.188
+  angleY 0
+ }
+ {
+  coords 13516.962 60.865 2433.188
+  angleY 0
+ }
+ {
+  coords 13516.962 60.865 2633.188
+  angleY 0
+ }
+ {
+  coords 13516.962 60.865 2833.188
+  angleY 0
+ }
+ {
+  coords 13516.962 60.865 3033.188
+  angleY 0
+ }
+ {
+  coords 13516.962 60.865 3233.188
+  angleY 0
+ }
+ {
+  coords 13516.962 60.865 3433.188
+  angleY 0
+ }
+ {
+  coords 13516.962 60.865 3633.188
+  angleY 0
+ }
+ {
+  coords 13516.962 60.865 3833.188
+  angleY 0
+ }
+ {
+  coords 13516.962 60.865 4033.188
+  angleY 0
+ }
+ {
+  coords 13516.962 60.865 4233.188
+  angleY 0
+ }
+ {
+  coords 13516.962 60.865 4433.188
+  angleY 0
+ }
+ {
+  coords 13516.962 60.865 4633.188
+  angleY 0
+ }
+ {
+  coords 13516.962 60.865 4833.188
+  angleY 0
+ }
+ {
+  coords 13516.962 60.865 5033.188
+  angleY 0
+ }
+ {
+  coords 13716.962 60.865 5233.188
+  angleY 0
+ }
+ {
+  coords 13916.962 60.865 5433.188
+  angleY 0
+ }
+ {
+  coords 14116.962 60.865 5633.188
+  angleY 0
+ }
+}

--- a/Worlds/COALobby/Gulfcoast/Harry_TVT_SpanishMoss_Layers/obj.layer
+++ b/Worlds/COALobby/Gulfcoast/Harry_TVT_SpanishMoss_Layers/obj.layer
@@ -1,0 +1,10 @@
+$grp SCR_BaseTriggerEntity {
+ aSiteTrigger {
+  coords 14041.563 11.437 4305.621
+  angleY 90
+ }
+ bSiteTrigger {
+  coords 14286.544 2.689 4281.042
+  angleY 90
+ }
+}

--- a/Worlds/COALobby/Gulfcoast/Harry_TVT_SpanishMoss_Layers/opfor.layer
+++ b/Worlds/COALobby/Gulfcoast/Harry_TVT_SpanishMoss_Layers/opfor.layer
@@ -1,0 +1,54 @@
+SCR_AIGroup : "{6524B6A6C69BD3EE}Prefabs/Groups/OPFOR/Standard/Command/CRF_OPFOR_Platoon_p.et" {
+ coords 14092.541 16.574 4403.706
+ {
+  SCR_AIGroup : "{24DA56B34E727840}Prefabs/Groups/OPFOR/Standard/Support/CRF_OPFOR_MedicTeam_p.et" {
+   coords -0.063 -0.134 6.142
+   {
+    $grp SCR_AIGroup : "{92F50F60726EB86D}Prefabs/Groups/OPFOR/Standard/Infantry/CRF_OPFOR_RifleSquad_p.et" {
+     {
+      coords 3.943 -0.478 25.654
+      m_aUnitPrefabSlots {
+       "{9CB623C7B62F4955}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_SL_P.et" "{4E3013C12F58ED57}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_TL_P.et" "{39339B4A6269FD3F}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AR_P.et" "{7C303B9DEA332DF9}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AAR_P.et" "{4E3013C12F58ED57}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_TL_P.et" "{84E3C9CD1D72E121}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AT_P.et" "{C1E0691A952831E7}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AAT_P.et" "{3B1B437AE8CB9AA4}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AA_P.et"
+      }
+     }
+     {
+      coords 3.943 -0.478 31.198
+      m_aUnitPrefabSlots {
+       "{9CB623C7B62F4955}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_SL_P.et" "{4E3013C12F58ED57}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_TL_P.et" "{39339B4A6269FD3F}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AR_P.et" "{7C303B9DEA332DF9}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AAR_P.et" "{4E3013C12F58ED57}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_TL_P.et" "{84E3C9CD1D72E121}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AT_P.et" "{C1E0691A952831E7}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AAT_P.et" "{3B1B437AE8CB9AA4}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AA_P.et"
+      }
+     }
+     {
+      coords 3.943 -0.478 37.367
+      m_aUnitPrefabSlots {
+       "{9CB623C7B62F4955}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_SL_P.et" "{4E3013C12F58ED57}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_TL_P.et" "{39339B4A6269FD3F}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AR_P.et" "{7C303B9DEA332DF9}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AAR_P.et" "{4E3013C12F58ED57}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_TL_P.et" "{84E3C9CD1D72E121}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AT_P.et" "{C1E0691A952831E7}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AAT_P.et" "{3B1B437AE8CB9AA4}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AA_P.et"
+      }
+     }
+     {
+      coords 3.943 -0.478 42.723
+      m_aUnitPrefabSlots {
+       "{9CB623C7B62F4955}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_SL_P.et" "{4E3013C12F58ED57}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_TL_P.et" "{39339B4A6269FD3F}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AR_P.et" "{7C303B9DEA332DF9}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AAR_P.et" "{4E3013C12F58ED57}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_TL_P.et" "{84E3C9CD1D72E121}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AT_P.et" "{C1E0691A952831E7}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AAT_P.et" "{3B1B437AE8CB9AA4}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AA_P.et"
+      }
+      {
+       SCR_AIGroup : "{F703D0D434EF9A1A}Prefabs/Groups/OPFOR/Standard/Support/CRF_OPFOR_HMGTeam_p.et" {
+        coords -4.09 0.301 -34.012
+        m_aUnitPrefabSlots {
+         "{9CB623C7B62F4955}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_SL_P.et" "{32681EB0A399591D}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_HMG_P.et" "{4100FF2BAF7A9D91}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AHMG_P.et"
+        }
+        {
+         SCR_AIGroup : "{2E159CDF28FA27ED}Prefabs/Groups/OPFOR/Standard/Support/CRF_OPFOR_EngiTeam_p.et" {
+          coords -0.061 0.051 -3.5
+          {
+           SCR_AIGroup : "{F1CCAEAE38D65D9E}Prefabs/Groups/OPFOR/Standard/Support/CRF_OPFOR_SniperTeam_p.et" {
+            coords -0.111 -0.124 6.505
+           }
+          }
+         }
+        }
+       }
+      }
+     }
+    }
+   }
+  }
+ }
+}

--- a/Worlds/COALobby/Gulfcoast/Harry_TVT_SpanishMoss_Layers/props.layer
+++ b/Worlds/COALobby/Gulfcoast/Harry_TVT_SpanishMoss_Layers/props.layer
@@ -1,0 +1,8 @@
+$grp Tree : "{8F91FCAFE65FCDA6}Prefabs/Vegetation/Tree/t_carpinus_betulus/t_carpinus_betulus_3s.et" {
+ {
+  coords 14277.091 0.001 4278.917
+ }
+ {
+  coords 14297.265 0.001 4277.864
+ }
+}


### PR DESCRIPTION
Mission Pull Request Template

This Pull Request will:

Add the mission Spanish Moss made by Harry to the repository.

**Mission Creation Checklist:**
- [x] Mission File
- [x] Gearscripts Tested
- [x] Ingame Play Area Markers
- [x] Ingame Briefings to all players
- [x] Side-based briefings  
- [x] Mission .conf file


**Faction(s):**

BLUFOR - US 80s - Attacking
BLUFOR Comp: Motorized Inf
BLUFOR Assets: LAV, AH-6M

OPFOR - USSR 80s - Defending
OPFOR Comp: Infantry with Integrated AA
OPFOR Assets: HMG, Construction Trucks

**Objectives/Win Conditions:**

Blufor: Find and destroy both bomb sites
Opfor: Defend both bomb sites

**Terrain:**

Gulfcoast

**Short mission description:**

This is the search and destroy game mode, but an option to hide the universal bomb site markers has been added. Blufor must search for the bomb sites, while Opfor is aware of where they are and must defend them.

**Slotting Ratio:**

<3:2>

**Time limit:**

<40min>

**Mission Briefing Screenshot:**

![image](https://github.com/user-attachments/assets/d1af4ebb-9542-4741-b475-b06f4e5544c2)

**Design concept/thoughts:**

Trying out a hidden S&D using the new toggle. Also an easier to build mission this week because I got my computer out of a box last night. 

**Other Notes:**

There's construction trucks enabled, and AA in the demo slot on Opfor. Opfor has 4 engi's to compensate the explosive diff. HMG will be an important balance point. 
