### PR TITLE
Cvon fixes

### DIFF
--- a/scripts/Game/Systems/Core/Managers/CRF_GearscriptManager.c
+++ b/scripts/Game/Systems/Core/Managers/CRF_GearscriptManager.c
@@ -156,8 +156,8 @@ class CRF_GearscriptManager : ScriptComponent
 		{
 			SCR_PlayerController pc = SCR_PlayerController.Cast(GetGame().GetPlayerManager().GetPlayerController(playerId));
 			SCR_GroupsManagerComponent groupsMan = SCR_GroupsManagerComponent.GetInstance();
-			GetGame().GetCallqueue().CallLater(groupsMan.TuneFreqDelayWithPresets, 2000, false, playerId, entity);
-			GetGame().GetCallqueue().CallLater(pc.InitializeRadios, 2000, false, entity);
+			GetGame().GetCallqueue().CallLater(groupsMan.TuneFreqDelayWithPresets, 500, false, playerId, entity);
+			GetGame().GetCallqueue().CallLater(pc.InitializeRadios, 500, false, entity);
 			pc.InitializeRadioFromServer();
 		}
 	}

--- a/scripts/Game/Systems/Core/Managers/CRF_RplToAuthorityManager.c
+++ b/scripts/Game/Systems/Core/Managers/CRF_RplToAuthorityManager.c
@@ -1000,6 +1000,11 @@ class CRF_RplToAuthorityManager : ScriptComponent
 				}
 			}
 		}
+		SCR_PlayerController pc = SCR_PlayerController.Cast(GetGame().GetPlayerManager().GetPlayerController(playerId));
+		SCR_GroupsManagerComponent groupsMan = SCR_GroupsManagerComponent.GetInstance();
+		GetGame().GetCallqueue().CallLater(groupsMan.TuneFreqDelayWithPresets, 500, false, playerId, player);
+		GetGame().GetCallqueue().CallLater(pc.InitializeRadios, 500, false, player);
+		pc.InitializeRadioFromServer();
 	}
 	
 	[RplRpc(RplChannel.Reliable, RplRcver.Server)]

--- a/scripts/Game/Systems/ModdedOverrides/CVON/CRF_CVON_GroupsManagerComponent.c
+++ b/scripts/Game/Systems/ModdedOverrides/CVON/CRF_CVON_GroupsManagerComponent.c
@@ -18,23 +18,29 @@ modded class SCR_GroupsManagerComponent
 		if (!playerController)
 			return;
 		
+		int SRIndex = 0;
+		int LRIndex = 0;
+		array<IEntity> radiosDone = {};
 		if (playerController.m_aRadioSettings.Count() > 0)
 		{
 			foreach (IEntity radio: playerController.m_aRadios)
 			{
 				CVON_RadioComponent radioComp = CVON_RadioComponent.Cast(radio.FindComponent(CVON_RadioComponent));
-				CVON_RadioSettingObject radioSetting = playerController.m_aRadioSettings.Get(playerController.m_aRadios.Find(radio));
-				
+				int index = playerController.m_aRadios.Find(radio);
+				if (playerController.m_aRadioSettings.Count() <= index)
+					break;
+				CVON_RadioSettingObject radioSetting = playerController.m_aRadioSettings.Get(index);
 				if (radioComp.m_aChannels.Contains(radioSetting.m_sFreq))
-						radioComp.UpdateChannelServer(radioComp.m_aChannels.Find(radioSetting.m_sFreq) + 1);
+				{
+					radioComp.UpdateChannelServer(radioComp.m_aChannels.Find(radioSetting.m_sFreq) + 1);
+					radioComp.UpdateFrequncyServer(radioSetting.m_sFreq, -1, false);
+					radiosDone.Insert(radio);
+					if (radioComp.m_eRadioType == 0)
+						SRIndex++;
 					else
-						radioComp.UpdateChannelServer(radioComp.m_aChannels.Count() + 1);
-				
-				radioComp.UpdateFrequncyServer(radioSetting.m_sFreq);
-				playerController.SetVolumeFromServer(radioSetting.m_iVolume, playerController.m_aRadios.Find(radio));
-				playerController.SetStereoFromServer(radioSetting.m_Stereo, playerController.m_aRadios.Find(radio));
+						LRIndex++;
+				}			
 			}
-			return;
 		}
 		
 		SCR_FactionManager factionMan = SCR_FactionManager.Cast(GetGame().GetFactionManager());
