### PR TITLE
Wait For Full Gear Initilization Before We Initilize Player

### DIFF
--- a/Configs/System/chimeraMenus.conf
+++ b/Configs/System/chimeraMenus.conf
@@ -7,7 +7,7 @@ MenuManager {
   }
   MenuPreset EditorAttributesDialog {
   }
-  MenuPreset CoalAdminMenu {
+  MenuPreset CRF_AdminMenu {
    Layout "{EC85C0A243D90BB7}UI/layouts/Menus/PauseMenu/AdminMenu.layout"
    ActionContext "MenuWithEditorContext"
    Class "CRF_AdminMenu"
@@ -36,6 +36,10 @@ MenuManager {
    Layout "{FDCDD64F28A1B925}UI/Respawn/CRF_Respawn.layout"
    ActionContext "SpectatorContext"
    Class "CRF_RespawnMenu"
+  }
+  MenuPreset CRF_CharacterLoading {
+   Layout "{0AF7559B6D2A1B2C}UI/layouts/Menus/Common/Loading_Character.layout"
+   Class "CRF_CharacterLoading"
   }
  }
 }

--- a/UI/layouts/Menus/Common/Loading_Character.layout
+++ b/UI/layouts/Menus/Common/Loading_Character.layout
@@ -1,0 +1,69 @@
+FrameWidgetClass {
+ Name "rootFrame"
+ {
+  ImageWidgetClass "{655776471F9009D1}" {
+   Name "m_Background"
+   Slot FrameWidgetSlot "{655776471F900627}" {
+    Anchor 0 0 1 1
+    PositionX 272.434
+    PositionY 180.194
+    SizeX -1820
+    OffsetRight 0
+    SizeY -1050
+    OffsetBottom 0
+   }
+   Color 0 0 0 1
+   Size 256 256
+   Mask "{8EE474586CD656CE}Common/Postprocess/HDR/HDR_MeasureArea_01_Mask.edds"
+   "Transition width" 0.36
+   Progress 0.62
+   "Mask Mode" "Include Below"
+   "Shadow Color" 0 0 0 0.6353
+  }
+  TextWidgetClass "{6557764770ABEBC9}" {
+   Name "m_InitilizationText"
+   Slot FrameWidgetSlot "{6557764770ABE82D}" {
+    Anchor 0.5 0.5 0.5 0.5
+    PositionX -960
+    OffsetLeft -960
+    PositionY -540
+    OffsetTop -540
+    SizeX 1920
+    OffsetRight -960
+    SizeY 854.28
+    OffsetBottom -314.28
+   }
+   Color 0.761 0.386 0.078 1
+   Text "Character Initialization In Progress..."
+   "Font Size" 42
+   "Min Font Size" 42
+   "Horizontal Alignment" Center
+   "Vertical Alignment" Center
+   Wrap 1
+  }
+  ImageWidgetClass "{65577658D9644857}" {
+   Name "m_LoadingIcon"
+   Slot FrameWidgetSlot "{65577658D96448B3}" {
+    Anchor 0.5 0.5 0.5 0.5
+    PositionX -113.28
+    OffsetLeft -113.28
+    PositionY -57.24
+    OffsetTop -57.24
+    SizeX 226.56
+    OffsetRight -113.28
+    SizeY 225.72
+    OffsetBottom -168.48
+   }
+   Color 0.761 0.386 0.078 1
+   components {
+    SCR_SpinningWidgetComponent "{655776580646776F}" {
+    }
+   }
+   Texture "{94A2AACD460E517C}UI/Textures/Loading/loadingSpinner_128_UI.edds"
+   Size 128 128
+   "Transition width" 0.531
+   Progress 0.561
+   "Mask Mode" "Include Below"
+  }
+ }
+}

--- a/UI/layouts/Menus/Common/Loading_Character.layout.meta
+++ b/UI/layouts/Menus/Common/Loading_Character.layout.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{0AF7559B6D2A1B2C}UI/layouts/Menus/Common/Loading Character.layout"
+ Configurations {
+  LayoutResourceClass PC {
+  }
+  LayoutResourceClass XBOX_ONE : PC {
+  }
+  LayoutResourceClass XBOX_SERIES : PC {
+  }
+  LayoutResourceClass PS4 : PC {
+  }
+  LayoutResourceClass PS5 : PC {
+  }
+  LayoutResourceClass HEADLESS : PC {
+  }
+  LayoutResourceClass Xbox : PC {
+  }
+ }
+}

