### PR TITLE
Madd mission CRF_S&D89 Full english to repo

### DIFF
--- a/Configs/Gearscripts/Custom/fluff/CRF_GS_80sUSSRklmk.conf
+++ b/Configs/Gearscripts/Custom/fluff/CRF_GS_80sUSSRklmk.conf
@@ -365,6 +365,12 @@ CRF_GearScriptConfig {
       }
      }
     }
+    m_AdditionalInventoryItems {
+     CRF_Inventory_Item "{65D4611A4C94ADDB}" {
+      m_sItemPrefab "{C166493B95671DEE}Prefabs/Items/Equipment/Radios/OPFOR_Radio_GI.et"
+      m_iItemCount 1
+     }
+    }
    }
   }
  }

--- a/Configs/Gearscripts/Custom/fluff/CRF_GS_80sUSSRklmk.conf
+++ b/Configs/Gearscripts/Custom/fluff/CRF_GS_80sUSSRklmk.conf
@@ -76,12 +76,12 @@ CRF_GearScriptConfig {
    }
   }
   m_AR CRF_Spec_Weapon_Class "{62AF7D030677A9F3}" {
-   m_Weapon "{A89BC9D55FFB4CD8}Prefabs/Weapons/MachineGuns/PKM/MG_PKM.et"
+   m_Weapon "{A7AF84C6C58BA3E8}Prefabs/Weapons/MachineGuns/RPK74/MG_RPK74.et"
    m_MagazineArray {
     CRF_Spec_Magazine_Class "{62AF7D034472DDC4}" {
-     m_Magazine "{E5E9C5897CF47F44}Prefabs/Weapons/Magazines/Box_762x54_PK_100rnd_4Ball_1Tracer.et"
-     m_MagazineCount 5
-     m_AssistantMagazineCount 4
+     m_Magazine "{D78C667F59829717}Prefabs/Weapons/Magazines/Magazine_545x39_RPK_45rnd_4Ball_1Tracer.et"
+     m_MagazineCount 14
+     m_AssistantMagazineCount 16
     }
    }
   }
@@ -92,9 +92,14 @@ CRF_GearScriptConfig {
    }
    m_MagazineArray {
     CRF_Spec_Magazine_Class "{62AF7D03A8615D54}" {
+     m_Magazine "{4A3B196E4EA820E9}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_OG7V.et"
+     m_MagazineCount 1
+     m_AssistantMagazineCount 1
+    }
+    CRF_Spec_Magazine_Class "{65D447086BD9DD45}" {
      m_Magazine "{32E12D322E107F1C}Prefabs/Weapons/Ammo/Ammo_Rocket_PG7VM.et"
-     m_MagazineCount 2
-     m_AssistantMagazineCount 3
+     m_MagazineCount 1
+     m_AssistantMagazineCount 2
     }
    }
   }
