### PR TITLE
Update CRF_GS_VC_BoltAction.conf

### DIFF
--- a/Configs/Gearscripts/Standard/Vietnam/Varients/CRF_GS_VC_BoltAction.conf
+++ b/Configs/Gearscripts/Standard/Vietnam/Varients/CRF_GS_VC_BoltAction.conf
@@ -365,6 +365,10 @@ CRF_GearScriptConfig {
         m_Magazine "{CA96DF808C7F2269}Prefabs/Weapons/Magazines/Magazine_762x54_B30_Mosin_Nagant.et"
         m_MagazineCount 115
        }
+       CRF_Magazine_Class "{665F70A416512DD2}" {
+        m_Magazine "{B0C4B62DDD002478}Prefabs/Weapons/Magazines/545x39_RPK74_45rnd/Magazine_545x39_RPK74_45rnd_4AP_1Tracer_7N10_7T3.et"
+        m_MagazineCount 10
+       }
       }
      }
     }


### PR DESCRIPTION
Overwriting the AAR weapon removes the lmg ammo from it. Fixed on this. 