@@ -95,10 +101,10 @@ modded class SCR_GroupsManagerComponent
 			freqContainer.m_aLRFrequencies = {};
 			freqContainer.m_aLRFrequencies.Insert(factionMan.GetFactionActiveChannelLR(playerFaction.GetFactionKey()).Get(0));
 		}
-		int SRIndex = 0;
-		int LRIndex = 0;
 		for (int i = 0; i < playerController.m_aRadios.Count(); i++)
 		{
+			if (radiosDone.Contains(playerController.m_aRadios.Get(i)))
+				continue;
 			bool m_bFrequencyFound = false;
 			CVON_RadioComponent radioComp = CVON_RadioComponent.Cast(playerController.m_aRadios.Get(i).FindComponent(CVON_RadioComponent));
 			switch (radioComp.m_eRadioType)

--- a/scripts/Game/Systems/ModdedOverrides/CVON/CRV_CVON_RadioComponent.c
+++ b/scripts/Game/Systems/ModdedOverrides/CVON/CRV_CVON_RadioComponent.c
@@ -2,9 +2,8 @@ modded class CVON_RadioComponent
 {
 	//Handles assigning 
 	//==========================================================================================================================================================================
-	override void EOnFixedFrame(IEntity owner, float timeSlice)
+	override void InitializeRadios()
 	{
-		
 		//Have this ifdef here cause in the workshop its a listen server, I explain the code in the non workshop version.
 		#ifdef WORKBENCH
 		if (m_sFactionKey != "")
@@ -31,32 +30,24 @@ modded class CVON_RadioComponent
 			m_sFrequency = m_aChannels.Get(0);
 		}
 		Replication.BumpMe();
-		
-		if (m_iTempChannel != m_iCurrentChannel || m_sTempFrequency != m_sFrequency || m_iTempTimeDeviation != m_iTimeDeviation || m_sTempFactionKey != m_sFactionKey)
-		{
-			m_iTempChannel = m_iCurrentChannel;
-			m_sTempFrequency = m_sFrequency;
-			m_iTempTimeDeviation = m_iTimeDeviation;
-			m_sTempFactionKey = m_sFactionKey;
-			WriteJSON(SCR_PlayerController.GetLocalControlledEntity());
-		}
 		#else
 		if (System.IsConsoleApp())
 		{
 			//Faction found no longer needed.
 			if (m_sFactionKey != "")
 				return;
-		
+
 			if (!GetOwner().GetRootParent())
 				return;
-	
+
 			//Radio is in the inventory of a player.
 			if (!SCR_ChimeraCharacter.Cast(GetOwner().GetRootParent()))
 				return;
-			
+
 			FactionAffiliationComponent factionComp = FactionAffiliationComponent.Cast(GetOwner().GetRootParent().FindComponent(FactionAffiliationComponent));
 			if (!factionComp)
 				return;
+
 			m_sFactionKey = factionComp.GetAffiliatedFactionKey();
 			//Add that faction to this radio and get the faction to prep to load the factions frequencies
 			SCR_FactionManager factionMan = SCR_FactionManager.Cast(GetGame().GetFactionManager());
@@ -72,18 +63,6 @@ modded class CVON_RadioComponent
 			}
 			//hehe
 			Replication.BumpMe();
-		}
-		else
-		{
-			//Woah the client, just checking if anythings changed, this is mostly redundant but neccessary mostly for unit creation and onccupation.
-			if (m_iTempChannel != m_iCurrentChannel || m_sTempFrequency != m_sFrequency || m_iTempTimeDeviation != m_iTimeDeviation || m_sTempFactionKey != m_sFactionKey)
-			{
-				m_iTempChannel = m_iCurrentChannel;
-				m_sTempFrequency = m_sFrequency;
-				m_iTempTimeDeviation = m_iTimeDeviation;
-				m_sTempFactionKey = m_sFactionKey;
-				WriteJSON(SCR_PlayerController.GetLocalControlledEntity());
-			}
 		}
 		#endif
 	}