--- a/scripts/Game/GameMode/FrontLine/CRF_Frontline_PlayerController.c
+++ b/scripts/Game/GameMode/FrontLine/CRF_Frontline_PlayerController.c
@@ -1,0 +1,53 @@
+modded class CRF_PlayerControllerManager
+{
+	/**
+	 * Update map markers for objectives in Frontline gamemode
+	 * @param zoneStatus - Array of zone status strings
+	 * @param zoneObjectNames - Array of zone object names
+	 * @param bluforSide - Blue force faction key
+	 * @param opforSide - Opposing force faction key
+	 */
+	void UpdateMapMarkers(array<string> zoneStatus, array<string> zoneObjectNames, FactionKey bluforSide, FactionKey opforSide)
+	{
+		RemoveALLScriptedMarkers();
+
+		foreach (int i, string zoneName : zoneObjectNames)
+		{
+			string status = zoneStatus[i];
+			string imageTexture;
+			int imageColor;
+
+			// Parse zone status
+			array<string> zoneStatusArray = {};
+			status.Split(":", zoneStatusArray, false);
+
+			string zoneLocked = zoneStatusArray[1];
+			FactionKey zoneFactionStored = zoneStatusArray[2];
+
+			// Select image based on zone index
+			switch (i)
+			{
+				case 0: {imageTexture = "{21A2A457BD0E42C1}UI\Objectives\A.edds"; break; };
+				case 1: {imageTexture = "{7F4A8D140283CCCE}UI\Objectives\B.edds"; break; };
+				case 2: {imageTexture = "{8B42CA8C0F5EA4BA}UI\Objectives\C.edds"; break; };
+				case 3: {imageTexture = "{C29ADF937D98D0D0}UI\Objectives\D.edds"; break; };
+				case 4: {imageTexture = "{3692980B7045B8A4}UI\Objectives\E.edds"; break; };
+			}
+
+			// Add lock marker if zone is locked
+			if (zoneLocked == "Locked")
+				AddScriptedMarker(zoneName, "0 0 0", 0, "", "{91427B7866707601}UI\Objectives\lock.edds", 50, ARGB(255, 142, 142, 142));
+
+			// Set color based on controlling faction
+			switch (zoneFactionStored)
+			{
+				case bluforSide: {imageColor = ARGB(255, 0, 25, 225); break; }; // Blufor
+				case opforSide: {imageColor = ARGB(255, 225, 25, 0); break; }; // Opfor
+				default: {imageColor = ARGB(255, 225, 225, 225); break; }; // Uncaptured
+			}
+
+			// Add zone marker
+			AddScriptedMarker(zoneName, "0 0 0", 0, "", imageTexture, 45, imageColor);
+		}
+	}
+}

--- a/scripts/Game/Systems/Core/CRF_PlayableCharacter.c
+++ b/scripts/Game/Systems/Core/CRF_PlayableCharacter.c
@@ -16,6 +16,7 @@ class CRF_PlayableCharacter : ScriptComponent
 
 	// State variables
 	protected bool m_bIsSlotSpawned = false;
+	protected bool m_bGearscriptCompleted = false;
 	
 	// Component references
 	protected CRF_Gamemode m_Gamemode;
@@ -66,6 +67,18 @@ class CRF_PlayableCharacter : ScriptComponent
 	void SetIsSlotSpawned()
 	{
 		m_bIsSlotSpawned = true;
+	}
+	
+	//------------------------------------------------------------------------------------------------
+	void SetGearscriptCompleted()
+	{
+		m_bGearscriptCompleted = true;
+	}
+	
+	//------------------------------------------------------------------------------------------------
+	bool GetGearscriptCompleted()
+	{
+		return m_bGearscriptCompleted;
 	}
 	
 	//------------------------------------------------------------------------------------------------

--- a/scripts/Game/Systems/Core/Containers & Configs/CRF_Enums.c
+++ b/scripts/Game/Systems/Core/Containers & Configs/CRF_Enums.c
@@ -204,6 +204,21 @@ class CRF_RoleHelper
 }
 
 //------------------------------------------------------------------------------------
+// Enumerations for menus
+//------------------------------------------------------------------------------------
+
+modded enum ChimeraMenuPreset : ScriptMenuPresetEnum
+{
+	CRF_AARMenu,
+	CRF_AdminMenu,
+	CRF_PreviewMenu,
+	CRF_RespawnMenu,
+	CRF_SlottingMenu,
+	CRF_SpectatorMenu,
+	CRF_CharacterLoading
+}
+
+//------------------------------------------------------------------------------------
 // Enumerations for game state tracking
 //------------------------------------------------------------------------------------
 