@@ -343,6 +348,20 @@ CRF_GearScriptConfig {
       m_iClothingType BACKPACK
       m_ClothingPrefabs {
        "{F2748E353A275677}Prefabs/Items/Equipment/Radios/CRF_Radio_R107M_Inert.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D43E18B1B6BD33}" {
+    m_Role TEAM_LEAD
+    m_PrimaryWeapon {
+     CRF_Weapon_Class "{65D43E18B9A4FC91}" {
+      m_Weapon "{FA5C25BF66A53DCF}Prefabs/Weapons/Rifles/AK74/Rifle_AK74.et"
+      m_MagazineArray {
+       CRF_Magazine_Class "{65D43E18C5922539}" {
+        m_Magazine "{0A84AA5A3884176F}Prefabs/Weapons/Magazines/Magazine_545x39_AK_30rnd_Last_5Tracer.et"
+        m_MagazineCount 9
+       }
       }
      }
     }

--- a/Configs/Gearscripts/Custom/fluff/CRF_GS_80sUSSRklmk.conf
+++ b/Configs/Gearscripts/Custom/fluff/CRF_GS_80sUSSRklmk.conf
@@ -115,7 +115,7 @@ CRF_GearScriptConfig {
   m_bEnableLeadershipBinoculars 1
   m_sLeadershipBinocularsPrefab "{F2539FA5706E51E4}Prefabs/Items/Equipment/Binoculars/Binoculars_B12/Binoculars_B12.et"
   m_bEnableAssistantBinoculars 1
-  m_sAssistantBinocularsPrefab "{F2539FA5706E51E4}Prefabs/Items/Equipment/Binoculars/Binoculars_B12/Binoculars_B12.et"
+  m_sAssistantBinocularsPrefab "{243948B23D90BECB}Prefabs/Items/Equipment/Binoculars/Binoculars_B8/Binoculars_B8.et"
   m_bEnableMedicFrags 0
   m_DefaultMedicMedicalItems {
    CRF_Inventory_Item "{62AF55AFAA8D85CD}" {
@@ -140,6 +140,22 @@ CRF_GearScriptConfig {
    }
    CRF_Inventory_Item "{62AF55AFAA8D8579}" {
     m_sItemPrefab "{5B2FD067D70C1E8F}Prefabs/Items/Medicine/EpinephrineInjection/ACE_Medical_EpinephrineInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{65D00DCFCEF52FD1}" {
+    m_sItemPrefab "{58CF3AB87C441295}Prefabs/Items/Medicine/AmmoniumCarbonatePackage/ACE_Medical_AmmoniumCarbonatePackage.et"
+    m_iItemCount 10
+   }
+   CRF_Inventory_Item "{65D00DCFD035827D}" {
+    m_sItemPrefab "{02DD34077F51F65E}Prefabs/Items/Medicine/NaloxoneInjection/ACE_Medical_NaloxoneInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{65D00DCFD429565E}" {
+    m_sItemPrefab "{9BBA766CD869002C}Prefabs/Items/Medicine/PhenylephrineInjection/ACE_Medical_PhenylephrineInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{65D00DCFD406AB3D}" {
+    m_sItemPrefab "{D0434D5215B54181}Prefabs/Items/Medicine/MetoprololInjection/ACE_Medical_MetoprololInjection.et"
     m_iItemCount 6
    }
   }
@@ -175,6 +191,12 @@ CRF_GearScriptConfig {
     m_iClothingType BOOTS
     m_ClothingPrefabs {
      "{C7923961D7235D70}Prefabs/Characters/Footwear/CombatBoots_Soviet_01.et"
+    }
+   }
+   CRF_Clothing "{65D00DCE5A31CA23}" {
+    m_iClothingType BACKPACK
+    m_ClothingPrefabs {
+     "{CE832B86D234AD62}Prefabs/Items/Equipment/Backpacks/CRF_Backpack_Invisable.et"
     }
    }
   }
@@ -216,154 +238,53 @@ CRF_GearScriptConfig {
     m_iItemCount 2
    }
    CRF_Inventory_Item "{62FB6045D8FA7EF1}" {
-    m_sItemPrefab "{8554ED3F088BADA6}Prefabs/Items/Core/wirecutters.et"
+    m_sItemPrefab "{8554ED3F088BADA6}Prefabs/Items/Core/Wirecutters/wirecutters.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{65D00DCE023B365A}" {
+    m_sItemPrefab "{E096C6BD45C87B63}Prefabs/Items/PersonalBelongings/PersonalBelongings_USSR.et"
     m_iItemCount 1
    }
   }
  }
  m_CustomFactionGear CRF_Custom_Gear "{62AF55AE3A78E19F}" {
-  m_LeadershipCustomGear {
-   CRF_Leadership_Custom_Gear "{62AF55AEA1DEB9B1}" {
-    m_sRoleToOverride "Platoon Leader"
-    m_CustomClothing {
-     CRF_Clothing "{62AF55AEDB10DD0A}" {
-      m_iClothingType HEADGEAR
-      m_ClothingPrefabs {
-       "{B54B78383E64268F}Prefabs/Characters/HeadGear/Hat_M88_01/Hat_M88_01_v2.et"
-      }
-     }
-     CRF_Clothing "{62B0056088FD206E}" {
-      m_iClothingType HANDWEAR
-      m_ClothingPrefabs {
-       "{8266820FFDE17477}Prefabs/Characters/Handwear/Gloves_Wool_01/Gloves_Wool_01.et"
-      }
-     }
-    }
-   }
-   CRF_Leadership_Custom_Gear "{62AF55A8F626DB04}" {
-    m_sRoleToOverride "Company Commander"
-    m_CustomClothing {
-     CRF_Clothing "{62AF55A8F513F06C}" {
-      m_iClothingType HEADGEAR
+  m_RolesToSetCustomGear {
+   CRF_Role_Custom_Gear "{65D00DCE1E9C10CA}" {
+    m_Role PLATOON_LEADER
+    m_Clothing {
+     CRF_Clothing "{65D00DCE21485AD4}" {
       m_ClothingPrefabs {
        "{3523CB7D5961246B}Prefabs/Characters/HeadGear/Hat_PeakedCap_USSR_01/Hat_PeakedCap_USSR_01.et"
       }
      }
-     CRF_Clothing "{62B00565CDBCC370}" {
-      m_iClothingType ARMOREDVEST
-      m_ClothingPrefabs {
-       ""
-      }
-     }
-     CRF_Clothing "{62B00565D274EC66}" {
-      m_iClothingType VEST
-      m_ClothingPrefabs {
-       "{F2D03ED36FAC87FF}Prefabs/Characters/Vests/Vest_SovietHarness/Variants/Vest_SovietHarness_officer.et"
-      }
-     }
-     CRF_Clothing "{62B005609822A26B}" {
-      m_iClothingType HANDWEAR
-      m_ClothingPrefabs {
-       "{4F71E7468E78DDD2}Prefabs/Characters/Handwear/Gloves_Leather_01/Gloves_Leather_01.et"
-      }
-     }
     }
    }
-   CRF_Leadership_Custom_Gear "{62B00563167B5B38}" {
-    m_sRoleToOverride "Medical Officer"
-    m_CustomClothing {
-     CRF_Clothing "{62B005631AECB5CF}" {
-      m_iClothingType HEADGEAR
-      m_ClothingPrefabs {
-       "{2B29B7E1C6BD1048}Prefabs/Characters/HeadGear/Hat_M88_01/Hat_M88_01_v1.et"
-      }
-     }
-     CRF_Clothing "{62B005631AC97283}" {
-      m_iClothingType HANDWEAR
-      m_ClothingPrefabs {
-       "{4F71E7468E78DDD2}Prefabs/Characters/Handwear/Gloves_Leather_01/Gloves_Leather_01.et"
-      }
-     }
-    }
-   }
-  }
-  m_SquadLevelCustomGear {
-   CRF_Squad_Level_Custom_Gear "{62AF55A926C5A42F}" {
-    m_sRoleToOverride "Rifleman Demo"
-    m_CustomClothing {
-     CRF_Clothing "{62AF55A92DCC183C}" {
+   CRF_Role_Custom_Gear "{65D00DCE1F595430}" {
+    m_Role MEDICAL_OFFICER
+    m_Clothing {
+     CRF_Clothing "{65D00DCE787DA9C2}" {
       m_iClothingType BACKPACK
       m_ClothingPrefabs {
-       "{3DE0155EC9767B98}Prefabs/Items/Equipment/Backpacks/Backpack_Veshmeshok.et"
+       "{79015191C0E77E48}Prefabs/Items/Equipment/Backpacks/Backpack_Medical_Soviet_02.et"
       }
      }
     }
-    m_AdditionalInventoryItems {
-     CRF_Inventory_Item "{62AF55A93AA1F50F}" {
-      m_sItemPrefab "{73F69547963CAEE0}PrefabsEditable/Explosives/E_DemoBlock_TSh400g.et"
-      m_iItemCount 3
-     }
-     CRF_Inventory_Item "{62AF55A93B6FA596}" {
-      m_sItemPrefab "{90976DC90A223095}Prefabs/Items/Equipment/Detonators/BlastingMachine_KPM_3U1/BlastingMachine_KPM_3U1.et"
-      m_iItemCount 1
-     }
-    }
    }
-   CRF_Squad_Level_Custom_Gear "{62AF55A960BBF987}" {
-    m_sRoleToOverride "Medic"
-    m_CustomClothing {
-     CRF_Clothing "{62AF55A998315EE0}" {
+   CRF_Role_Custom_Gear "{65D00DCE1F3FC806}" {
+    m_Role MEDIC
+    m_Clothing {
+     CRF_Clothing "{65D00DCE8A52CC96}" {
       m_iClothingType BACKPACK
       m_ClothingPrefabs {
-       "{7AC107CA7AFC9B59}Prefabs/Items/Equipment/Backpacks/Backpack_Medical_Soviet.et"
-      }
-     }
-     CRF_Clothing "{62B0056346FF6A4B}" {
-      m_iClothingType HANDWEAR
-      m_ClothingPrefabs {
-       "{4F71E7468E78DDD2}Prefabs/Characters/Handwear/Gloves_Leather_01/Gloves_Leather_01.et"
+       "{79015191C0E77E48}Prefabs/Items/Equipment/Backpacks/Backpack_Medical_Soviet_02.et"
       }
      }
     }
    }
-   CRF_Squad_Level_Custom_Gear "{62AF55A9A9329ADC}" {
-    m_sRoleToOverride "Automatic Rifleman"
-    m_CustomClothing {
-     CRF_Clothing "{62AF55A9B46035E3}" {
-      m_iClothingType BACKPACK
-      m_ClothingPrefabs {
-       "{3DE0155EC9767B98}Prefabs/Items/Equipment/Backpacks/Backpack_Veshmeshok.et"
-      }
-     }
-     CRF_Clothing "{62B00565F5070913}" {
-      m_iClothingType ARMOREDVEST
-      m_ClothingPrefabs {
-       "{ADE19B33DCBB9005}Prefabs/Characters/Vests/Vest_6B2/Vest_6B2.et"
-      }
-     }
-     CRF_Clothing "{62B00565F5E397BE}" {
-      m_iClothingType VEST
-      m_ClothingPrefabs {
-       "{15067AD09803580D}Prefabs/Characters/Vests/Vest_SovietHarness/Variants/Vest_SovietHarness_MG.et"
-      }
-     }
-    }
-   }
-   CRF_Squad_Level_Custom_Gear "{62AF55A9B340B6F5}" {
-    m_sRoleToOverride "Assistant Automatic Rifleman"
-    m_CustomClothing {
-     CRF_Clothing "{62AF55A9C36337C7}" {
-      m_iClothingType BACKPACK
-      m_ClothingPrefabs {
-       "{41A9C55B61F375F0}Prefabs/Items/Equipment/Backpacks/Backpack_Kolobok.et"
-      }
-     }
-    }
-   }
-   CRF_Squad_Level_Custom_Gear "{62AF55A9AEAA6474}" {
-    m_sRoleToOverride "Rifleman AntiTank"
-    m_CustomClothing {
-     CRF_Clothing "{62AF55A9D0A6ABD7}" {
+   CRF_Role_Custom_Gear "{65D00DCE1F1220C8}" {
+    m_Role RIFLEMAN_ANTITANK
+    m_Clothing {
+     CRF_Clothing "{65D00DC93D9FD46D}" {
       m_iClothingType BACKPACK
       m_ClothingPrefabs {
        "{0D39750E5695B9D8}Prefabs/Items/Equipment/Backpacks/Backpack_RPG_Gunner.et"
@@ -371,10 +292,10 @@ CRF_GearScriptConfig {
      }
     }
    }
-   CRF_Squad_Level_Custom_Gear "{62AF55A9AF6028F3}" {
-    m_sRoleToOverride "Assistant Rifleman AntiTank"
-    m_CustomClothing {
-     CRF_Clothing "{62AF55A9DF870765}" {
+   CRF_Role_Custom_Gear "{65D00DCE1FFB8EA8}" {
+    m_Role ASSISTANT_RIFLEMAN_ANTITANK
+    m_Clothing {
+     CRF_Clothing "{65D00DC93111692F}" {
       m_iClothingType BACKPACK
       m_ClothingPrefabs {
        "{6A39B5843B3F36DA}Prefabs/Items/Equipment/Backpacks/Backpack_RPG_Assistant.et"
@@ -382,74 +303,46 @@ CRF_GearScriptConfig {
      }
     }
    }
-  }
-  m_InfantrySpecialtiesCustomGear {
-   CRF_Infantry_Specialties_Custom_Gear "{62B15E0F74458018}" {
-    m_sRoleToOverride "Sniper"
-    m_CustomClothing {
-     CRF_Clothing "{62B15E0F93CDC7A5}" {
-      m_iClothingType HEADGEAR
+   CRF_Role_Custom_Gear "{65D00DCE1FD3392B}" {
+    m_Role ASSISTANT_AUTOMATIC_RIFLEMAN
+    m_Clothing {
+     CRF_Clothing "{65D00DC9291A69CE}" {
+      m_iClothingType BACKPACK
       m_ClothingPrefabs {
-       "{5F8928B41FB86990}Prefabs/Characters/HeadGear/Helmet_SSh68_01/Helmet_SSh68_01_cover_KZS.et"
-      }
-     }
-     CRF_Clothing "{62B15E0F901250F2}" {
-      m_iClothingType SHIRT
-      m_ClothingPrefabs {
-       "{F1E29085C62F0D55}Prefabs/Characters/Uniforms/Jacket_KZS/Jacket_KZS.et"
-      }
-     }
-     CRF_Clothing "{62B15E0FA4810DC1}" {
-      m_iClothingType PANTS
-      m_ClothingPrefabs {
-       "{5E17C1AE66A6FF00}Prefabs/Characters/Uniforms/Pants_KZS/Pants_KZS.et"
-      }
-     }
-     CRF_Clothing "{62B15E0FA5C5A394}" {
-      m_iClothingType HANDWEAR
-      m_ClothingPrefabs {
-       "{8266820FFDE17477}Prefabs/Characters/Handwear/Gloves_Wool_01/Gloves_Wool_01.et"
-      }
-     }
-     CRF_Clothing "{62B15E0C6FBC731A}" {
-      m_iClothingType HEAD
-      m_ClothingPrefabs {
-       "{EAB83C517A735C5C}Prefabs/Characters/HeadGear/Head_Cover/Buff1.et"
+       "{3DE0155EC9767B98}Prefabs/Items/Equipment/Backpacks/Backpack_Veshmeshok.et"
       }
      }
     }
    }
-   CRF_Infantry_Specialties_Custom_Gear "{62B15E0F752C1C97}" {
-    m_sRoleToOverride "Spotter"
-    m_CustomClothing {
-     CRF_Clothing "{62B15E0C897810E6}" {
-      m_iClothingType HEADGEAR
+   CRF_Role_Custom_Gear "{65D00DCE98AE48DC}" {
+    m_Role HEAVY_MACHINEGUN
+    m_Clothing {
+     CRF_Clothing "{65D00DC909CB96A2}" {
+      m_iClothingType BACKPACK
       m_ClothingPrefabs {
-       "{5F8928B41FB86990}Prefabs/Characters/HeadGear/Helmet_SSh68_01/Helmet_SSh68_01_cover_KZS.et"
+       "{A207909C42E58944}Prefabs/Items/Equipment/Backpacks/Backpack_US_Tripod.et"
       }
      }
-     CRF_Clothing "{62B15E0C89161CF0}" {
-      m_iClothingType SHIRT
+    }
+   }
+   CRF_Role_Custom_Gear "{65D00DCE9880DC77}" {
+    m_Role ASSISTANT_HEAVY_MACHINEGUN
+    m_Clothing {
+     CRF_Clothing "{65D00DCECECBDBED}" {
+      m_iClothingType BACKPACK
       m_ClothingPrefabs {
-       "{F1E29085C62F0D55}Prefabs/Characters/Uniforms/Jacket_KZS/Jacket_KZS.et"
+       "{177B1CD9D9A93A5A}Prefabs/Items/Equipment/Backpacks/NSV/Backpack_NSV_Weapon_MoreAmmo.et"
       }
      }
-     CRF_Clothing "{62B15E0C89EFC3FD}" {
-      m_iClothingType PANTS
+    }
+   }
+   CRF_Role_Custom_Gear "{65D00DCE9960870C}" {
+    m_Role RADIO_TELEPHONE_OPERATOR
+    m_Clothing {
+     CRF_Clothing "{65D00DC95C7B9D32}" {
+      m_iClothingType BACKPACK
       m_ClothingPrefabs {
-       "{5E17C1AE66A6FF00}Prefabs/Characters/Uniforms/Pants_KZS/Pants_KZS.et"
-      }
-     }
-     CRF_Clothing "{62B15E0C89BA9761}" {
-      m_iClothingType HANDWEAR
-      m_ClothingPrefabs {
-       "{8266820FFDE17477}Prefabs/Characters/Handwear/Gloves_Wool_01/Gloves_Wool_01.et"
-      }
-     }
-     CRF_Clothing "{62B15E0C899F3AE3}" {
-      m_iClothingType HEAD
-      m_ClothingPrefabs {
-       "{EAB83C517A735C5C}Prefabs/Characters/HeadGear/Head_Cover/Buff1.et"
+       "{F2748E353A275677}Prefabs/Items/Equipment/Radios/CRF_Radio_R107M_Inert.et"
       }
      }
     }

--- a/Configs/Gearscripts/Custom/fluff/CRF_GS_UK80s_fluff.conf
+++ b/Configs/Gearscripts/Custom/fluff/CRF_GS_UK80s_fluff.conf
@@ -115,11 +115,11 @@ CRF_GearScriptConfig {
    }
   }
   m_Sniper CRF_Weapon_Class "{65D00DC87CF99743}" {
-   m_Weapon "{81EB948E6414BD6F}Prefabs/Weapons/Rifles/M14/Rifle_M21_ARTII.et"
+   m_Weapon "{09699B08F1B93D16}Prefabs/Weapons/Rifles/PM/Rifle_AI_L96A1_PM6x42.et"
    m_MagazineArray {
     CRF_Magazine_Class "{65D00DC87CF99744}" {
-     m_Magazine "{627255315038152A}Prefabs/Weapons/Magazines/Magazine_762x51_M14_20rnd_SpecialBall.et"
-     m_MagazineCount 5
+     m_Magazine "{4EBDF52AD20AC6D1}Prefabs/Weapons/Magazines/Magazine_762x51_AIPM_10rnd_Ball_L2A2.et"
+     m_MagazineCount 8
     }
    }
   }
@@ -290,20 +290,6 @@ CRF_GearScriptConfig {
   m_RolesToSetCustomGear {
    CRF_Role_Custom_Gear "{65D00DC87CF998FD}" {
     m_Role VEHICLE_LEAD
-    m_Clothing {
-     CRF_Clothing "{65D00DC87CF998FF}" {
-      m_iClothingType PANTS
-      m_ClothingPrefabs {
-       ""
-      }
-     }
-     CRF_Clothing "{65D00DC87CF998C0}" {
-      m_iClothingType SHIRT
-      m_ClothingPrefabs {
-       "{C42C535F667B250E}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_UK_01_tucked.et"
-      }
-     }
-    }
    }
    CRF_Role_Custom_Gear "{65D00DC87CF998C2}" {
     m_Role INDIRECT_LEAD
@@ -479,37 +465,9 @@ CRF_GearScriptConfig {
    }
    CRF_Role_Custom_Gear "{65D00DC87CF96098}" {
     m_Role VEHICLE_DRIVER
-    m_Clothing {
-     CRF_Clothing "{65D00DC87CF96099}" {
-      m_iClothingType PANTS
-      m_ClothingPrefabs {
-       ""
-      }
-     }
-     CRF_Clothing "{65D00DC87CF9609B}" {
-      m_iClothingType SHIRT
-      m_ClothingPrefabs {
-       "{C42C535F667B250E}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_UK_01_tucked.et"
-      }
-     }
-    }
    }
    CRF_Role_Custom_Gear "{65D00DC87CF9609C}" {
     m_Role VEHICLE_GUNNER
-    m_Clothing {
-     CRF_Clothing "{65D00DC87CF9609D}" {
-      m_iClothingType PANTS
-      m_ClothingPrefabs {
-       ""
-      }
-     }
-     CRF_Clothing "{65D00DC87CF9609E}" {
-      m_iClothingType SHIRT
-      m_ClothingPrefabs {
-       "{C42C535F667B250E}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_UK_01_tucked.et"
-      }
-     }
-    }
    }
    CRF_Role_Custom_Gear "{65D00DC87CF9609F}" {
     m_Role VEHICLE_LOADER
@@ -638,6 +596,20 @@ CRF_GearScriptConfig {
      CRF_Inventory_Item "{65D00DC87CFE795B}" {
       m_sItemPrefab "{55641F140F92FDCD}Prefabs/Weapons/Explosives/Explosive_Satchels/BLUFOR_Satchel.et"
       m_iItemCount 3
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D43E1A6954D99F}" {
+    m_Role TEAM_LEAD
+    m_PrimaryWeapon {
+     CRF_Weapon_Class "{65D43E1A72E450E8}" {
+      m_Weapon "{53CFFE29990A260D}Prefabs/Weapons/Rifles/AR15/Rifle_AR15_604_20rnd.et"
+      m_MagazineArray {
+       CRF_Magazine_Class "{65D43E1A7BF6FCF3}" {
+        m_Magazine "{96F9473920A51844}Prefabs/Weapons/Magazines/Magazine_556x45_STANAG_20rnd_2+2.et"
+        m_MagazineCount 14
+       }
+      }
      }
     }
    }

--- a/Configs/Gearscripts/Custom/fluff/CRF_GS_UK80s_fluff.conf
+++ b/Configs/Gearscripts/Custom/fluff/CRF_GS_UK80s_fluff.conf
@@ -1,0 +1,646 @@
+CRF_GearScriptConfig {
+ m_FactionName "United Kingdom"
+ m_FactionIcon "{ADFB7BB15C9AF6F3}UI/Icons/Icon_UK.edds"
+ m_FactionWeapons CRF_Weapons "{65D00DC87CF99724}" {
+  m_Rifle {
+   CRF_Weapon_Class "{65D00DC87CF99730}" {
+    m_Weapon "{53CFFE29990A260D}Prefabs/Weapons/Rifles/AR15/Rifle_AR15_604_20rnd.et"
+    m_MagazineArray {
+     CRF_Magazine_Class "{65D00DC87CF99731}" {
+      m_Magazine "{96F9473920A51844}Prefabs/Weapons/Magazines/Magazine_556x45_STANAG_20rnd_2+2.et"
+      m_MagazineCount 14
+     }
+    }
+   }
+  }
+  m_RifleUGL {
+   CRF_Weapon_Class "{65D00DC87CF99737}" {
+    m_Weapon "{A0B26BDE66E0BA41}Prefabs/Weapons/Rifles/AR15/Rifle_AR15_M203_604_20rnd.et"
+    m_MagazineArray {
+     CRF_Magazine_Class "{65D00DC87CF99738}" {
+      m_Magazine "{96F9473920A51844}Prefabs/Weapons/Magazines/Magazine_556x45_STANAG_20rnd_2+2.et"
+      m_MagazineCount 14
+     }
+     CRF_Magazine_Class "{65D00DC87CF9973C}" {
+      m_Magazine "{1663496AE5B9F10B}Prefabs/Weapons/Ammo/Ammo_Grenade_HEDP_M433.et"
+      m_MagazineCount 4
+     }
+     CRF_Magazine_Class "{65D00DC87CF99700}" {
+      m_Magazine "{98DB57ECEDC81CC2}Prefabs/Weapons/Ammo/Ammo_Flare_40mm_M583A1_White.et"
+      m_MagazineCount 2
+     }
+     CRF_Magazine_Class "{65D00DC87CF99702}" {
+      m_Magazine "{0AF10C206CF1A282}Prefabs/Weapons/Ammo/US_Ammo_Smoke_Green.et"
+      m_MagazineCount 1
+     }
+     CRF_Magazine_Class "{65D00DC87CF99706}" {
+      m_Magazine "{2B0C4280078D96B6}Prefabs/Weapons/Ammo/US_Ammo_Smoke_Red.et"
+      m_MagazineCount 1
+     }
+     CRF_Magazine_Class "{65D00DC87CF99708}" {
+      m_Magazine "{AABE8FE0BA33DC8A}Prefabs/Weapons/Ammo/US_Ammo_Smoke_White.et"
+      m_MagazineCount 2
+     }
+    }
+   }
+  }
+  m_Carbine {
+   CRF_Weapon_Class "{65D00DC87CF9970D}" {
+    m_Weapon "{FF884E7842A33270}Prefabs/Weapons/Rifles/AR15/Rifle_CAR15_653_20rnd.et"
+    m_MagazineArray {
+     CRF_Magazine_Class "{65D00DC87CF9970E}" {
+      m_Magazine "{96F9473920A51844}Prefabs/Weapons/Magazines/Magazine_556x45_STANAG_20rnd_2+2.et"
+      m_MagazineCount 12
+     }
+    }
+   }
+  }
+  m_Pistol {
+   CRF_Weapon_Class "{65D00DC87CF9970F}" {
+    m_Weapon "{D9889FC9DB8C06C0}Prefabs/Weapons/Handguns/HiPower/Handgun_HiPower.et"
+    m_MagazineArray {
+     CRF_Magazine_Class "{65D00DC87CF99717}" {
+      m_Magazine "{1E7D876C06089E21}Prefabs/Weapons/Magazines/Magazine_9x19_HiPower_13rnd_Ball.et"
+      m_MagazineCount 3
+     }
+    }
+   }
+  }
+  m_AR CRF_Spec_Weapon_Class "{65D00DC87CF9971B}" {
+   m_Weapon "{D074FC61809F92F5}Prefabs/Weapons/MachineGuns/M249/MG_Minimi.et"
+   m_MagazineArray {
+    CRF_Spec_Magazine_Class "{65D00DC87CF9971D}" {
+     m_Magazine "{06D722FC2666EB83}Prefabs/Weapons/Magazines/Box_556x45_M249_200rnd_4Ball_1Tracer.et"
+     m_MagazineCount 3
+     m_AssistantMagazineCount 4
+    }
+   }
+  }
+  m_MMG CRF_Spec_Weapon_Class "{65D00DC87CF99760}" {
+   m_Weapon "{78975C5D9C1AFA4C}Prefabs/Weapons/MachineGuns/GPMG/MG_GPMG_L7A2.et"
+   m_MagazineArray {
+    CRF_Spec_Magazine_Class "{65D00DC87CF99761}" {
+     m_Magazine "{D22DF40D07DA4615}Prefabs/Weapons/Magazines/Box_762x51_GPMG_100rnd_4Ball_1Tracer.et"
+     m_MagazineCount 7
+     m_AssistantMagazineCount 8
+    }
+   }
+  }
+  m_AT CRF_Spec_Weapon_Class "{65D00DC87CF99766}" {
+   m_Weapon "{E0CFA3FE78FC5190}Prefabs/Weapons/Launchers/M72/Launcher_LAW66_L1A1.et"
+  }
+  m_MAT CRF_Spec_Weapon_Class "{65D00DC87CF99769}" {
+   m_Weapon "{DA376E83952F1DFD}Prefabs/Weapons/Launchers/M2CG/Launcher_M2CG.et"
+   m_MagazineArray {
+    CRF_Spec_Magazine_Class "{65D00DC87CF9976A}" {
+     m_Magazine "{0B1906A687028974}Prefabs/Weapons/Ammo/Ammo_Rocket_HEDP502.et"
+     m_MagazineCount 2
+     m_AssistantMagazineCount 2
+    }
+    CRF_Spec_Magazine_Class "{65D00DC87CF9976E}" {
+     m_Magazine "{972E4239C2F8D0DB}Prefabs/Weapons/Ammo/Ammo_Rocket_HE411B.et"
+     m_MagazineCount 1
+     m_AssistantMagazineCount 1
+    }
+   }
+  }
+  m_AA CRF_Spec_Weapon_Class "{65D00DC87CF99773}" {
+   m_Weapon "{3DF204EEE0534EF2}Prefabs/Weapons/Launchers/FIM92_Stinger/Launcher_FIM92_Stinger.et"
+   m_MagazineArray {
+    CRF_Spec_Magazine_Class "{65D00DC87CF99774}" {
+     m_Magazine "{3DF204EEE0534EF2}Prefabs/Weapons/Launchers/FIM92_Stinger/Launcher_FIM92_Stinger.et"
+     m_MagazineCount 1
+     m_AssistantMagazineCount 2
+    }
+   }
+  }
+  m_Sniper CRF_Weapon_Class "{65D00DC87CF99743}" {
+   m_Weapon "{81EB948E6414BD6F}Prefabs/Weapons/Rifles/M14/Rifle_M21_ARTII.et"
+   m_MagazineArray {
+    CRF_Magazine_Class "{65D00DC87CF99744}" {
+     m_Magazine "{627255315038152A}Prefabs/Weapons/Magazines/Magazine_762x51_M14_20rnd_SpecialBall.et"
+     m_MagazineCount 5
+    }
+   }
+  }
+ }
+ m_DefaultFactionGear CRF_Default_Gear "{65D00DC87CF9974C}" {
+  m_sLeadershipBinocularsPrefab "{9065E77698E63C1B}Prefabs/Items/Equipment/Binoculars/Binoculars_L12A1_Avimo.et"
+  m_sAssistantBinocularsPrefab "{9065E77698E63C1B}Prefabs/Items/Equipment/Binoculars/Binoculars_L12A1_Avimo.et"
+  m_DefaultMedicMedicalItems {
+   CRF_Inventory_Item "{65D00DC87CF9974D}" {
+    m_sItemPrefab "{A81F501D3EF6F38E}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_US_01.et"
+    m_iItemCount 10
+   }
+   CRF_Inventory_Item "{65D00DC87CF99752}" {
+    m_sItemPrefab "{D70216B1B2889129}Prefabs/Items/Medicine/Tourniquet_01/Tourniquet_US_01.et"
+    m_iItemCount 3
+   }
+   CRF_Inventory_Item "{65D00DC87CF99755}" {
+    m_sItemPrefab "{0D9A5DCF89AE7AA9}Prefabs/Items/Medicine/MorphineInjection_01/MorphineInjection_01.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{65D00DC87CF99759}" {
+    m_sItemPrefab "{5B2FD067D70C1E8F}Prefabs/Items/Medicine/EpinephrineInjection/ACE_Medical_EpinephrineInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{65D00DC87CF9975D}" {
+    m_sItemPrefab "{00E36F41CA310E2A}Prefabs/Items/Medicine/SalineBag_01/SalineBag_US_01.et"
+    m_iItemCount 5
+   }
+   CRF_Inventory_Item "{65D00DC87CF9975F}" {
+    m_sItemPrefab "{AE578EEA4244D41F}Prefabs/Items/Equipment/Kits/MedicalKit_01/MedicalKit_01_US.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{65D00DC87CF998A2}" {
+    m_sItemPrefab "{14C1A0F061D9DDEE}Prefabs/Weapons/Grenades/M18/Smoke_M18_Violet.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{65D00DC87CF998A4}" {
+    m_sItemPrefab "{D41D22DD1B8E921E}Prefabs/Weapons/Grenades/M18/Smoke_M18_Green.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{65D00DC87CF998A7}" {
+    m_sItemPrefab "{58CF3AB87C441295}Prefabs/Items/Medicine/AmmoniumCarbonatePackage/ACE_Medical_AmmoniumCarbonatePackage.et"
+    m_iItemCount 10
+   }
+   CRF_Inventory_Item "{65D00DC87CF998A8}" {
+    m_sItemPrefab "{02DD34077F51F65E}Prefabs/Items/Medicine/NaloxoneInjection/ACE_Medical_NaloxoneInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{65D00DC87CF998AA}" {
+    m_sItemPrefab "{9BBA766CD869002C}Prefabs/Items/Medicine/PhenylephrineInjection/ACE_Medical_PhenylephrineInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{65D00DC87CF998AC}" {
+    m_sItemPrefab "{D0434D5215B54181}Prefabs/Items/Medicine/MetoprololInjection/ACE_Medical_MetoprololInjection.et"
+    m_iItemCount 6
+   }
+  }
+  m_DefaultClothing {
+   CRF_Clothing "{65D00DC87CF998AE}" {
+    m_iClothingType BACKPACK
+    m_ClothingPrefabs {
+     "{CE832B86D234AD62}Prefabs/Items/Equipment/Backpacks/CRF_Backpack_Invisable.et"
+    }
+   }
+   CRF_Clothing "{65D00DC87CF998B3}" {
+    m_iClothingType HEADGEAR
+    m_ClothingPrefabs {
+     "{3CFFDE50C3FA8581}Prefabs/Characters/HeadGear/Hat_ECW/Hat_ECW_EarsUp_DPM_01.et"
+     "{709EA8530C2E5F7D}Prefabs/Characters/HeadGear/Hat_ECW/Hat_ECW_EarsDown_DPM_01.et"
+     "{6EC95DD403B97326}Prefabs/Characters/HeadGear/Helmet_HSAT_01/Helmet_HSAT_01_base.et"
+     "{6EC95DD403B97326}Prefabs/Characters/HeadGear/Helmet_HSAT_01/Helmet_HSAT_01_base.et"
+     "{85500C8BBF163D56}Prefabs/Characters/HeadGear/Helmet_HSAT_01/Helmet_HSAT_Cover_01.et"
+     "{2B23520E2A74387F}Prefabs/Characters/HeadGear/Helmet_HSAT_01/Helmet_HSAT_Cover_Net_01.et"
+     "{DA660EE7E43B8364}Prefabs/Characters/HeadGear/Helmet_HSAT_01/Helmet_HSAT_Cover_Net_Scrim_01.et"
+    }
+   }
+   CRF_Clothing "{65D00DC87CF998B8}" {
+    m_iClothingType SHIRT
+    m_ClothingPrefabs {
+     "{688C4289C3B91EF3}Prefabs/Characters/Uniforms/Jacket_M70_DPM_68.et"
+     "{406B620B4285240B}Prefabs/Characters/Uniforms/Smock_Combat_68Pat_DPM_01.et"
+     "{29FE6813D23713EA}Prefabs/Characters/Uniforms/Smock_Combat_Rolled_68Pat_DPM_01.et"
+     "{406B620B4285240B}Prefabs/Characters/Uniforms/Smock_Combat_68Pat_DPM_01.et"
+    }
+   }
+   CRF_Clothing "{65D00DC87CF998BD}" {
+    m_iClothingType ARMOREDVEST
+    m_ClothingPrefabs {
+     "{F342102250ED03CC}Prefabs/Characters/Vests/Vest_CBA/Vest_CBA.et"
+    }
+   }
+   CRF_Clothing "{65D00DC87CF99880}" {
+    m_iClothingType PANTS
+    m_ClothingPrefabs {
+     "{B229872AD9A322A4}Prefabs/Characters/Uniforms/Trousers_Combat_68Pat_DPM_01.et"
+     "{B229872AD9A322A4}Prefabs/Characters/Uniforms/Trousers_Combat_68Pat_DPM_01.et"
+     "{B229872AD9A322A4}Prefabs/Characters/Uniforms/Trousers_Combat_68Pat_DPM_01.et"
+     "{99AC8884E9595B90}Prefabs/Characters/Uniforms/Trousers_Lightweight_OD_01.et"
+     "{19D99E797021D64C}Prefabs/Characters/Uniforms/Trousers_Combat_68Pat_DPM_Tropical_01.et"
+    }
+   }
+   CRF_Clothing "{65D00DC87CF99885}" {
+    m_iClothingType BOOTS
+    m_ClothingPrefabs {
+     "{3E907D6732445C0F}Prefabs/Characters/Footwear/Boots_DMS_UK_01.et"
+    }
+   }
+   CRF_Clothing "{65D00DC87CF99887}" {
+    m_iClothingType VEST
+    m_ClothingPrefabs {
+     "{EBC6EF54E8AFF8BB}Prefabs/Characters/Vests/Vest_58Pattern/Variants/Vest_P58_rifleman.et"
+     "{1033EBAF2CD0FD52}Prefabs/Characters/Vests/Vest_58Pattern/Variants/Vest_P58_rifleman_2.et"
+    }
+   }
+  }
+  m_DefaultInventoryItems {
+   CRF_Inventory_Item "{65D00DC87CF9989A}" {
+    m_sItemPrefab "{3A421547BC29F679}Prefabs/Items/Equipment/Flashlights/Flashlight_MX991/Flashlight_MX991.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{65D00DC87CF9989D}" {
+    m_sItemPrefab "{CE179546A16382BA}Prefabs/Weapons/Grenades/Grenade_L2A2.et"
+    m_iItemCount 2
+   }
+   CRF_Inventory_Item "{65D00DC87CF998E1}" {
+    m_sItemPrefab "{96FFE213B19D1D57}Prefabs/Weapons/Grenades/Smoke_No80_WP.et"
+    m_iItemCount 2
+   }
+   CRF_Inventory_Item "{65D00DC87CF998E4}" {
+    m_sItemPrefab "{C8B6565467AA8CB7}Prefabs/Items/Equipment/Compass/Compass_Baseplate.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{65D00DC87CF998E6}" {
+    m_sItemPrefab "{13772C903CB5E4F7}Prefabs/Items/Equipment/Maps/PaperMap_01_folded.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{65D00DC87CF998E8}" {
+    m_sItemPrefab "{072E87366E193577}Prefabs/Items/Equipment/Watches/Watch_SandY184A_UK.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{65D00DC87CF998EB}" {
+    m_sItemPrefab "{06858A926A75DE90}Prefabs/Items/Medicine/FieldDressing_UK_Taped_01.et"
+    m_iItemCount 2
+   }
+   CRF_Inventory_Item "{65D00DC87CF998EC}" {
+    m_sItemPrefab "{842E93279EA18647}Prefabs/Items/Medicine/Tourniquet_01/Tourniquet_UK_01.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{65D00DC87CF998ED}" {
+    m_sItemPrefab "{6E35D94130954509}Prefabs/Items/Equipment/Accessories/ETool_ALICE/ETool_ALICE_FreeRoamBuilding_Gadget.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{65D00DC87CF998F1}" {
+    m_sItemPrefab "{8554ED3F088BADA6}Prefabs/Items/Core/Wirecutters/wirecutters.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{65D00DC87CF998F5}" {
+    m_sItemPrefab "{CBF9B9942E07B6B8}Prefabs/Items/Equipment/Accessories/ZipCuffs/ACE_Captives_ZipCuffs.et"
+    m_iItemCount 2
+   }
+   CRF_Inventory_Item "{65D00DC87CF998FA}" {
+    m_sItemPrefab "{AF6ECB8928E020C3}Prefabs/Items/PersonalBelongings/PersonalBelongings_UK.et"
+    m_iItemCount 1
+   }
+  }
+ }
+ m_CustomFactionGear CRF_Custom_Gear "{65D00DC87CF998FC}" {
+  m_RolesToSetCustomGear {
+   CRF_Role_Custom_Gear "{65D00DC87CF998FD}" {
+    m_Role VEHICLE_LEAD
+    m_Clothing {
+     CRF_Clothing "{65D00DC87CF998FF}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       ""
+      }
+     }
+     CRF_Clothing "{65D00DC87CF998C0}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{C42C535F667B250E}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_UK_01_tucked.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D00DC87CF998C2}" {
+    m_Role INDIRECT_LEAD
+    m_AdditionalInventoryItems {
+     CRF_Inventory_Item "{65D00DC87CF998C3}" {
+      m_sItemPrefab "{6113990D163E5249}Prefabs/Items/Equipment/BalisticTable/BalisticTable_US.et"
+      m_iItemCount 1
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D00DC87CF998C5}" {
+    m_Role LOGI_LEAD
+    m_Clothing {
+     CRF_Clothing "{65D00DC87CF998C6}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{0960A1A0B891F243}Prefabs/Items/Equipment/Backpacks/Rucksack_P58_Large_Pack.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D00DC87CF998C8}" {
+    m_Role MEDICAL_OFFICER
+    m_Clothing {
+     CRF_Clothing "{65D00DC87CF998CA}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{4805E67E2AE30F8D}Prefabs/Items/Equipment/Backpacks/Backpack_Medical_M5.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D00DC87CF998CD}" {
+    m_Role MEDIC
+    m_Clothing {
+     CRF_Clothing "{65D00DC87CF998CE}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{4805E67E2AE30F8D}Prefabs/Items/Equipment/Backpacks/Backpack_Medical_M5.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D00DC87CF998CF}" {
+    m_Role ASSISTANT_AUTOMATIC_RIFLEMAN
+    m_Clothing {
+     CRF_Clothing "{65D00DC87CF998D0}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{0960A1A0B891F243}Prefabs/Items/Equipment/Backpacks/Rucksack_P58_Large_Pack.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D00DC87CF998D1}" {
+    m_Role ASSISTANT_RIFLEMAN_ANTITANK
+    m_Clothing {
+     CRF_Clothing "{65D00DC87CF998D2}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{0960A1A0B891F243}Prefabs/Items/Equipment/Backpacks/Rucksack_P58_Large_Pack.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D01B11744A6167}" {
+    m_Role GRENADIER
+    m_PrimaryWeapon {
+     CRF_Weapon_Class "{65D01B11784FB044}" {
+      m_Weapon "{83096A3D7ACA6A07}Prefabs/Weapons/Launchers/M79/Launcher_M79.et"
+      m_MagazineArray {
+       CRF_Magazine_Class "{65D01B119821D5A7}" {
+        m_Magazine "{5375FA7CB1F68573}Prefabs/Weapons/Ammo/Ammo_Grenade_HE_M406.et"
+        m_MagazineCount 10
+       }
+       CRF_Magazine_Class "{65D01B119F8C7D88}" {
+        m_Magazine "{1663496AE5B9F10B}Prefabs/Weapons/Ammo/Ammo_Grenade_HEDP_M433.et"
+        m_MagazineCount 4
+       }
+       CRF_Magazine_Class "{65D01B11C3CED54A}" {
+        m_Magazine "{0AF10C206CF1A282}Prefabs/Weapons/Ammo/US_Ammo_Smoke_Green.et"
+        m_MagazineCount 2
+       }
+       CRF_Magazine_Class "{65D01B11C0DFD9CF}" {
+        m_Magazine "{2B0C4280078D96B6}Prefabs/Weapons/Ammo/US_Ammo_Smoke_Red.et"
+        m_MagazineCount 2
+       }
+       CRF_Magazine_Class "{65D01B11E84D331E}" {
+        m_Magazine "{5C54A41F9CBB1CCA}Prefabs/Weapons/Ammo/US_Ammo_Smoke_Purple.et"
+        m_MagazineCount 1
+       }
+       CRF_Magazine_Class "{65D01B11E89F5B5F}" {
+        m_Magazine "{AABE8FE0BA33DC8A}Prefabs/Weapons/Ammo/US_Ammo_Smoke_White.et"
+        m_MagazineCount 4
+       }
+      }
+     }
+    }
+    m_SecondaryWeapon {
+     CRF_Weapon_Class "{65D01B117DDBDA32}" {
+      m_Weapon "{ADDB4062CA2910CB}Prefabs/Weapons/Rifles/L2A3/Rifle_L2A3_Sterling.et"
+      m_MagazineArray {
+       CRF_Magazine_Class "{65D01B1605F91F3A}" {
+        m_Magazine "{01F56F6D9A15D96A}Prefabs/Weapons/Magazines/Magazine_9x19_L2A3_34rnd_BattleMix.et"
+        m_MagazineCount 9
+       }
+      }
+     }
+    }
+    m_Clothing {
+     CRF_Clothing "{65D01B1186B4B4CE}" {
+      m_iClothingType VEST
+      m_ClothingPrefabs {
+       "{2CBF6C876586A8CC}Prefabs/Characters/Vests/Vest_58Pattern/Variants/Vest_P58_GL.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D00DC87CF998D3}" {
+    m_Role ASSISTANT_HEAVY_ANTITANK
+    m_Clothing {
+     CRF_Clothing "{65D00DC87CF998D5}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{0960A1A0B891F243}Prefabs/Items/Equipment/Backpacks/Rucksack_P58_Large_Pack.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D00DC87CF998D6}" {
+    m_Role ASSISTANT_MEDIUM_ANTITANK
+    m_Clothing {
+     CRF_Clothing "{65D00DC87CF998D8}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{0960A1A0B891F243}Prefabs/Items/Equipment/Backpacks/Rucksack_P58_Large_Pack.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D00DC87CF998D9}" {
+    m_Role ASSISTANT_HEAVY_MACHINEGUN
+    m_Clothing {
+     CRF_Clothing "{65D00DC87CF998DA}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{0960A1A0B891F243}Prefabs/Items/Equipment/Backpacks/Rucksack_P58_Large_Pack.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D00DC87CF998DB}" {
+    m_Role ASSISTANT_MEDIUM_MACHINEGUN
+    m_Clothing {
+     CRF_Clothing "{65D00DC87CF96063}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{0960A1A0B891F243}Prefabs/Items/Equipment/Backpacks/Rucksack_P58_Large_Pack.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D00DC87CF96066}" {
+    m_Role ASSISTANT_ANTI_AIR
+    m_Clothing {
+     CRF_Clothing "{65D00DC87CF96067}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{0960A1A0B891F243}Prefabs/Items/Equipment/Backpacks/Rucksack_P58_Large_Pack.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D00DC87CF96098}" {
+    m_Role VEHICLE_DRIVER
+    m_Clothing {
+     CRF_Clothing "{65D00DC87CF96099}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       ""
+      }
+     }
+     CRF_Clothing "{65D00DC87CF9609B}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{C42C535F667B250E}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_UK_01_tucked.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D00DC87CF9609C}" {
+    m_Role VEHICLE_GUNNER
+    m_Clothing {
+     CRF_Clothing "{65D00DC87CF9609D}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       ""
+      }
+     }
+     CRF_Clothing "{65D00DC87CF9609E}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{C42C535F667B250E}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_UK_01_tucked.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D00DC87CF9609F}" {
+    m_Role VEHICLE_LOADER
+    m_Clothing {
+     CRF_Clothing "{65D00DC87CFEFDD9}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       ""
+      }
+     }
+     CRF_Clothing "{65D00DC87CFEFDD7}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{C42C535F667B250E}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_UK_01_tucked.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D00DC87CFEFDD4}" {
+    m_Role PILOT
+    m_Clothing {
+     CRF_Clothing "{65D00DC87CFEFDD2}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       ""
+      }
+     }
+     CRF_Clothing "{65D00DC87CFEFDD3}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{0EE94404A7B2657F}Prefabs/Characters/Uniforms/Suit_Pilot_US_01/Suit_Pilot_UK_01.et"
+      }
+     }
+     CRF_Clothing "{65D00DC87CFEFDD1}" {
+      m_iClothingType HEADGEAR
+      m_ClothingPrefabs {
+       "{483A80042765275F}Prefabs/Characters/HeadGear/Helmet_SPH4_01/Helmet_SPH4_01.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D00DC87CFEFDCD}" {
+    m_Role CREW_CHIEF
+    m_Clothing {
+     CRF_Clothing "{65D00DC87CFEFDCA}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       ""
+      }
+     }
+     CRF_Clothing "{65D00DC87CFEFDCB}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{0EE94404A7B2657F}Prefabs/Characters/Uniforms/Suit_Pilot_US_01/Suit_Pilot_UK_01.et"
+      }
+     }
+     CRF_Clothing "{65D00DC87CFEFDC8}" {
+      m_iClothingType HEADGEAR
+      m_ClothingPrefabs {
+       "{483A80042765275F}Prefabs/Characters/HeadGear/Helmet_SPH4_01/Helmet_SPH4_01.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D00DC87CFEFDC9}" {
+    m_Role LOGI_RUNNER
+    m_Clothing {
+     CRF_Clothing "{65D00DC87CFEFDC6}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{0960A1A0B891F243}Prefabs/Items/Equipment/Backpacks/Rucksack_P58_Large_Pack.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D00DC87CFEFDC7}" {
+    m_Role INDIRECT_GUNNER
+    m_Clothing {
+     CRF_Clothing "{65D00DC87CFEFDC5}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{EE53109CB37C43B1}Prefabs/Items/Equipment/Backpacks/M2/Backpack_m252_Mortar_Weapon.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D00DC87CFEFDC3}" {
+    m_Role INDIRECT_GUNNER
+    m_Clothing {
+     CRF_Clothing "{65D00DC87CFEFDEC}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{A207909C42E58944}Prefabs/Items/Equipment/Backpacks/Backpack_US_Tripod.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D00DC87CFEFDEB}" {
+    m_Role RIFLEMAN_DEMO
+    m_AdditionalInventoryItems {
+     CRF_Inventory_Item "{65D00DC87CFEFDE8}" {
+      m_sItemPrefab "{D9B1F65D20081DEF}PrefabsEditable/Explosives/E_DemoBlock_M112.et"
+      m_iItemCount 2
+     }
+     CRF_Inventory_Item "{65D00DC87CFEFDE4}" {
+      m_sItemPrefab "{CE0AF733722B3978}Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_M34.et"
+      m_iItemCount 1
+     }
+     CRF_Inventory_Item "{65D00DC87CFEFDE3}" {
+      m_sItemPrefab "{55641F140F92FDCD}Prefabs/Weapons/Explosives/Explosive_Satchels/BLUFOR_Satchel.et"
+      m_iItemCount 1
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D00DC87CFEFDE1}" {
+    m_Role COMBAT_ENGINEER
+    m_AdditionalInventoryItems {
+     CRF_Inventory_Item "{65D00DC87CFEFD9E}" {
+      m_sItemPrefab "{D9B1F65D20081DEF}PrefabsEditable/Explosives/E_DemoBlock_M112.et"
+      m_iItemCount 1
+     }
+     CRF_Inventory_Item "{65D00DC87CFE795A}" {
+      m_sItemPrefab "{CE0AF733722B3978}Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_M34.et"
+      m_iItemCount 1
+     }
+     CRF_Inventory_Item "{65D00DC87CFE795B}" {
+      m_sItemPrefab "{55641F140F92FDCD}Prefabs/Weapons/Explosives/Explosive_Satchels/BLUFOR_Satchel.et"
+      m_iItemCount 3
+     }
+    }
+   }
+  }
+ }
+}

--- a/Configs/Gearscripts/Custom/fluff/CRF_GS_UK80s_fluff.conf
+++ b/Configs/Gearscripts/Custom/fluff/CRF_GS_UK80s_fluff.conf
@@ -187,8 +187,6 @@ CRF_GearScriptConfig {
    CRF_Clothing "{65D00DC87CF998B3}" {
     m_iClothingType HEADGEAR
     m_ClothingPrefabs {
-     "{3CFFDE50C3FA8581}Prefabs/Characters/HeadGear/Hat_ECW/Hat_ECW_EarsUp_DPM_01.et"
-     "{709EA8530C2E5F7D}Prefabs/Characters/HeadGear/Hat_ECW/Hat_ECW_EarsDown_DPM_01.et"
      "{6EC95DD403B97326}Prefabs/Characters/HeadGear/Helmet_HSAT_01/Helmet_HSAT_01_base.et"
      "{6EC95DD403B97326}Prefabs/Characters/HeadGear/Helmet_HSAT_01/Helmet_HSAT_01_base.et"
      "{85500C8BBF163D56}Prefabs/Characters/HeadGear/Helmet_HSAT_01/Helmet_HSAT_Cover_01.et"
@@ -609,6 +607,32 @@ CRF_GearScriptConfig {
         m_Magazine "{96F9473920A51844}Prefabs/Weapons/Magazines/Magazine_556x45_STANAG_20rnd_2+2.et"
         m_MagazineCount 14
        }
+      }
+     }
+    }
+    m_AdditionalInventoryItems {
+     CRF_Inventory_Item "{65D4611A625F241E}" {
+      m_sItemPrefab "{0FA212334ACFBABB}Prefabs/Items/Equipment/Radios/BLUFOR_Radio_GI.et"
+      m_iItemCount 1
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D4611A7068D2F4}" {
+    m_Role PLATOON_LEADER
+    m_Clothing {
+     CRF_Clothing "{65D4611A7B8064AC}" {
+      m_ClothingPrefabs {
+       "{7CA4B6E76443A62E}Prefabs/Characters/HeadGear/Hat_Beret_01/Hat_Beret_01_Marine.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{65D4611A7726BEDA}" {
+    m_Role PLATOON_SERGEANT
+    m_Clothing {
+     CRF_Clothing "{65D4611A9316080A}" {
+      m_ClothingPrefabs {
+       "{7CA4B6E76443A62E}Prefabs/Characters/HeadGear/Hat_Beret_01/Hat_Beret_01_Marine.et"
       }
      }
     }

--- a/Configs/Gearscripts/Custom/fluff/CRF_GS_UK80s_fluff.conf.meta
+++ b/Configs/Gearscripts/Custom/fluff/CRF_GS_UK80s_fluff.conf.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{0AA69970E43F5CE5}Configs/Gearscripts/Standard/80s/CRF_GS_UK80s_fluff.conf"
+ Configurations {
+  CONFResourceClass PC {
+  }
+  CONFResourceClass XBOX_ONE : PC {
+  }
+  CONFResourceClass XBOX_SERIES : PC {
+  }
+  CONFResourceClass PS4 : PC {
+  }
+  CONFResourceClass PS5 : PC {
+  }
+  CONFResourceClass HEADLESS : PC {
+  }
+  CONFResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Missions/CRF_S&D89_FullEnglish.conf
+++ b/Missions/CRF_S&D89_FullEnglish.conf
@@ -1,0 +1,12 @@
+SCR_MissionHeader {
+ World "{10DA4DD2E6A26A16}Worlds/COALobby/Gogland/FullEnglish.ent"
+ m_sName "Full English"
+ m_sAuthor "fluff_"
+ m_sDescription "Gogland Search and destroy"
+ m_sIcon "{B7385DA4504BD4D5}CRF Images/crflogo.edds"
+ m_sLoadingScreen "{B7385DA4504BD4D5}CRF Images/crflogo.edds"
+ m_sPreviewImage "{B7385DA4504BD4D5}CRF Images/crflogo.edds"
+ m_sGameMode "Search and Destroy"
+ m_iPlayerCount 89
+ m_iMapMarkerLimitPerPlayer 120
+}

--- a/Missions/CRF_S&D89_FullEnglish.conf.meta
+++ b/Missions/CRF_S&D89_FullEnglish.conf.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{FD5AB82093CCBE70}Missions/CRF_SND89_FullEnglish.conf"
+ Configurations {
+  CONFResourceClass PC {
+  }
+  CONFResourceClass XBOX_ONE : PC {
+  }
+  CONFResourceClass XBOX_SERIES : PC {
+  }
+  CONFResourceClass PS4 : PC {
+  }
+  CONFResourceClass PS5 : PC {
+  }
+  CONFResourceClass HEADLESS : PC {
+  }
+  CONFResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Rifles/AR15/Rifle_AR15_604_20rnd.et
+++ b/Prefabs/Weapons/Rifles/AR15/Rifle_AR15_604_20rnd.et
@@ -1,0 +1,30 @@
+GenericEntity : "{A7D7A2CE27279236}Prefabs/Weapons/Rifles/M16/Rifle_AR15_base.et" {
+ ID "CFBAA4B725411E45"
+ components {
+  WeaponComponent "{CFBAA4B706BA66E8}" {
+   components {
+    AttachmentSlotComponent "{65ACCAF5678E650A}" {
+     AttachmentSlot InventoryStorageSlot Handguard {
+      Prefab "{9DA34415492DCF5E}Prefabs/Weapons/Attachments/Handguards/Handguard_M16A1_Triangle/Handguard_AR15_Triangle.et"
+     }
+    }
+    MuzzleComponent "{CA6BE4D6B867541F}" {
+     WeaponAimModifiers {
+      RecoilWeaponAimModifier "{65ACCAF5678F52B5}" {
+       LinearData RecoilData "{65ACCAF5678F52B4}" {
+        "Curve Magnitudes" 1.2 1.2 1.2
+       }
+       AngularData RecoilData "{65ACCAF5678F52B3}" {
+        "Curve Magnitudes" 1.2 1.2 1.2
+       }
+       TurnOffsetData RecoilData "{65ACCAF5678F52B1}" {
+        "Curve Magnitudes" 1.4 1.4 0
+       }
+      }
+     }
+     MagazineTemplate "{96F9473920A51844}Prefabs/Weapons/Magazines/Magazine_556x45_STANAG_20rnd_2+2.et"
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Weapons/Rifles/AR15/Rifle_AR15_604_20rnd.et.meta
+++ b/Prefabs/Weapons/Rifles/AR15/Rifle_AR15_604_20rnd.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{53CFFE29990A260D}Prefabs/Weapons/Rifles/M16/Rifle_AR15_604_20rnd.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Rifles/AR15/Rifle_AR15_M203_604_20rnd.et
+++ b/Prefabs/Weapons/Rifles/AR15/Rifle_AR15_M203_604_20rnd.et
@@ -1,0 +1,39 @@
+GenericEntity : "{DAA36547CA7D808E}Prefabs/Weapons/Rifles/M16/Rifle_AR15_M203_base.et" {
+ ID "CFBAA4B725411E45"
+ components {
+  SCR_WeaponAttachmentsStorageComponent "{51F080D5CE45A1A2}" {
+   Attributes SCR_ItemAttributeCollection "{51F080D5C64F12C5}" {
+   }
+  }
+  WeaponComponent "{CFBAA4B706BA66E8}" {
+   components {
+    AttachmentSlotComponent "{5534745C44D1EF58}" {
+     AttachmentSlot InventoryStorageSlot optics {
+     }
+    }
+    AttachmentSlotComponent "{65ACCAF6A00E5DDB}" {
+     AttachmentSlot InventoryStorageSlot underbarrel {
+      Offset 0 0 -0.01
+      Prefab "{635E3A255B60888F}Prefabs/Weapons/Attachments/Underbarrel/UGL_M203_long_parkerised.et"
+     }
+    }
+    MuzzleComponent "{CA6BE4D6B867541F}" {
+     WeaponAimModifiers {
+      RecoilWeaponAimModifier "{65ACCAF5678F52B5}" {
+       LinearData RecoilData "{65ACCAF5678F52B4}" {
+        "Curve Magnitudes" 1.2 1.2 1.2
+       }
+       AngularData RecoilData "{65ACCAF5678F52B3}" {
+        "Curve Magnitudes" 1.2 1.2 1.2
+       }
+       TurnOffsetData RecoilData "{65ACCAF5678F52B1}" {
+        "Curve Magnitudes" 1.4 1.4 0
+       }
+      }
+     }
+     MagazineTemplate "{96F9473920A51844}Prefabs/Weapons/Magazines/Magazine_556x45_STANAG_20rnd_2+2.et"
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Weapons/Rifles/AR15/Rifle_AR15_M203_604_20rnd.et.meta
+++ b/Prefabs/Weapons/Rifles/AR15/Rifle_AR15_M203_604_20rnd.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{A0B26BDE66E0BA41}Prefabs/Weapons/Rifles/M16/Rifle_AR15_M203_604_20rnd.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Rifles/AR15/Rifle_CAR15_653_20rnd.et
+++ b/Prefabs/Weapons/Rifles/AR15/Rifle_CAR15_653_20rnd.et
@@ -1,0 +1,25 @@
+GenericEntity : "{66346810703572BC}Prefabs/Weapons/Rifles/M16/Rifle_CAR15_base.et" {
+ ID "CFBAA4B725411E45"
+ components {
+  WeaponComponent "{CFBAA4B706BA66E8}" {
+   components {
+    MuzzleComponent "{CA6BE4D6B867541F}" {
+     WeaponAimModifiers {
+      RecoilWeaponAimModifier "{65ACCAF5678F52B5}" {
+       LinearData RecoilData "{65ACCAF5678F52B4}" {
+        "Curve Magnitudes" 1.5 1.5 1.2
+       }
+       AngularData RecoilData "{65ACCAF5678F52B3}" {
+        "Curve Magnitudes" 1.5 1.5 1.2
+       }
+       TurnOffsetData RecoilData "{65ACCAF5678F52B1}" {
+        "Curve Magnitudes" 1.5 1.5 0
+       }
+      }
+     }
+     MagazineTemplate "{96F9473920A51844}Prefabs/Weapons/Magazines/Magazine_556x45_STANAG_20rnd_2+2.et"
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Weapons/Rifles/AR15/Rifle_CAR15_653_20rnd.et.meta
+++ b/Prefabs/Weapons/Rifles/AR15/Rifle_CAR15_653_20rnd.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{FF884E7842A33270}Prefabs/Weapons/Rifles/M16/Rifle_CAR15_653_20rnd.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Worlds/COALobby/Gogland/FullEnglish.ent
+++ b/Worlds/COALobby/Gogland/FullEnglish.ent
@@ -1,0 +1,3 @@
+SubScene {
+ Parent "{246FC37C0435BBCD}Worlds/Gogland/Gogland.ent"
+}

--- a/Worlds/COALobby/Gogland/FullEnglish.ent.meta
+++ b/Worlds/COALobby/Gogland/FullEnglish.ent.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{10DA4DD2E6A26A16}Worlds/COALobby/Gogland/FullEnglish.ent"
+ Configurations {
+  ENTResourceClass PC {
+  }
+  ENTResourceClass XBOX_ONE : PC {
+  }
+  ENTResourceClass XBOX_SERIES : PC {
+  }
+  ENTResourceClass PS4 : PC {
+  }
+  ENTResourceClass PS5 : PC {
+  }
+  ENTResourceClass HEADLESS : PC {
+  }
+  ENTResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Worlds/COALobby/Gogland/FullEnglish_Layers/blufor.layer
+++ b/Worlds/COALobby/Gogland/FullEnglish_Layers/blufor.layer
@@ -28,11 +28,19 @@ SCR_AIGroup : "{3D4D53B053964445}Prefabs/Groups/BLUFOR/Standard/Command/CRF_BLUF
             "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{690B6588C8F675A4}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AR_P.et" "{F8F683DD0F361239}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AAR_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{EC7EF569E938BD63}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_Gren_P.et"
            }
            {
-            SCR_AIGroup : "{5804AD2759E17E13}Prefabs/Groups/BLUFOR/Standard/Vehicle/CRF_BLUFOR_3manCrew_p.et" {
-             coords 15.947 0.465 -6.086
+            SCR_AIGroup : "{9C45BAF40F909576}Prefabs/Groups/BLUFOR/Standard/Infantry/CRF_BLUFOR_RifleSquad_p.et" {
+             coords -0.087 -0.178 -5.076
+             m_aUnitPrefabSlots {
+              "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{690B6588C8F675A4}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AR_P.et" "{F8F683DD0F361239}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AAR_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{EC7EF569E938BD63}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_Gren_P.et"
+             }
              {
               SCR_AIGroup : "{5804AD2759E17E13}Prefabs/Groups/BLUFOR/Standard/Vehicle/CRF_BLUFOR_3manCrew_p.et" {
-               coords 2.455 20.941 -7.596
+               coords 16.034 0.643 -1.01
+               {
+                SCR_AIGroup : "{5804AD2759E17E13}Prefabs/Groups/BLUFOR/Standard/Vehicle/CRF_BLUFOR_3manCrew_p.et" {
+                 coords 2.455 20.941 -7.596
+                }
+               }
               }
              }
             }

--- a/Worlds/COALobby/Gogland/FullEnglish_Layers/blufor.layer
+++ b/Worlds/COALobby/Gogland/FullEnglish_Layers/blufor.layer
@@ -1,20 +1,140 @@
-$grp SCR_AIGroup : "{9C45BAF40F909576}Prefabs/Groups/BLUFOR/Standard/Infantry/CRF_BLUFOR_RifleSquad_p.et" {
+SCR_AIGroup : "{3D4D53B053964445}Prefabs/Groups/BLUFOR/Standard/Command/CRF_BLUFOR_Platoon_p.et" {
+ coords 7332.289 4.185 1099.504
  {
-  coords 7305.243 5.112 1088.778
-  m_aUnitPrefabSlots {
-   "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{690B6588C8F675A4}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AR_P.et" "{F8F683DD0F361239}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AAR_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{EC7EF569E938BD63}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_Gren_P.et"
+  SCR_AIGroup : "{D0B17EDF43465305}Prefabs/Groups/BLUFOR/Standard/Support/CRF_BLUFOR_MedicTeam_p.et" {
+   coords 13.038 29.1 10.401
+   {
+    SCR_AIGroup : "{9C45BAF40F909576}Prefabs/Groups/BLUFOR/Standard/Infantry/CRF_BLUFOR_RifleSquad_p.et" {
+     coords -50.647 -26.872 -27.425
+     m_aUnitPrefabSlots {
+      "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{690B6588C8F675A4}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AR_P.et" "{F8F683DD0F361239}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AAR_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{EC7EF569E938BD63}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_Gren_P.et"
+     }
+     {
+      SCR_AIGroup : "{9C45BAF40F909576}Prefabs/Groups/BLUFOR/Standard/Infantry/CRF_BLUFOR_RifleSquad_p.et" {
+       coords 1.305 0.059 -5.435
+       m_aUnitPrefabSlots {
+        "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{690B6588C8F675A4}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AR_P.et" "{F8F683DD0F361239}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AAR_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{EC7EF569E938BD63}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_Gren_P.et"
+       }
+       {
+        SCR_AIGroup : "{9C45BAF40F909576}Prefabs/Groups/BLUFOR/Standard/Infantry/CRF_BLUFOR_RifleSquad_p.et" {
+         coords 0.24 -0.439 -4.299
+         m_aUnitPrefabSlots {
+          "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{690B6588C8F675A4}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AR_P.et" "{F8F683DD0F361239}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AAR_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{EC7EF569E938BD63}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_Gren_P.et"
+         }
+         {
+          SCR_AIGroup : "{9C45BAF40F909576}Prefabs/Groups/BLUFOR/Standard/Infantry/CRF_BLUFOR_RifleSquad_p.et" {
+           coords -2.597 -1.169 -8.265
+           m_aUnitPrefabSlots {
+            "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{690B6588C8F675A4}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AR_P.et" "{F8F683DD0F361239}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AAR_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{EC7EF569E938BD63}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_Gren_P.et"
+           }
+           {
+            SCR_AIGroup : "{5804AD2759E17E13}Prefabs/Groups/BLUFOR/Standard/Vehicle/CRF_BLUFOR_3manCrew_p.et" {
+             coords 15.947 0.465 -6.086
+             {
+              SCR_AIGroup : "{5804AD2759E17E13}Prefabs/Groups/BLUFOR/Standard/Vehicle/CRF_BLUFOR_3manCrew_p.et" {
+               coords 2.455 20.941 -7.596
+              }
+             }
+            }
+           }
+          }
+         }
+        }
+       }
+      }
+     }
+    }
+   }
   }
  }
+}
+$grp GenericEntity : "{8B3E3492620C745C}PrefabsEditable/CRF_VehicleSpawner.et" {
  {
-  coords 7295.126 6.356 1082.256
-  m_aUnitPrefabSlots {
-   "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{690B6588C8F675A4}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AR_P.et" "{F8F683DD0F361239}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AAR_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{EC7EF569E938BD63}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_Gren_P.et"
+  components {
+   CRF_VehicleSpawner "{64626B666A3B82E3}" {
+    m_rVehicle "{671AA29846EC7406}Prefabs/Vehicles/Wheeled/M998/M997_maxi_ambulance_UK.et"
+   }
   }
+  coords 7348.795 6.356 1131.74
+  angleX 0
+  angleY 0
+  angleZ 0
  }
  {
-  coords 7278.081 6.365 1071.109
-  m_aUnitPrefabSlots {
-   "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{690B6588C8F675A4}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AR_P.et" "{F8F683DD0F361239}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AAR_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{EC7EF569E938BD63}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_Gren_P.et"
+  components {
+   CRF_VehicleSpawner "{64626B666A3B82E3}" {
+    m_rVehicle "{D278451CC406036E}Prefabs/Vehicles/Wheeled/LR_3Series/3Series_SWB_Transport_Variant_3.et"
+   }
   }
+  coords 7344.33 5.99 1136.272
+  angleX 0
+  angleY 0
+  angleZ 0
+ }
+ {
+  components {
+   CRF_VehicleSpawner "{64626B666A3B82E3}" {
+    m_rVehicle "{53982BB1E5E3BE60}Prefabs/Vehicles/Wheeled/LR_3Series/3Series_LWB_Recce.et"
+   }
+  }
+  coords 7317.911 3.967 1110.094
+  angleX 0
+  angleY 68.155
+  angleZ 0
+ }
+ {
+  components {
+   CRF_VehicleSpawner "{64626B666A3B82E3}" {
+    m_rVehicle "{7E1384719B3EF464}Prefabs/Vehicles/Wheeled/LR_3Series/3Series_LWB_Recce_Variant_3.et"
+   }
+  }
+  coords 7326.192 4.134 1108.499
+  angleX 0
+  angleY 0
+  angleZ 0
+ }
+ {
+  components {
+   CRF_VehicleSpawner "{64626B666A3B82E3}" {
+    m_rVehicle "{701ADC27F9D842DF}Prefabs/Vehicles/Wheeled/LR_3Series/3Series_LWB_Transport.et"
+   }
+  }
+  coords 7330.804 5.982 1148.812
+  angleX 0
+  angleY 0
+  angleZ 0
+ }
+ {
+  components {
+   CRF_VehicleSpawner "{64626B666A3B82E3}" {
+    m_rVehicle "{098E31B006CAE0CE}Prefabs/Vehicles/Wheeled/LR_3Series/3Series_LWB_Transport_Camo.et"
+   }
+  }
+  coords 7334.03 5.597 1138.724
+  angleX 0
+  angleY 0
+  angleZ 0
+ }
+ {
+  components {
+   CRF_VehicleSpawner "{64626B666A3B82E3}" {
+    m_rVehicle "{FDDB4A5C62272B16}Prefabs/Vehicles/Wheeled/LR_3Series/3Series_LWB_Transport_Variant_2.et"
+   }
+  }
+  coords 7337.208 5.191 1127.732
+  angleX 0
+  angleY 0
+  angleZ 0
+ }
+ {
+  components {
+   CRF_VehicleSpawner "{64626B666A3B82E3}" {
+    m_rVehicle "{184706A56EC2BC7D}Prefabs/Vehicles/Wheeled/LR_3Series/3Series_LWB_Transport_Variant_3.et"
+   }
+  }
+  coords 7339.379 4.92 1116.894
+  angleX 0
+  angleY 0
+  angleZ 0
  }
 }

--- a/Worlds/COALobby/Gogland/FullEnglish_Layers/blufor.layer
+++ b/Worlds/COALobby/Gogland/FullEnglish_Layers/blufor.layer
@@ -1,0 +1,20 @@
+$grp SCR_AIGroup : "{9C45BAF40F909576}Prefabs/Groups/BLUFOR/Standard/Infantry/CRF_BLUFOR_RifleSquad_p.et" {
+ {
+  coords 7305.243 5.112 1088.778
+  m_aUnitPrefabSlots {
+   "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{690B6588C8F675A4}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AR_P.et" "{F8F683DD0F361239}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AAR_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{EC7EF569E938BD63}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_Gren_P.et"
+  }
+ }
+ {
+  coords 7295.126 6.356 1082.256
+  m_aUnitPrefabSlots {
+   "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{690B6588C8F675A4}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AR_P.et" "{F8F683DD0F361239}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AAR_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{EC7EF569E938BD63}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_Gren_P.et"
+  }
+ }
+ {
+  coords 7278.081 6.365 1071.109
+  m_aUnitPrefabSlots {
+   "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{690B6588C8F675A4}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AR_P.et" "{F8F683DD0F361239}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AAR_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{EC7EF569E938BD63}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_Gren_P.et"
+  }
+ }
+}

--- a/Worlds/COALobby/Gogland/FullEnglish_Layers/init.layer
+++ b/Worlds/COALobby/Gogland/FullEnglish_Layers/init.layer
@@ -5,9 +5,45 @@ CRF_Gamemode CRF_Lobby1 : "{6A996BBFCEB37E78}Prefabs/MP/Modes/Lobby/CRF_Lobby.et
  components {
   CRF_SearchAndDestroyGamemodeManager "{65D01B16AAD89F2D}" {
   }
+  SCR_InitWeatherComponent "{64427EEC0AFF43EE}" {
+   m_sInitialStartingWeatherId "Clear"
+  }
+  SCR_TimeAndWeatherHandlerComponent "{64427EEC304DD9A0}" {
+   m_bUsePredefineStartingTimeAndWeather 1
+   m_aStartingWeatherAndTime {
+    SCR_TimeAndWeatherState "{65D4611AB12A3DB3}" {
+     m_sWeatherPresetName "Clear Fog"
+    }
+   }
+  }
  }
  coords 7302.647 4.99 1064.706
- m_iTimeLimitMinutes 60
+ m_aMissionDescriptors {
+  CRF_MissionDescriptor "{644250503DF684C0}" {
+   m_sTextData "The UK's forces will try and detonate two bombsites on Gogland. One of them is of quite some strategic signifigance, best hope the bomb doesn't cause any collateral, perhaps nuclear, damage."\
+   ""\
+   "BLUFOR Composition: Motorized"\
+   "BLUFOR Assets: 2x Land Rover Gun Trucks"\
+   ""\
+   "OPFOR Composition: Infantry"\
+   "OPFOR Assets: 1x HMG Team"\
+   ""\
+   "Time: 0800"\
+   "Weather: Clear Fog"\
+   "Length: 45 minutes"
+  }
+  CRF_MissionDescriptor "{64425051F2E00216}" {
+   m_sTextData "Destroy Bombsites Alpha and Bravo"
+  }
+  CRF_MissionDescriptor "{64425051B9B5AF67}" {
+   m_sTextData "Defend Bombsites Alpha and Bravo"
+  }
+  CRF_MissionDescriptor "{6442505149CF6C93}" {
+   m_sTextData "No GI Radios are available. Leadership has 2 channel radios and TLs have 1 channel radios."\
+   "TLs have had their GLs removed."
+   m_bShowForAnyFaction 1
+  }
+ }
  m_iFactionOneRatio 3
  m_sFactionOneKey "BLU"
  m_iFactionTwoRatio 2
@@ -22,7 +58,7 @@ CRF_Gamemode CRF_Lobby1 : "{6A996BBFCEB37E78}Prefabs/MP/Modes/Lobby/CRF_Lobby.et
  }
  m_iTimeToRespawn 45
  {
-  SCR_FactionManager {
+  SCR_FactionManager "65D46118B579BB2B" {
    ID "632A77473B3CC3A8"
    Factions {
     SCR_Faction "{628B22E9B4056C88}" {
@@ -44,9 +80,12 @@ CRF_Gamemode CRF_Lobby1 : "{6A996BBFCEB37E78}Prefabs/MP/Modes/Lobby/CRF_Lobby.et
         m_sCallsign "1-4"
        }
        SCR_CallsignInfo "{65D4470F419BA7D0}" {
-        m_sCallsign "GT1"
+        m_sCallsign "1-5"
        }
        SCR_CallsignInfo "{65D4470F467866AB}" {
+        m_sCallsign "GT1"
+       }
+       SCR_CallsignInfo "{65D4611EA3AE5DAA}" {
         m_sCallsign "GT2"
        }
       }

--- a/Worlds/COALobby/Gogland/FullEnglish_Layers/init.layer
+++ b/Worlds/COALobby/Gogland/FullEnglish_Layers/init.layer
@@ -20,7 +20,7 @@ CRF_Gamemode CRF_Lobby1 : "{6A996BBFCEB37E78}Prefabs/MP/Modes/Lobby/CRF_Lobby.et
  coords 7302.647 4.99 1064.706
  m_aMissionDescriptors {
   CRF_MissionDescriptor "{644250503DF684C0}" {
-   m_sTextData "The UK's forces will try and detonate two bombsites on Gogland. One of them is of quite some strategic signifigance, best hope the bomb doesn't cause any collateral, perhaps nuclear, damage."\
+   m_sTextData "The UK's forces will try and detonate two bombsites on Gogland. One of them is of quite some strategic significance, best hope the bomb doesn't cause any collateral, perhaps nuclear, damage."\
    ""\
    "BLUFOR Composition: Motorized"\
    "BLUFOR Assets: 2x Land Rover Gun Trucks"\

--- a/Worlds/COALobby/Gogland/FullEnglish_Layers/init.layer
+++ b/Worlds/COALobby/Gogland/FullEnglish_Layers/init.layer
@@ -6,7 +6,7 @@ CRF_Gamemode CRF_Lobby1 : "{6A996BBFCEB37E78}Prefabs/MP/Modes/Lobby/CRF_Lobby.et
   CRF_SearchAndDestroyGamemodeManager "{65D01B16AAD89F2D}" {
   }
   SCR_InitWeatherComponent "{64427EEC0AFF43EE}" {
-   m_sInitialStartingWeatherId "Clear"
+   m_sInitialStartingWeatherId "Clear Fog"
   }
   SCR_TimeAndWeatherHandlerComponent "{64427EEC304DD9A0}" {
    m_bUsePredefineStartingTimeAndWeather 1

--- a/Worlds/COALobby/Gogland/FullEnglish_Layers/init.layer
+++ b/Worlds/COALobby/Gogland/FullEnglish_Layers/init.layer
@@ -1,0 +1,17 @@
+SCR_AIWorld : "{656B40C99B8724C5}Prefabs/AI/SCR_AIWorld_Gogland.et" {
+ coords 7301.776 5.285 1071.333
+}
+CRF_Gamemode CRF_Lobby1 : "{6A996BBFCEB37E78}Prefabs/MP/Modes/Lobby/CRF_Lobby.et" {
+ components {
+  CRF_SearchAndDestroyGamemodeManager "{65D01B16AAD89F2D}" {
+  }
+ }
+ coords 7302.647 4.99 1064.706
+ m_iTimeLimitMinutes 60
+ m_BLUFORGearScriptSettings CRF_GearScriptContainer "{64570ACB9B419A7B}" {
+  m_rGearScript "{0AA69970E43F5CE5}Configs/Gearscripts/Custom/fluff/CRF_GS_UK80s_fluff.conf"
+ }
+ m_OPFORGearScriptSettings CRF_GearScriptContainer "{64570ACB9B11EAAD}" {
+  m_rGearScript "{E22DAC2682656C91}Configs/Gearscripts/Custom/fluff/CRF_GS_80sUSSRklmk.conf"
+ }
+}

--- a/Worlds/COALobby/Gogland/FullEnglish_Layers/init.layer
+++ b/Worlds/COALobby/Gogland/FullEnglish_Layers/init.layer
@@ -1,5 +1,5 @@
-SCR_AIWorld : "{656B40C99B8724C5}Prefabs/AI/SCR_AIWorld_Gogland.et" {
- coords 7301.776 5.285 1071.333
+SCR_AIWorld : "{E0A05C76552E7F58}Prefabs/AI/SCR_AIWorld.et" {
+ coords 7294.133 4.872 1064.842
 }
 CRF_Gamemode CRF_Lobby1 : "{6A996BBFCEB37E78}Prefabs/MP/Modes/Lobby/CRF_Lobby.et" {
  components {
@@ -8,10 +8,72 @@ CRF_Gamemode CRF_Lobby1 : "{6A996BBFCEB37E78}Prefabs/MP/Modes/Lobby/CRF_Lobby.et
  }
  coords 7302.647 4.99 1064.706
  m_iTimeLimitMinutes 60
+ m_iFactionOneRatio 3
+ m_sFactionOneKey "BLU"
+ m_iFactionTwoRatio 2
+ m_sFactionTwoKey "OPF"
  m_BLUFORGearScriptSettings CRF_GearScriptContainer "{64570ACB9B419A7B}" {
   m_rGearScript "{0AA69970E43F5CE5}Configs/Gearscripts/Custom/fluff/CRF_GS_UK80s_fluff.conf"
+  m_bEnableGIRadios 0
  }
  m_OPFORGearScriptSettings CRF_GearScriptContainer "{64570ACB9B11EAAD}" {
   m_rGearScript "{E22DAC2682656C91}Configs/Gearscripts/Custom/fluff/CRF_GS_80sUSSRklmk.conf"
+  m_bEnableGIRadios 0
+ }
+ m_iTimeToRespawn 45
+ {
+  SCR_FactionManager {
+   ID "632A77473B3CC3A8"
+   Factions {
+    SCR_Faction "{628B22E9B4056C88}" {
+     m_CallsignInfo SCR_FactionCallsignInfo "{5DA0F2A6677ADA9E}" {
+      m_aSquadNames {
+       SCR_CallsignInfo "{55CCB792D13759D8}" {
+        m_sCallsign "MED"
+       }
+       SCR_CallsignInfo "{55CCB792D1218E95}" {
+        m_sCallsign "1-1"
+       }
+       SCR_CallsignInfo "{55CCB792D0C8B3CE}" {
+        m_sCallsign "1-2"
+       }
+       SCR_CallsignInfo "{65D4470F379715D3}" {
+        m_sCallsign "1-3"
+       }
+       SCR_CallsignInfo "{65D4470F3479251F}" {
+        m_sCallsign "1-4"
+       }
+       SCR_CallsignInfo "{65D4470F419BA7D0}" {
+        m_sCallsign "GT1"
+       }
+       SCR_CallsignInfo "{65D4470F467866AB}" {
+        m_sCallsign "GT2"
+       }
+      }
+     }
+    }
+    SCR_Faction "{628C2D2BFC8C6447}" {
+     m_CallsignInfo SCR_FactionCallsignInfo "{5DA0F2A67DFB8809}" {
+      m_aSquadNames {
+       SCR_CallsignInfo "{55CCB79287936EBD}" {
+        m_sCallsign "MED"
+       }
+       SCR_CallsignInfo "{55CCB79287BAFBD6}" {
+        m_sCallsign "1-1"
+       }
+       SCR_CallsignInfo "{55CCB79287A4D7B6}" {
+        m_sCallsign "1-2"
+       }
+       SCR_CallsignInfo "{65D4470F694C4851}" {
+        m_sCallsign "1-3"
+       }
+       SCR_CallsignInfo "{65D4470F692CBD54}" {
+        m_sCallsign "HMG"
+       }
+      }
+     }
+    }
+   }
+  }
  }
 }

--- a/Worlds/COALobby/Gogland/FullEnglish_Layers/markers.layer
+++ b/Worlds/COALobby/Gogland/FullEnglish_Layers/markers.layer
@@ -1,0 +1,129 @@
+PolylineShapeEntity : "{318DDE6633C34CF1}PrefabsEditable/PolyZone/GameBoundry.et" {
+ coords 7232.404 43.221 3147.781
+ Points {
+  ShapePoint "{65D4611B0E525DC0}" {
+   Position 1128.167 -53.722 -23.08
+  }
+  ShapePoint "{65D4611B117D0781}" {
+   Position 597.139 -31.267 26.514
+  }
+  ShapePoint "{65D4611B11CDC07E}" {
+   Position 190.214 -17.23 134.752
+  }
+  ShapePoint "{65D4611B1A67061A}" {
+   Position -729.451 -3.715 46.19
+  }
+  ShapePoint "{65D4611B1E2DC7C3}" {
+   Position -1145.704 -4.86 -52.637
+  }
+  ShapePoint "{65D4611B1D6623CD}" {
+   Position -1771.765 -53.425 -101.367
+  }
+  ShapePoint "{65D4611B23879AEE}" {
+   Position -1533.653 -46.76 -767.789
+  }
+  ShapePoint "{65D4611B201D8292}" {
+   Position -1571.313 -55.735 -1433.488
+  }
+  ShapePoint "{65D4611B2098FCC6}" {
+   Position -1464.701 -70.947 -2153.592
+  }
+  ShapePoint "{65D4611B26F7F166}" {
+   Position -358.555 -102.967 -2466.665
+  }
+  ShapePoint "{65D4611B2466BCCC}" {
+   Position 542.923 -99.716 -2515.21
+  }
+  ShapePoint "{65D4611B25A58F45}" {
+   Position 1348.888 -110.043 -1401.936
+  }
+  ShapePoint "{65D4611B32C73E98}" {
+   Position 1342.886 -55.374 -664.513
+  }
+ }
+}
+PolylineShapeEntity : "{8AE1D02BC25C93C5}PrefabsEditable/PolyZone/BLUFORSafestartBoundry.et" {
+ coords 7331.302 5.103 1037.296
+ Points {
+  ShapePoint "{65D46118CB9EA653}" {
+   Position -57.748 0.713 87.955
+  }
+  ShapePoint "{65D46118C8FFA700}" {
+   Position -62.785 2.221 31.781
+  }
+  ShapePoint "{65D46118CE5C37AA}" {
+   Position -37.691 0.648 -33.22
+  }
+  ShapePoint "{65D46118CF8EB1F6}" {
+   Position 29.193 -2.625 -22.293
+  }
+  ShapePoint "{65D46118CDBB8678}" {
+   Position 116.622 0.309 15.962
+  }
+  ShapePoint "{65D46118D0F9ECC6}" {
+   Position 89.839 3.618 143.662
+  }
+  ShapePoint "{65D46118D622BAB9}" {
+   Position -52.884 0.52 138.411
+  }
+ }
+}
+PolylineShapeEntity : "{D8E7812AC12E29EB}PrefabsEditable/PolyZone/OPFORSafestartBoundry.et" {
+ coords 6914.113 131.06 2432.24
+ Points {
+  ShapePoint "{65D46118E391DEEA}" {
+   Position 216.947 -62.617 -191.297
+  }
+  ShapePoint "{65D46118E0CC5816}" {
+   Position 24.277 -37.321 -128.144
+  }
+  ShapePoint "{65D46118E11E94D1}" {
+   Position -184.52 -21.354 -42.886
+  }
+  ShapePoint "{65D46118E79FB3BA}" {
+   Position -293.427 -16.597 92.019
+  }
+  ShapePoint "{65D46118E5FBC957}" {
+   Position -356.11 -8.259 153.573
+  }
+  ShapePoint "{65D46118EA3D03B8}" {
+   Position -468.861 -58.174 288.94
+  }
+  ShapePoint "{65D46118E9BDD39F}" {
+   Position -410.998 -15.186 427.471
+  }
+  ShapePoint "{65D46118EFFBCC91}" {
+   Position -292.84 -4.232 534.899
+  }
+  ShapePoint "{65D46118ECDCBFE2}" {
+   Position -201.227 -22.066 576.083
+  }
+  ShapePoint "{65D46118EDA8B874}" {
+   Position -71.317 -35.344 565.904
+  }
+  ShapePoint "{65D46118F347F48D}" {
+   Position 116.958 -59.438 579.25
+  }
+  ShapePoint "{65D46118F07898B9}" {
+   Position 267.776 -75.692 610.737
+  }
+  ShapePoint "{65D46118F0C58075}" {
+   Position 359.827 -83.083 643.684
+  }
+  ShapePoint "{65D46118F416E792}" {
+   Position 364.871 -74.543 507.767
+  }
+  ShapePoint "{65D46118F5A91897}" {
+   Position 332.853 -57.22 328.044
+  }
+  ShapePoint "{65D46118FB6EC443}" {
+   Position 246.671 -28.638 91.122
+  }
+  ShapePoint "{65D46118F84B0348}" {
+   Position 214.523 -43.392 -32
+  }
+  ShapePoint "{65D46118F9280346}" {
+   Position 215.482 -61.433 -154.013
+  }
+ }
+}

--- a/Worlds/COALobby/Gogland/FullEnglish_Layers/objectives.layer
+++ b/Worlds/COALobby/Gogland/FullEnglish_Layers/objectives.layer
@@ -1,0 +1,8 @@
+$grp BaseGameTriggerEntity {
+ aSiteTrigger {
+  coords 6829.507 138.842 2515.548
+ }
+ bSiteTrigger {
+  coords 6680.385 145.436 2766.689
+ }
+}

--- a/Worlds/COALobby/Gogland/FullEnglish_Layers/opfor.layer
+++ b/Worlds/COALobby/Gogland/FullEnglish_Layers/opfor.layer
@@ -1,0 +1,14 @@
+SCR_AIGroup : "{6524B6A6C69BD3EE}Prefabs/Groups/OPFOR/Standard/Command/CRF_OPFOR_Platoon_p.et" {
+ coords 6866.339 138.449 2456.941
+}
+$grp SCR_AIGroup : "{92F50F60726EB86D}Prefabs/Groups/OPFOR/Standard/Infantry/CRF_OPFOR_RifleSquad_p.et" {
+ {
+  coords 6854.717 138.621 2455.016
+ }
+ {
+  coords 6846.767 138.546 2456.933
+ }
+}
+SCR_AIGroup : "{F703D0D434EF9A1A}Prefabs/Groups/OPFOR/Standard/Support/CRF_OPFOR_HMGTeam_p.et" {
+ coords 6870.899 138.541 2462.023
+}

--- a/Worlds/COALobby/Gogland/FullEnglish_Layers/opfor.layer
+++ b/Worlds/COALobby/Gogland/FullEnglish_Layers/opfor.layer
@@ -1,14 +1,39 @@
 SCR_AIGroup : "{6524B6A6C69BD3EE}Prefabs/Groups/OPFOR/Standard/Command/CRF_OPFOR_Platoon_p.et" {
- coords 6866.339 138.449 2456.941
-}
-$grp SCR_AIGroup : "{92F50F60726EB86D}Prefabs/Groups/OPFOR/Standard/Infantry/CRF_OPFOR_RifleSquad_p.et" {
+ coords 6824.745 126.531 2378.78
  {
-  coords 6854.717 138.621 2455.016
- }
- {
-  coords 6846.767 138.546 2456.933
+  SCR_AIGroup : "{24DA56B34E727840}Prefabs/Groups/OPFOR/Standard/Support/CRF_OPFOR_MedicTeam_p.et" {
+   coords 0.559 0.027 4.313
+   {
+    SCR_AIGroup : "{92F50F60726EB86D}Prefabs/Groups/OPFOR/Standard/Infantry/CRF_OPFOR_RifleSquad_p.et" {
+     coords -18.151 3.204 10.71
+     {
+      SCR_AIGroup : "{92F50F60726EB86D}Prefabs/Groups/OPFOR/Standard/Infantry/CRF_OPFOR_RifleSquad_p.et" {
+       coords 2.471 0.378 5.828
+       {
+        SCR_AIGroup : "{92F50F60726EB86D}Prefabs/Groups/OPFOR/Standard/Infantry/CRF_OPFOR_RifleSquad_p.et" {
+         coords -0.049 0.295 6.217
+         {
+          SCR_AIGroup : "{F703D0D434EF9A1A}Prefabs/Groups/OPFOR/Standard/Support/CRF_OPFOR_HMGTeam_p.et" {
+           coords 27.841 -9.582 -42.927
+          }
+         }
+        }
+       }
+      }
+     }
+    }
+   }
+  }
  }
 }
-SCR_AIGroup : "{F703D0D434EF9A1A}Prefabs/Groups/OPFOR/Standard/Support/CRF_OPFOR_HMGTeam_p.et" {
- coords 6870.899 138.541 2462.023
+GenericEntity : "{8B3E3492620C745C}PrefabsEditable/CRF_VehicleSpawner.et" {
+ components {
+  CRF_VehicleSpawner "{64626B666A3B82E3}" {
+   m_rVehicle "{43C4AF1EEBD001CE}Prefabs/Vehicles/Wheeled/UAZ452/UAZ452_ambulance.et"
+  }
+ }
+ coords 6835.217 138.546 2469.3
+ angleX 0
+ angleY 0
+ angleZ 0
 }

--- a/Worlds/COALobby/Gogland/FullEnglish_Layers/props.layer
+++ b/Worlds/COALobby/Gogland/FullEnglish_Layers/props.layer
@@ -1,0 +1,219 @@
+GenericEntity : "{03DE957D8161212B}Prefabs/Props/Civilian/Notebook_01_Open.et" {
+ coords 6663.283 151.472 2797.697
+ angleY -112.982
+}
+GenericEntity : "{3B19CA49C71B8D33}Prefabs/Props/Military/Sandbags/Dst/Sandbag_01_single_dst_01_burlap.et" {
+ coords 6661.924 150.729 2807.98
+ angleY 78.605
+}
+$grp SCR_DestructibleBuildingEntity : "{501A020C34E2FB63}Prefabs/Structures/Military/Bunkers/Bunker_01/Bunker_01_3fp_Camo.et" {
+ {
+  coords 6666.232 0.33 2811.301
+  angleY -49.138
+ }
+ {
+  coords 6669.137 0.354 2794.727
+  angleY -159.575
+ }
+}
+GameEntity : "{50E6A3845C9F20FD}Prefabs/Props/Military/Camps/LanternMilitary_US_01.et" {
+ coords 6665.682 151.458 2795.551
+}
+GenericEntity : "{64C6B8E8931FB36D}Prefabs/Props/Military/Sandbags/Sandbag_01_empty_burlap.et" {
+ coords 6661.853 150.73 2806.095
+ angleY -82.438
+}
+$grp SCR_DestructibleEntity : "{879865F07EA907B0}Prefabs/Structures/Walls/Concrete/ConcreteWall_02/ConcreteWall_02_4m.et" {
+ {
+  components {
+   MeshObject "{56DE7C8DCD0F4E0A}" {
+    Materials {
+     MaterialAssignClass "{65D447036FD11CA7}" {
+      SourceMaterial "ConcreteRetainingWall_02"
+      AssignedMaterial "{9B834DE7895E2645}Assets/Structures/Military/Bunkers/Bunker_01/Data/Bunker_01_3fp_Ext_Camo.emat"
+     }
+     MaterialAssignClass "{65D447036FD11C83}" {
+      SourceMaterial "ConcreteRetainingWall_02_MLod"
+      AssignedMaterial "{61253AC2D1484B37}Assets/Structures/Military/Bunkers/Bunker_01/Data/Bunker_01_3fp_Ext_Camo_MLOD.emat"
+     }
+    }
+   }
+  }
+  coords 6661.866 -0.838 2806.222
+  angleY 93.745
+ }
+ {
+  components {
+   MeshObject "{56DE7C8DCD0F4E0A}" {
+    Materials {
+     MaterialAssignClass "{65D4470370D22F5B}" {
+      SourceMaterial "ConcreteRetainingWall_02"
+      AssignedMaterial "{9B834DE7895E2645}Assets/Structures/Military/Bunkers/Bunker_01/Data/Bunker_01_3fp_Ext_Camo.emat"
+     }
+     MaterialAssignClass "{65D4470370D230B4}" {
+      SourceMaterial "ConcreteRetainingWall_02_MLod"
+      AssignedMaterial "{61253AC2D1484B37}Assets/Structures/Military/Bunkers/Bunker_01/Data/Bunker_01_3fp_Ext_Camo_MLOD.emat"
+     }
+    }
+   }
+  }
+  coords 6662.623 -0.329 2809.935
+  angleY -69.863
+ }
+ {
+  components {
+   MeshObject "{56DE7C8DCD0F4E0A}" {
+    Materials {
+     MaterialAssignClass "{65D447036FD11CA7}" {
+      SourceMaterial "ConcreteRetainingWall_02"
+      AssignedMaterial "{9B834DE7895E2645}Assets/Structures/Military/Bunkers/Bunker_01/Data/Bunker_01_3fp_Ext_Camo.emat"
+     }
+     MaterialAssignClass "{65D447036FD11C83}" {
+      SourceMaterial "ConcreteRetainingWall_02_MLod"
+      AssignedMaterial "{61253AC2D1484B37}Assets/Structures/Military/Bunkers/Bunker_01/Data/Bunker_01_3fp_Ext_Camo_MLOD.emat"
+     }
+    }
+   }
+  }
+  coords 6662.744 -0.635 2798.979
+  angleY 66.407
+ }
+ {
+  components {
+   MeshObject "{56DE7C8DCD0F4E0A}" {
+    Materials {
+     MaterialAssignClass "{65D447036FD11CA7}" {
+      SourceMaterial "ConcreteRetainingWall_02"
+      AssignedMaterial "{9B834DE7895E2645}Assets/Structures/Military/Bunkers/Bunker_01/Data/Bunker_01_3fp_Ext_Camo.emat"
+     }
+     MaterialAssignClass "{65D447036FD11C83}" {
+      SourceMaterial "ConcreteRetainingWall_02_MLod"
+      AssignedMaterial "{61253AC2D1484B37}Assets/Structures/Military/Bunkers/Bunker_01/Data/Bunker_01_3fp_Ext_Camo_MLOD.emat"
+     }
+    }
+   }
+  }
+  coords 6665.012 -0.599 2796.06
+  angleY 38.319
+ }
+}
+$grp GenericEntity : "{898B81D2B9E9B2DC}Prefabs/Compositions/Misc/FreeRoamBuilding/SandbagWallSolidBurlap_S_USSR_01.et" {
+ {
+  coords 6670.863 148.16 2813.694
+  angleY 48.513
+ }
+ {
+  coords 6669.283 148.188 2813.935
+  angleY -35.857
+ }
+ {
+  coords 6669.506 150.387 2814.038
+  angleY -35.857
+  {
+   GenericEntity {
+    ID "5D70BA356CD2E641"
+    coords -0.098 -4.127 0.115
+   }
+  }
+ }
+ {
+  coords 6674.463 148.892 2794.821
+  angleY -71.207
+ }
+ {
+  coords 6673.197 148.663 2793.266
+ }
+}
+GenericEntity : "{9C9C4BED9E19C374}Prefabs/Props/Military/Sandbags/Sandbag_01_wall_solid_burlap.et" {
+ components {
+  Hierarchy "{5D70BA354E208E2C}" {
+   Enabled 1
+  }
+ }
+ coords 6670.938 146.231 2813.834
+ angleY 43.485
+}
+SCR_DestructibleBuildingEntity : "{A2726797F70F52D8}Prefabs/Structures/Military/Bunkers/Bunker_01/Bunker_01_1fp_Camo.et" {
+ coords 6663.884 -0.001 2802.666
+ angleY -99.939
+}
+GenericEntity : "{B04F2A9C5356C02D}Prefabs/Compositions/Slotted/SlotFlatSmall/SandbagPosition_S_FIA_01.et" {
+ coords 6677.84 148.311 2802.962
+ angleX -2.935
+ angleY 69.226
+ angleZ -2.888
+ {
+  GenericEntity {
+   ID "5D1ED9174DD9311F"
+   coords 5.549 -1.608 0.438
+  }
+  GenericEntity {
+   ID "5D1ED9174DD93183"
+   coords 0.179 -1.25 2.933
+  }
+  GenericEntity {
+   ID "5D1ED9174DD9314C"
+   coords 1.059 0.1 2.764
+  }
+  GenericEntity {
+   ID "5D1ED9174DD9316B"
+   coords 4.558 0 2.659
+  }
+  GenericEntity {
+   ID "5D1ED9174DD933FE"
+   coords 1.888 0.318 0
+  }
+  GenericEntity {
+   ID "5D1ED9174DD93111"
+   coords 5.908 -2.05 0.745
+  }
+  GenericEntity {
+   ID "5D1ED9174DD931B7"
+   coords -1.231 -1.929 2.88
+  }
+  StaticModelEntity {
+   ID "5D1ED9174DD93103"
+   coords -0.569 -2.362 3.002
+  }
+  StaticModelEntity {
+   ID "5D1ED9174DD932C1"
+   coords -6.422 -2.342 1.453
+  }
+  StaticModelEntity {
+   ID "5D1ED9174DD932F1"
+   coords 8.883 -0.969 4.938
+   angleY -143.587
+  }
+  StaticModelEntity {
+   ID "5D1ED9174DD93120"
+   coords 5.909 -1.725 1.647
+  }
+  StaticModelEntity {
+   ID "5D1ED9174DD93133"
+   coords -6.281 -2.689 1.833
+  }
+ }
+}
+GenericEntity : "{BE2B14A482E169F7}Prefabs/Structures/Military/CamoNets/FIA/CamoNet_Large_Top_FIA_01_V1.et" {
+ coords 6682.563 145.872 2765.86
+ angleY -47.276
+}
+$grp GenericEntity : "{C7A49C5B54C86903}Prefabs/Props/Military/Sandbags/Sandbag_01_single_burlap.et" {
+ {
+  coords 6661.853 150.73 2805.421
+  angleY -90.156
+ }
+ {
+  coords 6661.858 150.73 2806.454
+  angleY 103.268
+ }
+ {
+  coords 6662.06 150.741 2808.324
+  angleY 108.605
+  angleZ -18.364
+ }
+}
+GenericEntity : "{F76340CCD79DCC5A}Prefabs/Props/Civilian/RadioSmall_01_red.et" {
+ coords 6662.427 150.695 2808.93
+ angleY 138.574
+}


### PR DESCRIPTION
Mission Pull Request Template

This Pull Request will: add mission CRF_S&D89 Full english to repo

Add the mission fullenglish  made by fluff <author name!> to the repository.

**Mission Creation Checklist:**
- [x] Mission File
- [x] Gearscripts Tested
- [x] Ingame Play Area Markers
- [x] Ingame Briefings to all players
- [x] Side-based briefings  
- [x] Mission .conf file


**Faction(s):**

BLUFOR - (UK 80s) - Attacking
BLUFOR Comp: Motorized
BLUFOR Assets: 2x land rover gun trucks

OPFOR - ( USSR 80s) - Defending
OPFOR Comp: infantry
OPFOR Assets: 1x hmg squad



**Objectives/Win Conditions:**

blufor destroy both bombsites

**Terrain:**

gogland

**Short mission description:**

blufor must destroy opfors bombsite on gogland

**Slotting Ratio:**

<3:2>

**Time limit:**

45 minutes

**Mission Briefing Screenshot:**
![image](https://github.com/user-attachments/assets/d09da674-db0f-4019-96a6-61941ea226fd)

**Design concept/thoughts:**


Wanted to get the new UK equipment in, namely the m79 and land rovers.
To make the m79 more valuable to the squad, both sides had their TL gls removed. 
UK got 20rnd mags to help offset their massive AR advantage with the m249 minimi vs the rpk74, but the UK does have AR604s that are full auto which will help them.
Its reorganized but i dont think its unbalanced, changes were made with reason

No GI radio mission. TLs have 1 channel, SLs and other leadership have 2 channels

Theres a big ass bunker underneath bombsite A. Ill make a special out of it soon, but as for this mission I just left it alone. OPFOR can use it if they want, but it just takes 1 guy watching the door to lock them down there so I dont think its going to factor into gameplay enough to worry about it. 

**Other Notes:**

<Assets? Admin notes? Anything else?>
