### PR TITLE
Cleaning up VON Override

### DIFF
--- a/scripts/Game/Systems/ModdedOverrides/CVON/CRF_CVON_VONController.c
+++ b/scripts/Game/Systems/ModdedOverrides/CVON/CRF_CVON_VONController.c
@@ -189,6 +189,20 @@ modded class SCR_VONController
 		ref array<int> playerIds = {};
 		m_PlayerManager.GetPlayers(playerIds);
 		int maxDistance = m_PlayerController.m_aVolumeValues.Get(4);
+		
+		//When a player disconnects, they are no longer in the players array, so it just leaves an empty container.
+		//This removes that container as when they reconnect they will no longer be heard.
+		foreach (int playerId: m_PlayerController.m_aLocalActiveVONEntriesIds)
+		{
+			if (playerIds.Contains(playerId))
+				continue;
+			
+			int index = m_PlayerController.m_aLocalActiveVONEntriesIds.Find(playerId);
+			m_PlayerController.m_aLocalActiveVONEntriesIds.RemoveOrdered(index);
+			m_PlayerController.m_aLocalActiveVONEntries.RemoveOrdered(index);
+			continue;
+		}
+		
 		foreach (int playerId: playerIds)
 		{
 			if (!SCR_PlayerController.GetLocalControlledEntity())

--- a/scripts/Game/Systems/ModdedOverrides/CVON/CRF_CVON_VONController.c
+++ b/scripts/Game/Systems/ModdedOverrides/CVON/CRF_CVON_VONController.c
@@ -171,7 +171,6 @@ modded class SCR_VONController
 	
 	override void EOnFixedFrame(IEntity owner, float timeSlice)
 	{
-		super.EOnFixedFrame(owner, timeSlice);
 		if (!CVON_VONGameModeComponent.GetInstance())
 			return;
 		
@@ -252,8 +251,11 @@ modded class SCR_VONController
 		//Local processing of data being sent to us
 		foreach (CVON_VONContainer container: m_PlayerController.m_aLocalActiveVONEntries)
 		{
+			if (!SCR_PlayerController.GetLocalControlledEntity())
+				break;
 			if (!container.m_SoundSource)
 				continue;
+			
 			float distance = vector.Distance(container.m_SoundSource.GetOrigin(), SCR_PlayerController.GetLocalControlledEntity().GetOrigin());
 			if (distance < maxDistance || IsPlayerSpectator(SCR_PlayerController.GetLocalPlayerId()))
 				container.m_fDistanceToSender = distance;


### PR DESCRIPTION
Removes the super from inside of CRF_CVON_VONController as it would cause VON to be processed twice on the client.

Also fixed a bug in the CRF in CVON with entity load times.