--- a/scripts/Game/Systems/Core/Managers/CRF_GamemodeManager.c
+++ b/scripts/Game/Systems/Core/Managers/CRF_GamemodeManager.c
@@ -13,7 +13,6 @@ class CRF_GamemodeManager : SCR_BaseGameModeComponent
 	protected CRF_Gamemode m_Gamemode;
 	protected CRF_SlottingManager m_SlottingManager;
 	protected CRF_SafestartManager m_SafestartManager;
-	protected CRF_RplBroadcastManager m_RplBroadcastManager;
 	protected SCR_GroupsManagerComponent m_GroupsManagerComponent;
 	protected CRF_AdminMenuManager m_AdminMenuManager;
 	
@@ -49,7 +48,6 @@ class CRF_GamemodeManager : SCR_BaseGameModeComponent
 		m_Gamemode = CRF_Gamemode.GetInstance();
 		m_SlottingManager = CRF_SlottingManager.GetInstance();
 		m_SafestartManager = CRF_SafestartManager.GetInstance();
-		m_RplBroadcastManager = CRF_RplBroadcastManager.GetInstance();
 		m_GroupsManagerComponent = SCR_GroupsManagerComponent.GetInstance();
 		m_AdminMenuManager = CRF_AdminMenuManager.GetInstance();
 	}
@@ -107,9 +105,7 @@ class CRF_GamemodeManager : SCR_BaseGameModeComponent
 		if (!playerController)
 			return;
 			
-		m_RplBroadcastManager = CRF_RplBroadcastManager.GetInstance();
 		SCR_ChimeraCharacter playerCharacter = null;
-		bool isSpectator = false;
 		Faction faction = null;
 		
 		// Determine if player should be spectator or playable character
@@ -117,26 +113,29 @@ class CRF_GamemodeManager : SCR_BaseGameModeComponent
 		{
 			playerCharacter = CreateSpectatorEntity();
 			faction = GetGame().GetFactionManager().GetFactionByKey("SPEC");
-			isSpectator = true;
 			
 			RemovePlayerFromCurrentGroup(playerId);
 			DisableDamageForSpectator(playerCharacter);
 		} 
 		else 
 		{
+			CRF_RplBroadcastManager.GetInstance().SendCharacterLoadingScreen(playerId);
 			playerCharacter = GetOrCreatePlayableCharacter(playerId, overrideLocation);
 			faction = m_SlottingManager.GetPlayerSlotFaction(playerId);
 		}
-
-		AssignFactionToPlayer(playerController, faction);
-		AssignCharacterToPlayer(playerController, playerCharacter);
-
-		if (!isSpectator)
-		{
-			AssignPlayerToGroup(playerId);
-		}
 		
-		m_RplBroadcastManager.InitilizePlayerBroadcast(playerId, isSpectator);
+		if (playerController && playerCharacter)
+		{
+			CRF_PlayerControllerManager playerControllerComp = CRF_PlayerControllerManager.Cast(playerController.FindComponent(CRF_PlayerControllerManager));
+			
+			if (playerControllerComp)
+			{
+				if(!CRF_GamemodeManager.IsSpectator(playerCharacter))
+					playerControllerComp.InitilizePlayerCharacterCheck(playerCharacter, faction);
+				else
+					playerControllerComp.InitilizePlayerCharacter(playerCharacter, faction);
+			};
+		};
 	}
 	
 	//------------------------------------------------------------------------------------------------
@@ -144,7 +143,7 @@ class CRF_GamemodeManager : SCR_BaseGameModeComponent
 	* Create a spectator entity in the world
 	* @return The created spectator character
 	*/
