### PR TITLE
Adds generic LR net if none are provided

### DIFF
--- a/scripts/Game/Systems/VanillaOverrides/CRF_SCR_Faction.c
+++ b/scripts/Game/Systems/VanillaOverrides/CRF_SCR_Faction.c
@@ -98,6 +98,8 @@ modded class SCR_Faction
 				m_aActiveSRChannels.Insert(groupName);
 			}
 		}
+		if (m_aActiveLRChannels.Count() == 0)
+			m_aActiveLRChannels.Insert(GetFactionKey() + "LR");
 		SCR_FactionManager.Cast(GetGame().GetFactionManager()).UpdateFactionActiveChannelSR(GetFactionKey(), m_aActiveSRChannels);
 		SCR_FactionManager.Cast(GetGame().GetFactionManager()).UpdateFactionActiveChannelLR(GetFactionKey(), m_aActiveLRChannels);
 	}


### PR DESCRIPTION
Adds a generic LR net if no elements like COY or PLT are assigned to a side.
This came up in my latest mission where INDFOR does not have any centralized command, so they never get assigned an LR frequency.