--- a/scripts/Game/Systems/VanillaOverrides/CRF_SCR_Faction.c
+++ b/scripts/Game/Systems/VanillaOverrides/CRF_SCR_Faction.c
@@ -93,6 +93,7 @@ modded class SCR_Faction
 		}
 		if (m_aActiveLRChannels.Count() == 0)
 			m_aActiveLRChannels.Insert(GetFactionKey() + "LR");
+		
 		SCR_FactionManager.Cast(GetGame().GetFactionManager()).UpdateFactionActiveChannelSR(GetFactionKey(), m_aActiveSRChannels);
 		SCR_FactionManager.Cast(GetGame().GetFactionManager()).UpdateFactionActiveChannelLR(GetFactionKey(), m_aActiveLRChannels);
 	}

--- a/scripts/Game/Systems/VanillaOverrides/CRF_SCR_PlayerController.c
+++ b/scripts/Game/Systems/VanillaOverrides/CRF_SCR_PlayerController.c
@@ -119,6 +119,45 @@ modded class SCR_PlayerController
 	[RplRpc(RplChannel.Reliable, RplRcver.Owner)]
 	void RpcDo_InitializeRadioFromServer()
 	{
-		GetGame().GetCallqueue().CallLater(InitializeRadios, 2000, false, GetLocalControlledEntity());
+		GetGame().GetCallqueue().CallLater(InitializeRadios, 500, false, GetLocalControlledEntity());
+	}
+	
+	override void UpdateSettings()
+	{
+		SCR_FactionManager factionMan = SCR_FactionManager.Cast(GetGame().GetFactionManager());
+		if (CRF_GamemodeManager.IsSpectator(GetControlledEntity()))
+			return;
+		
+		//Still trying to update with a spectator radio. No clue why this happens as theres the check above by whatever.
+		foreach (IEntity radio: m_aRadios)
+		{
+			if (!radio)
+				continue;
+			
+			if (!radio.GetPrefabData())
+				continue;
+			
+			if (!radio.GetPrefabData().GetPrefabName())
+				continue;
+			
+			if (radio.GetPrefabData().GetPrefabName() == "{13A97D10A827AE01}Prefabs/Items/Equipment/Radios/SpecRadioBag.et")
+				return;
+		}
+		
+		m_aRadioSettings.Clear();
+		foreach (IEntity radio: m_aRadios)
+		{
+			if (!radio)
+				continue;
+			CVON_RadioComponent radioComp = CVON_RadioComponent.Cast(radio.FindComponent(CVON_RadioComponent));
+			
+			if (radioComp.m_sFactionKey != "" && radioComp.m_sFactionKey != factionMan.GetPlayerFaction(GetPlayerId()).GetFactionKey())
+				return;
+			ref CVON_RadioSettingObject setting = new CVON_RadioSettingObject();
+			setting.m_sFreq = radioComp.m_sFrequency;
+			setting.m_Stereo = radioComp.m_eStereo;
+			setting.m_iVolume = radioComp.m_iVolume;
+			m_aRadioSettings.Insert(setting);
+		}
 	}
 }


### PR DESCRIPTION
Fixed radio frequencies not being assigned after mini arsenal update.
Fixed radio frequencies sometimes not assigning when loading in.
Fixed radio settings not applying on respawn or gearscript reset.
Fixed radios from appearing in RHS radio pouches.
Fixed radio icon sizes.