-	protected SCR_ChimeraCharacter CreateSpectatorEntity()
+	static SCR_ChimeraCharacter CreateSpectatorEntity()
 	{
 		Resource spectatorRes = Resource.Load(SPECTATOR_RESOURCE);
 		return SCR_ChimeraCharacter.Cast(GetGame().SpawnEntityPrefab(spectatorRes, GetGame().GetWorld()));
@@ -155,7 +154,7 @@ class CRF_GamemodeManager : SCR_BaseGameModeComponent
 	* Remove player from their current group if any
 	* @param playerId ID of the player to remove from group
 	*/
-	protected void RemovePlayerFromCurrentGroup(int playerId)
+	void RemovePlayerFromCurrentGroup(int playerId)
 	{
 		SCR_AIGroup currentGroup = m_GroupsManagerComponent.GetPlayerGroup(playerId);
 		if (currentGroup)
@@ -167,7 +166,7 @@ class CRF_GamemodeManager : SCR_BaseGameModeComponent
 	* Disable damage handling for spectator character
 	* @param character Character to disable damage for
 	*/
-	protected void DisableDamageForSpectator(SCR_ChimeraCharacter character)
+	static void DisableDamageForSpectator(SCR_ChimeraCharacter character)
 	{
 		if (!character)
 			return;
@@ -184,7 +183,7 @@ class CRF_GamemodeManager : SCR_BaseGameModeComponent
 	* @param overrideLocation Optional spawn location
 	* @return The character entity
 	*/
-	protected SCR_ChimeraCharacter GetOrCreatePlayableCharacter(int playerId, vector overrideLocation)
+	SCR_ChimeraCharacter GetOrCreatePlayableCharacter(int playerId, vector overrideLocation)
 	{
 		SCR_ChimeraCharacter playerCharacter = m_SlottingManager.GetPlayerSlotCharacter(playerId);
 		
@@ -193,14 +192,14 @@ class CRF_GamemodeManager : SCR_BaseGameModeComponent
 			
 		return playerCharacter;
 	}
-	
+
 	//------------------------------------------------------------------------------------------------
 	/**
 	* Assign faction to player controller
 	* @param playerController Player controller to assign faction to
 	* @param faction Faction to assign
 	*/
-	protected void AssignFactionToPlayer(SCR_PlayerController playerController, Faction faction)
+	static void AssignFactionToPlayer(SCR_PlayerController playerController, Faction faction)
 	{
 		if (!faction || !playerController)
 			return;
@@ -219,7 +218,7 @@ class CRF_GamemodeManager : SCR_BaseGameModeComponent
 	* @param playerController Player controller to assign character to
 	* @param character Character to assign
 	*/
-	protected void AssignCharacterToPlayer(SCR_PlayerController playerController, SCR_ChimeraCharacter character)
+	static void AssignCharacterToPlayer(SCR_PlayerController playerController, SCR_ChimeraCharacter character)
 	{
 		if (!character || !playerController)
 			return;
@@ -232,7 +231,7 @@ class CRF_GamemodeManager : SCR_BaseGameModeComponent
 	* Assign player to their slotted group
 	* @param playerId ID of the player to assign
 	*/
-	protected void AssignPlayerToGroup(int playerId)
+	void AssignPlayerToGroup(int playerId)
 	{
 		SCR_AIGroup group = m_SlottingManager.GetPlayerSlotGroup(playerId);
 		if (!group)

--- a/scripts/Game/Systems/Core/Managers/CRF_GamemodeManager.c
+++ b/scripts/Game/Systems/Core/Managers/CRF_GamemodeManager.c
@@ -119,7 +119,6 @@ class CRF_GamemodeManager : SCR_BaseGameModeComponent
 		} 
 		else 
 		{
-			CRF_RplBroadcastManager.GetInstance().SendCharacterLoadingScreen(playerId);
 			playerCharacter = GetOrCreatePlayableCharacter(playerId, overrideLocation);
 			faction = m_SlottingManager.GetPlayerSlotFaction(playerId);
 		}
@@ -188,7 +187,10 @@ class CRF_GamemodeManager : SCR_BaseGameModeComponent
 		SCR_ChimeraCharacter playerCharacter = m_SlottingManager.GetPlayerSlotCharacter(playerId);
 		
 		if (!playerCharacter || playerCharacter.GetCharacterController().IsDead())
+		{
+			CRF_RplBroadcastManager.GetInstance().SendCharacterLoadingScreen(playerId);
 			playerCharacter = m_SlottingManager.SpawnPlayableEntity(playerId, overrideLocation);
+		}
 			
 		return playerCharacter;
 	}

--- a/scripts/Game/Systems/Core/Managers/CRF_GearscriptManager.c
+++ b/scripts/Game/Systems/Core/Managers/CRF_GearscriptManager.c
@@ -142,6 +142,11 @@ class CRF_GearscriptManager : ScriptComponent
 		ApplyClothing(gearConfig, role, spawnParams, inventory, inventoryManager);
 		ApplyWeapons(gearConfig, role, factionKey, gearScriptSettings, spawnParams, inventory, inventoryManager);
 		ApplyInventoryItems(gearConfig, role, gearScriptSettings, spawnParams, inventory, inventoryManager);
+		
+		CRF_PlayableCharacter playable = CRF_PlayableCharacter.Cast(entity.FindComponent(CRF_PlayableCharacter));
+		
+		if (playable)
+			playable.SetGearscriptCompleted();
 	}
 
 	//------------------------------------------------------------------------------------------------

--- a/scripts/Game/Systems/Core/Managers/CRF_PlayerControllerManager.c
+++ b/scripts/Game/Systems/Core/Managers/CRF_PlayerControllerManager.c
@@ -56,7 +56,69 @@ class CRF_PlayerControllerManager : ScriptComponent
 	}
 
 	//------------------------------------------------------------------------------------------------
-	// INITIALIZATION
+	// INITIALIZATION AUTHORITY
+	//------------------------------------------------------------------------------------------------
+	
+	/**
+	 * (ONLY ON THE AUTHORITY) Initializes a looped check if the local player character has all gear from the GS manager
+	 * @param playerCharacter - Player character to pass along to InitilizePlayerCharacter from the gamemode manager
+	 * @param faction - Faction to pass alongto InitilizePlayerCharacter from the gamemode manager
+	 */
+	void InitilizePlayerCharacterCheck(SCR_ChimeraCharacter playerCharacter, Faction faction)
+	{
+		// Get the playable character comp from our entity so we can check if the gearscript has completed
+		CRF_PlayableCharacter playable = CRF_PlayableCharacter.Cast(playerCharacter.FindComponent(CRF_PlayableCharacter));
+		
+		// Check if we are already in a loop check, if we arent, start a loop check
+		GetGame().GetCallqueue().CallLater(PlayerCharacterCheck, 50, true, playable, playerCharacter, faction);
+	};
+	
+	/**
+	 * (ONLY ON THE AUTHORITY) Loop that checks if the local player character has all gear from the GS manager
+	 * @param playerCharacter - Player character to pass along to InitilizePlayerCharacter from the gamemode manager
+	 * @param faction - Faction to pass along to InitilizePlayerCharacter from the gamemode manager
+	 */
+	protected void PlayerCharacterCheck(CRF_PlayableCharacter playable, SCR_ChimeraCharacter playerCharacter, Faction faction)
+	{
+		// If gearscript hasnt been completed, dont initilize the entity
+		if (!playable.GetGearscriptCompleted())
+			return;
+		
+		// Initilize playable entity
+		GetGame().GetCallqueue().CallLater(InitilizePlayerCharacter, 325, false, playerCharacter, faction, false);
+		// Kill the loop
+		GetGame().GetCallqueue().Remove(PlayerCharacterCheck);
+	};
+	
+	/**
+	 * (ONLY ON THE AUTHORITY) Initilize the player character for the local player controller
+	 * @param playerCharacter - Player character that we are initilizing
+	 * @param faction - Faction to assign to the playercontroller
+	 */
+	void InitilizePlayerCharacter(SCR_ChimeraCharacter playerCharacter, Faction faction)
+	{	
+		// Get the local player controller
+		SCR_PlayerController playerController = SCR_PlayerController.Cast(GetOwner());
+		
+		// Get the local player id from the controller
+		int playerId = playerController.GetPlayerId();
+		
+		// Check if the entity we are setting is a spectator
+		bool isSpectator = CRF_GamemodeManager.IsSpectator(playerCharacter);
+		
+		CRF_GamemodeManager.AssignFactionToPlayer(playerController, faction);
+		CRF_GamemodeManager.AssignCharacterToPlayer(playerController, playerCharacter);
+
+		if (!isSpectator)
+		{
+			CRF_GamemodeManager.GetInstance().AssignPlayerToGroup(playerId);
+		}
+		
+		CRF_RplBroadcastManager.GetInstance().InitilizePlayerBroadcast(playerId, isSpectator);
+	}
+
+	//------------------------------------------------------------------------------------------------
+	// INITIALIZATION CLIENT
 	//------------------------------------------------------------------------------------------------
 
 	/**
@@ -105,7 +167,6 @@ class CRF_PlayerControllerManager : ScriptComponent
 		
 			// Schedule delayed initialization of player-specific settings
 			GetGame().GetCallqueue().CallLater(ResetSettingsToStoredValues, 100, false);
-			GetGame().GetCallqueue().CallLater(SetupRadioFrequency, 1000, false);
 		};
 		
 		if (IsSpectator)
@@ -220,72 +281,6 @@ class CRF_PlayerControllerManager : ScriptComponent
 			SCR_ScreenEffectsManager.GetScreenEffectsDisplay().RHS_SetHDR("{0AD0A1ADEBCF893F}Assets/Items/Equipment/NVG/pvs14/data/SpecNVGFilm.emat", true);
 		else
 			SCR_ScreenEffectsManager.GetScreenEffectsDisplay().RHS_SetHDR("{765A5E642D09A4B8}Common/Postprocess/HDR_Vanila.emat", false);
-	}
-
-	//------------------------------------------------------------------------------------------------
-	// PLAYER EQUIPMENT
-	//------------------------------------------------------------------------------------------------
-
-	/**
-	 * Sets up radio frequencies based on player group
-	 * Configures both group and platoon frequencies
-	 */
-	void SetupRadioFrequency()
-	{
-		// Get player's entity
-		IEntity entity = SCR_PlayerController.GetLocalMainEntity();
-		if (!entity || CRF_GamemodeManager.IsSpectator(entity))
-			return;
-		
-		// Find radio in inventory
-		array<IEntity> items = {};
-		SCR_InventoryStorageManagerComponent.Cast(entity.FindComponent(SCR_InventoryStorageManagerComponent)).GetItems(items);
-		IEntity radioEntity;
-		foreach (IEntity item : items)
-		{
-			if (item.FindComponent(BaseRadioComponent))
-			{
-				radioEntity = item;
-				break;
-			}
-		}
-
-		if (!radioEntity)
-			return;
-
-		// Get radio components
-		BaseRadioComponent radio = BaseRadioComponent.Cast(radioEntity.FindComponent(BaseRadioComponent));
-		BaseTransceiver grpTsv = radio.GetTransceiver(0);
-
-		// Get player's group
-		SCR_GroupsManagerComponent m_GroupManager = SCR_GroupsManagerComponent.GetInstance();
-		if (!m_GroupManager)
-			return;
-
-		SCR_AIGroup group = m_GroupManager.GetPlayerGroup(SCR_PlayerController.GetLocalPlayerId());
-		PlayerController pc = GetGame().GetPlayerController();
-		
-		// Set frequency based on group
-		if (pc && group)
-		{
-			RadioHandlerComponent rhc = RadioHandlerComponent.Cast(pc.FindComponent(RadioHandlerComponent));
-			if (rhc)
-				rhc.SetFrequency(grpTsv, group.GetRadioFrequency());
-		}
-
-		// Set up Voice over Network component
-		SCR_VONController vc = SCR_VONController.Cast(pc.FindComponent(SCR_VONController));
-		SCR_VoNComponent von = SCR_VoNComponent.Cast(entity.FindComponent(SCR_VoNComponent));
-		
-		von.SetTransmitRadio(grpTsv);
-
-		// Set up platoon radio if available
-		BaseTransceiver pltTsv = radio.GetTransceiver(1);
-		if (pltTsv)
-			von.SetTransmitRadio(pltTsv);
-		
-		vc.PublicResetVON();
-		vc.SetVONComponent(von);
 	}
 	
 	//------------------------------------------------------------------------------------------------
@@ -618,57 +613,6 @@ class CRF_PlayerControllerManager : ScriptComponent
 	//------------------------------------------------------------------------------------------------
 	// MAP MARKER SYSTEM
 	//------------------------------------------------------------------------------------------------
-	
-	/**
-	 * Update map markers for objectives in Frontline gamemode
-	 * @param zoneStatus - Array of zone status strings
-	 * @param zoneObjectNames - Array of zone object names
-	 * @param bluforSide - Blue force faction key
-	 * @param opforSide - Opposing force faction key
-	 */
-	void UpdateMapMarkers(array<string> zoneStatus, array<string> zoneObjectNames, FactionKey bluforSide, FactionKey opforSide)
-	{
-		RemoveALLScriptedMarkers();
-
-		foreach (int i, string zoneName : zoneObjectNames)
-		{
-			string status = zoneStatus[i];
-			string imageTexture;
-			int imageColor;
-
-			// Parse zone status
-			array<string> zoneStatusArray = {};
-			status.Split(":", zoneStatusArray, false);
-
-			string zoneLocked = zoneStatusArray[1];
-			FactionKey zoneFactionStored = zoneStatusArray[2];
-
-			// Select image based on zone index
-			switch (i)
-			{
-				case 0: {imageTexture = "{21A2A457BD0E42C1}UI\Objectives\A.edds"; break; };
-				case 1: {imageTexture = "{7F4A8D140283CCCE}UI\Objectives\B.edds"; break; };
-				case 2: {imageTexture = "{8B42CA8C0F5EA4BA}UI\Objectives\C.edds"; break; };
-				case 3: {imageTexture = "{C29ADF937D98D0D0}UI\Objectives\D.edds"; break; };
-				case 4: {imageTexture = "{3692980B7045B8A4}UI\Objectives\E.edds"; break; };
-			}
-
-			// Add lock marker if zone is locked
-			if (zoneLocked == "Locked")
-				AddScriptedMarker(zoneName, "0 0 0", 0, "", "{91427B7866707601}UI\Objectives\lock.edds", 50, ARGB(255, 142, 142, 142));
-
-			// Set color based on controlling faction
-			switch (zoneFactionStored)
-			{
-				case bluforSide: {imageColor = ARGB(255, 0, 25, 225); break; }; // Blufor
-				case opforSide: {imageColor = ARGB(255, 225, 25, 0); break; }; // Opfor
-				default: {imageColor = ARGB(255, 225, 225, 225); break; }; // Uncaptured
-			}
-
-			// Add zone marker
-			AddScriptedMarker(zoneName, "0 0 0", 0, "", imageTexture, 45, imageColor);
-		}
-	}
 
 	/**
 	 * Returns the array of scripted markers

--- a/scripts/Game/Systems/Core/Managers/CRF_RplBroadcastManager.c
+++ b/scripts/Game/Systems/Core/Managers/CRF_RplBroadcastManager.c
@@ -149,6 +149,16 @@ class CRF_RplBroadcastManager : ScriptComponent
 		Rpc(RpcDo_SendRespawnScreen, playerId);
 		#endif
 	}
+	
+	//------------------------------------------------------------------------------------------------
+	void SendCharacterLoadingScreen(int playerId)
+	{
+		#ifdef WORKBENCH
+		RpcDo_SendCharacterLoadingScreen(playerId);
+		#else
+		Rpc(RpcDo_SendCharacterLoadingScreen, playerId);
+		#endif
+	}
 
 	//------------------------------------------------------------------------------------------------
 	void InitilizePlayerBroadcast(int playerId, bool isSpectator)
@@ -424,6 +434,16 @@ class CRF_RplBroadcastManager : ScriptComponent
 		GetGame().GetCallqueue().CallLater(m_RespawnManager.RespawnTimer, 1000, true);
 		GetGame().GetCallqueue().CallLater(m_RespawnManager.CloseSlottingMenu, 100, true);
 	}
+	
+	//------------------------------------------------------------------------------------------------
+	[RplRpc(RplChannel.Reliable, RplRcver.Broadcast)]
+	void RpcDo_SendCharacterLoadingScreen(int playerId)
+	{
+		if (SCR_PlayerController.GetLocalPlayerId() != playerId)
+			return;
+		
+		GetGame().GetMenuManager().OpenMenu(ChimeraMenuPreset.CRF_CharacterLoading);
+	};
 	
 	//------------------------------------------------------------------------------------------------
 	[RplRpc(RplChannel.Reliable, RplRcver.Broadcast)]

--- a/scripts/Game/Systems/UI/Menus/CRF_AARMenu.c
+++ b/scripts/Game/Systems/UI/Menus/CRF_AARMenu.c
@@ -1,8 +1,3 @@
-modded enum ChimeraMenuPreset : ScriptMenuPresetEnum
-{
-	CRF_AARMenu
-}
-
 /**
  * After Action Report Menu UI class
  * Responsible for displaying mission summary, player statistics, and slot management

--- a/scripts/Game/Systems/UI/Menus/CRF_AdminMenuUI.c
+++ b/scripts/Game/Systems/UI/Menus/CRF_AdminMenuUI.c
@@ -1,9 +1,4 @@
-modded enum ChimeraMenuPreset
-{
-	CoalAdminMenu
-}
-
-/**
+ /**
  * Administrative menu for server management
  * Provides tools for player management including respawn, gear reset, teleport, etc.
  */

--- a/scripts/Game/Systems/UI/Menus/CRF_BriefingMenu.c
+++ b/scripts/Game/Systems/UI/Menus/CRF_BriefingMenu.c
@@ -1,8 +1,3 @@
-modded enum ChimeraMenuPreset : ScriptMenuPresetEnum
-{
-	CRF_PreviewMenu
-}
-
 class CRF_PreviewMenuUI: ChimeraMenuBase
 {
 	//--- UI Widgets ---

--- a/scripts/Game/Systems/UI/Menus/CRF_CharacterLoading.c
+++ b/scripts/Game/Systems/UI/Menus/CRF_CharacterLoading.c
@@ -4,19 +4,21 @@ class CRF_CharacterLoading: ChimeraMenuBase
 	
 	/**
 	 * Called when the menu is opened
-	 * Initializes UI elements and sets up event listeners
 	 */
 	override void OnMenuOpen()
 	{	
+		super.OnMenuOpen()
+		
 		GetGame().GetCallqueue().CallLater(ActivateFailsafe, 5000, false);
 	}
 	
 	/**
 	 * Cleans up resources when the menu is closed
-	 * Removes event listeners and slot update callback
 	 */
 	override void OnMenuClose()
 	{
+		super.OnMenuClose()
+		
 		GetGame().GetCallqueue().Remove(ActivateFailsafe);
 	};
 	

--- a/scripts/Game/Systems/UI/Menus/CRF_CharacterLoading.c
+++ b/scripts/Game/Systems/UI/Menus/CRF_CharacterLoading.c
@@ -1,0 +1,42 @@
+class CRF_CharacterLoading: ChimeraMenuBase
+{
+	protected bool m_bFailsafeActive;
+	
+	/**
+	 * Called when the menu is opened
+	 * Initializes UI elements and sets up event listeners
+	 */
+	override void OnMenuOpen()
+	{	
+		GetGame().GetCallqueue().CallLater(ActivateFailsafe, 5000, false);
+	}
+	
+	/**
+	 * Cleans up resources when the menu is closed
+	 * Removes event listeners and slot update callback
+	 */
+	override void OnMenuClose()
+	{
+		GetGame().GetCallqueue().Remove(ActivateFailsafe);
+	};
+	
+	/**
+	 * Updates the menu state during each frame
+	 * @param tDelta - Time elapsed since last frame
+	 */
+	override void OnMenuUpdate(float tDelta)
+	{
+		super.OnMenuUpdate(tDelta);
+		
+		IEntity mainEntity = SCR_PlayerController.GetLocalMainEntity();
+		
+		// If we have a valid main entity OR the menu has been up for more than 5 seconds;
+		if ((mainEntity && !CRF_GamemodeManager.IsSpectator(mainEntity)) || m_bFailsafeActive)
+			GetGame().GetMenuManager().CloseMenu(this);
+	}
+	
+	protected void ActivateFailsafe()
+	{
+		m_bFailsafeActive = true;
+	}
+}

--- a/scripts/Game/Systems/UI/Menus/CRF_PauseMenuUI.c
+++ b/scripts/Game/Systems/UI/Menus/CRF_PauseMenuUI.c
@@ -1,6 +1,5 @@
 class CRF_PauseMenuUI: PauseMenuUI
 {
-	
 	//--------------------------------------------------------------------------------------------------
 	// Overridden method that's called when the pause menu is opened
 	//--------------------------------------------------------------------------------------------------
@@ -41,6 +40,6 @@ class CRF_PauseMenuUI: PauseMenuUI
 	//--------------------------------------------------------------------------------------------------
 	void OpenAdminMenu()
 	{
-		GetGame().GetMenuManager().OpenMenu(ChimeraMenuPreset.CoalAdminMenu);
+		GetGame().GetMenuManager().OpenMenu(ChimeraMenuPreset.CRF_AdminMenu);
 	}
 }

--- a/scripts/Game/Systems/UI/Menus/CRF_RespawnMenu.c
+++ b/scripts/Game/Systems/UI/Menus/CRF_RespawnMenu.c
@@ -1,12 +1,4 @@
 /**
- * Extended ChimeraMenuPreset enum to include the CRF Respawn Menu
- */
-modded enum ChimeraMenuPreset : ScriptMenuPresetEnum
-{
-	CRF_RespawnMenu
-}
-
-/**
  * Custom respawn menu implementation for the Coalition Reforger Framework
  * Provides timer display, map view, and communication capabilities during respawn
  */

--- a/scripts/Game/Systems/UI/Menus/CRF_SlottingMenu.c
+++ b/scripts/Game/Systems/UI/Menus/CRF_SlottingMenu.c
@@ -1,8 +1,3 @@
-modded enum ChimeraMenuPreset : ScriptMenuPresetEnum
-{
-	CRF_SlottingMenu
-}
-
 class CRF_SlottingMenuUI: ChimeraMenuBase
 {
 	//---------------------------------------------------------------------

--- a/scripts/Game/Systems/UI/Menus/CRF_SpectatorMenu.c
+++ b/scripts/Game/Systems/UI/Menus/CRF_SpectatorMenu.c
@@ -1,8 +1,3 @@
-modded enum ChimeraMenuPreset : ScriptMenuPresetEnum
-{
-	CRF_SpectatorMenu
-}
-
 class CRF_SpectatorMenuUI: ChimeraMenuBase
 {
 	//=================================================================================================


### PR DESCRIPTION
It does exactly what it says. We now wait for the gear script manager to tell us it has given us all the gear we need, and then wait 325ms for all that gear/our entity to initialize.

This fixes the NVG issue we were having.
Also, we no longer need to set our radio channels through the client since the base game already does that, but we were just too fast in initializing the player.

Also, some standardization of Enums/Classes, while I was at it.