### PR TITLE
New Mission- Harry Push Start Pushing

### DIFF
--- a/Configs/Gearscripts/Custom/Harry/push/CRF_GS_RHSION_Urban_NoOptics_AP_CLS.conf
+++ b/Configs/Gearscripts/Custom/Harry/push/CRF_GS_RHSION_Urban_NoOptics_AP_CLS.conf
@@ -1,0 +1,596 @@
+CRF_GearScriptConfig {
+ m_FactionName "ION"
+ m_FactionIcon "{461AA37088E8A1A1}UI/Textures/Editor/EditableEntities/Factions/ION_icon.edds"
+ m_FactionIdentity "{11CAD6C8909CE567}Configs/Identities/CRF_CharacterIdentity_European.conf"
+ m_FactionWeapons CRF_Weapons "{668EF124C56E6B8B}" {
+  m_Rifle {
+   CRF_Weapon_Class "{668EF124C56E6BB2}" {
+    m_Weapon "{3BC80AAE900EC0B7}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_Suppressed.et"
+    m_Attachments {
+     "{3D4B54552E600505}Prefabs/Weapons/Attachments/Optics/Collimators/Optic_EotechEXPS3/Collim_EXPS3_BLK.et"
+    }
+    m_MagazineArray {
+     CRF_Magazine_Class "{668EF124C56E6BB3}" {
+      m_Magazine "{77AAEEB1D221D79A}Prefabs/Weapons/Magazines/762x51_SCARH_20rnd/Magazine_762x51_SCARH_20rnd_4Ball_1Tracer_M80A1_M62.et"
+      m_MagazineCount 14
+     }
+    }
+   }
+  }
+  m_RifleUGL {
+   CRF_Weapon_Class "{668EF124C56E6BA5}" {
+    m_Weapon "{3BC80AAE900EC0B8}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_Suppressed.et"
+    m_Attachments {
+     "{DBE8F7374A320BDF}Prefabs/Weapons/Attachments/Optics/Collimators/Optic_EotechEXPS3/Collim_EXPS3_base.et"
+     "{43FDAF3FA0FF2299}Prefabs/Weapons/Attachments/Underbarrel/UGL_M203_long.et"
+    }
+    m_MagazineArray {
+     CRF_Magazine_Class "{668EF124C56E6BA2}" {
+      m_Magazine "{77AAEEB1D221D79A}Prefabs/Weapons/Magazines/762x51_SCARH_20rnd/Magazine_762x51_SCARH_20rnd_4Ball_1Tracer_M80A1_M62.et"
+      m_MagazineCount 14
+     }
+     CRF_Magazine_Class "{668EF124C56E6BA0}" {
+      m_Magazine "{1663496AE5B9F10B}Prefabs/Weapons/Ammo/Ammo_Grenade_HEDP_M433.et"
+      m_MagazineCount 4
+     }
+     CRF_Magazine_Class "{668EF124C56E6BAC}" {
+      m_Magazine "{98DB57ECEDC81CC2}Prefabs/Weapons/Ammo/Ammo_Flare_40mm_M583A1_White.et"
+      m_MagazineCount 2
+     }
+     CRF_Magazine_Class "{668EF124C56E6BA9}" {
+      m_Magazine "{AABE8FE0BA33DC8A}Prefabs/Weapons/Ammo/US_Ammo_Smoke_White.et"
+      m_MagazineCount 2
+     }
+     CRF_Magazine_Class "{668EF124C56E6B54}" {
+      m_Magazine "{0AF10C206CF1A282}Prefabs/Weapons/Ammo/US_Ammo_Smoke_Green.et"
+      m_MagazineCount 1
+     }
+     CRF_Magazine_Class "{668EF124C56E6B52}" {
+      m_Magazine "{2B0C4280078D96B6}Prefabs/Weapons/Ammo/US_Ammo_Smoke_Red.et"
+      m_MagazineCount 1
+     }
+    }
+   }
+  }
+  m_Carbine {
+   CRF_Weapon_Class "{668EF124C56E6B5D}" {
+    m_Weapon "{20DDB7ABE9F2FC00}Prefabs/Weapons/Rifles/MPX/Rifle_MPX_MOD1.et"
+    m_Attachments {
+     ""
+    }
+    m_MagazineArray {
+     CRF_Magazine_Class "{668EF124C56E6B5A}" {
+      m_Magazine "{49A107C35547BC4B}Prefabs/Weapons/Magazines/9x19_MPX_41rnd/Magazine_9x19_MPX_41rnd_4Ball_1Tracer_M1152_M1156.et"
+      m_MagazineCount 6
+     }
+    }
+   }
+  }
+  m_Pistol {
+   CRF_Weapon_Class "{668EF124C56E6B58}" {
+    m_Weapon "{8069A3DF6410FDDF}Prefabs/Weapons/Handguns/M17/Handgun_M17.et"
+    m_MagazineArray {
+     CRF_Magazine_Class "{668EF124C56E6B77}" {
+      m_Magazine "{8FF49793853DB2F9}Prefabs/Weapons/Magazines/m17_magazines/Magazine_9x19_m17_17rnd_M1152.et"
+      m_MagazineCount 2
+     }
+    }
+   }
+  }
+  m_AR CRF_Spec_Weapon_Class "{668EF124C56E6B70}" {
+   m_Weapon "{D2B48DEBEF38D7D7}Prefabs/Weapons/MachineGuns/M249/MG_M249.et"
+   m_MagazineArray {
+    CRF_Spec_Magazine_Class "{668EF124C56E6B7E}" {
+     m_Magazine "{BEE3897D2286992A}Prefabs/Weapons/Magazines/Box_556x45_M249_200rnd_M855A1_4Ball_1Tracer.et"
+     m_MagazineCount 2
+     m_AssistantMagazineCount 4
+    }
+   }
+  }
+  m_MMG CRF_Spec_Weapon_Class "{668EF124C56E6B7A}" {
+   m_Weapon "{E233F4F03E05301E}Prefabs/Weapons/MachineGuns/M240/MG_M240_Light_AP.et"
+   m_MagazineArray {
+    CRF_Spec_Magazine_Class "{668EF124C56E6B78}" {
+     m_Magazine "{AAF51CFA75A9CF8B}Prefabs/Weapons/Magazines/Box_762x51_M60_100rnd_4AP_1Tracer.et"
+     m_MagazineCount 7
+     m_AssistantMagazineCount 8
+    }
+   }
+  }
+  m_AT CRF_Spec_Weapon_Class "{668EF124C56E6B65}" {
+   m_Weapon "{9C5C20FB0E01E64F}Prefabs/Weapons/Launchers/M72/Launcher_M72A3.et"
+  }
+  m_MAT CRF_Spec_Weapon_Class "{668EF124C56E6B63}" {
+   m_Weapon "{35022055DCDDE98B}Prefabs/Weapons/Launchers/MK153/Launcher_MK153mod2.et"
+   m_MagazineArray {
+    CRF_Spec_Magazine_Class "{668EF124C56E6B60}" {
+     m_Magazine "{30BFCCBBC986CF50}Prefabs/Weapons/Ammo/Rocket_83mm_MK153_HEDP.et"
+     m_MagazineCount 2
+     m_AssistantMagazineCount 3
+    }
+   }
+  }
+  m_AA CRF_Spec_Weapon_Class "{668EF124C56E6B15}" {
+   m_Weapon "{3DF204EEE0534EF2}Prefabs/Weapons/Launchers/FIM92_Stinger/Launcher_FIM92_Stinger.et"
+   m_MagazineArray {
+    CRF_Spec_Magazine_Class "{668EF124C56E6B12}" {
+     m_Magazine "{3DF204EEE0534EF2}Prefabs/Weapons/Launchers/FIM92_Stinger/Launcher_FIM92_Stinger.et"
+     m_MagazineCount 1
+     m_AssistantMagazineCount 2
+    }
+   }
+  }
+  m_Sniper CRF_Weapon_Class "{668EF124C56E6B1E}" {
+   m_Weapon "{56CE827F9AD5880E}Prefabs/Weapons/Rifles/M40/Rifle_M40A5_Optic_PEQ.et"
+   m_MagazineArray {
+    CRF_Magazine_Class "{668EF124C56E6B01}" {
+     m_Magazine "{925F3A6F7FE0DE64}Prefabs/Weapons/Magazines/Magazine_762x51_M40_5rnd_M61AP.et"
+     m_MagazineCount 23
+    }
+   }
+  }
+ }
+ m_DefaultFactionGear CRF_Default_Gear "{668EF124C56E6B0B}" {
+  m_sLeadershipBinocularsPrefab "{03810BEF182ADA0B}Prefabs/Items/Equipment/Binoculars/Rangefinder_Vector21.et"
+  m_sAssistantBinocularsPrefab "{243948B23D90BECB}Prefabs/Items/Equipment/Binoculars/Binoculars_B8/Binoculars_B8.et"
+  m_DefaultMedicMedicalItems {
+   CRF_Inventory_Item "{668EF124C56E6B09}" {
+    m_sItemPrefab "{A81F501D3EF6F38E}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_US_01.et"
+    m_iItemCount 10
+   }
+   CRF_Inventory_Item "{668EF124C56E6B35}" {
+    m_sItemPrefab "{D70216B1B2889129}Prefabs/Items/Medicine/Tourniquet_01/Tourniquet_US_01.et"
+    m_iItemCount 3
+   }
+   CRF_Inventory_Item "{668EF124C56E6B3E}" {
+    m_sItemPrefab "{0D9A5DCF89AE7AA9}Prefabs/Items/Medicine/MorphineInjection_01/MorphineInjection_01.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{668EF124C56E6B3A}" {
+    m_sItemPrefab "{5B2FD067D70C1E8F}Prefabs/Items/Medicine/EpinephrineInjection/ACE_Medical_EpinephrineInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{668EF124C56E6B39}" {
+    m_sItemPrefab "{00E36F41CA310E2A}Prefabs/Items/Medicine/SalineBag_01/SalineBag_US_01.et"
+    m_iItemCount 5
+   }
+   CRF_Inventory_Item "{668EF124C56E6B24}" {
+    m_sItemPrefab "{AE578EEA4244D41F}Prefabs/Items/Equipment/Kits/MedicalKit_01/MedicalKit_01_US.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{668EF124C56E6B20}" {
+    m_sItemPrefab "{14C1A0F061D9DDEE}Prefabs/Weapons/Grenades/M18/Smoke_M18_Violet.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{668EF124C56E6B2E}" {
+    m_sItemPrefab "{D41D22DD1B8E921E}Prefabs/Weapons/Grenades/M18/Smoke_M18_Green.et"
+    m_iItemCount 1
+   }
+  }
+  m_DefaultClothing {
+   CRF_Clothing "{668EF124C56E6B2C}" {
+    m_iClothingType BACKPACK
+    m_ClothingPrefabs {
+     "{DF886C6B22F49828}Prefabs/Items/Equipment/Backpacks/backpack_511_rush12/Backpack_511_rush12_black.et"
+    }
+   }
+   CRF_Clothing "{668EF124C56E6B29}" {
+    m_iClothingType HEADGEAR
+    m_ClothingPrefabs {
+     "{72785390F723C7DA}Prefabs/Characters/HeadGear/Helmet_OPSCORE/Helmet_OPSCORE_MID_GRAY_AMP_NVG.et"
+    }
+   }
+   CRF_Clothing "{668EF124C56E6CD5}" {
+    m_iClothingType SHIRT
+    m_ClothingPrefabs {
+     "{C6A69BD0EC2CCF9F}Prefabs/Characters/Uniforms/Shirt_flannel/flannel_shirt_white_1.et"
+     "{1F9B18BFD25D7119}Prefabs/Characters/Uniforms/Shirt_flannel/flannel_shirt_green_1.et"
+     "{0B1D9228473E05AF}Prefabs/Characters/Uniforms/Shirt_flannel/flannel_shirt_red_1.et"
+     "{DD9CB456376FB01F}Prefabs/Characters/Uniforms/Shirt_flannel/flannel_shirt_brown_1.et"
+     "{228DBC831D3EDD65}Prefabs/Characters/Uniforms/Shirt_flannel/flannel_shirt_blue_1.et"
+     "{C6A69BD0EC2CCF9F}Prefabs/Characters/Uniforms/Shirt_flannel/flannel_shirt_white_1.et"
+    }
+   }
+   CRF_Clothing "{668EF124C56E6CD1}" {
+    m_iClothingType ARMOREDVEST
+    m_ClothingPrefabs {
+     "{D4ACFC8F94EDE501}Prefabs/Characters/Vests/Vest_AVS/Vest_AVS_radio_MCBlk.et"
+    }
+   }
+   CRF_Clothing "{668EF124C56E6CD9}" {
+    m_iClothingType PANTS
+    m_ClothingPrefabs {
+     "{C749B2C1C2CF3863}Prefabs/Characters/Uniforms/Civi_Pants/Civi_Jeans_Blue_Ripped.et"
+     "{9C35EE1E76EFCE7F}Prefabs/Characters/Uniforms/Civi_Pants/Civi_Jeans_v1.et"
+    }
+   }
+   CRF_Clothing "{668EF124C56E6CC5}" {
+    m_iClothingType BOOTS
+    m_ClothingPrefabs {
+     "{057E63449502EBCA}Prefabs/Characters/Footwear/Boots_Salomon/Footwear_Salomon.et"
+     "{64B94D8A4D92A4BD}Prefabs/Characters/Footwear/Boots_Altama/Footwear_Altama.et"
+    }
+   }
+   CRF_Clothing "{668EF124C56E6CC1}" {
+    m_iClothingType VEST
+    m_ClothingPrefabs {
+     "{DC5ED2874B47C75A}Prefabs/Characters/Vests/Vest_AVS/Variants/Vest_AVS_MCBlk_Nobelt.et"
+     "{9FB6D7969BB672AD}Prefabs/Characters/Vests/Vest_AVS/Variants/Vest_AVS_MCBlk_ronin.et"
+     "{7C8DB0CFC233A993}Prefabs/Characters/Vests/Vest_AVS/Variants/Vest_AVS_6x9_MCBlk_ronin.et"
+    }
+   }
+   CRF_Clothing "{668EF124C56E6CCD}" {
+    m_iClothingType HANDWEAR
+    m_ClothingPrefabs {
+     ""
+     "{ABB779CFC2E11E89}Prefabs/Characters/Handwear/Gloves_MechanixMpact/Gloves_mpack_Covert.et"
+    }
+   }
+  }
+  m_DefaultInventoryItems {
+   CRF_Inventory_Item "{668EF124C56E6CCB}" {
+    m_sItemPrefab "{3A421547BC29F679}Prefabs/Items/Equipment/Flashlights/Flashlight_MX991/Flashlight_MX991.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{668EF124C56E6CF6}" {
+    m_sItemPrefab "{E8F00BF730225B00}Prefabs/Weapons/Grenades/Grenade_M67.et"
+    m_iItemCount 2
+   }
+   CRF_Inventory_Item "{668EF124C56E6CF4}" {
+    m_sItemPrefab "{9DB69176CEF0EE97}Prefabs/Weapons/Grenades/Smoke_ANM8HC.et"
+    m_iItemCount 2
+   }
+   CRF_Inventory_Item "{668EF124C56E6CF2}" {
+    m_sItemPrefab "{61D4F80E49BF9B12}Prefabs/Items/Equipment/Compass/Compass_SY183.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{668EF124C56E6CE8}" {
+    m_sItemPrefab "{13772C903CB5E4F7}Prefabs/Items/Equipment/Maps/PaperMap_01_folded.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{668EF124C56E6C97}" {
+    m_sItemPrefab "{C5C3EFA0B77F202D}Prefabs/Items/Equipment/Watches/Watch_GarminTactixBravo_Red.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{668EF124C56E6C93}" {
+    m_sItemPrefab "{A81F501D3EF6F38E}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_US_01.et"
+    m_iItemCount 2
+   }
+   CRF_Inventory_Item "{668EF124C56E6C90}" {
+    m_sItemPrefab "{D70216B1B2889129}Prefabs/Items/Medicine/Tourniquet_01/Tourniquet_US_01.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{668EF124C56E6C9E}" {
+    m_sItemPrefab "{6E35D94130954509}Prefabs/Items/Equipment/Accessories/ETool_ALICE/ETool_ALICE_FreeRoamBuilding_Gadget.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{668EF124C56E6C9C}" {
+    m_sItemPrefab "{8554ED3F088BADA6}Prefabs/Items/Core/Wirecutters/wirecutters.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{668EF124C56E6C98}" {
+    m_sItemPrefab "{CBF9B9942E07B6B8}Prefabs/Items/Equipment/Accessories/ZipCuffs/ACE_Captives_ZipCuffs.et"
+    m_iItemCount 2
+   }
+   CRF_Inventory_Item "{668EF124C56E6C86}" {
+    m_sItemPrefab "{6676FF9B716402CC}Prefabs/Items/PersonalBelongings/PersonalBelongings_US.et"
+    m_iItemCount 0
+   }
+  }
+ }
+ m_CustomFactionGear CRF_Custom_Gear "{668EF124C56E6C8C}" {
+  m_RolesToSetCustomGear {
+   CRF_Role_Custom_Gear "{668EF124C56E6C8A}" {
+    m_Role VEHICLE_LEAD
+    m_Clothing {
+     CRF_Clothing "{668EF124C56E6C8B}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{1D99585CF8E34D91}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01.et"
+       "{A4145024AE7084F6}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01_tucked.et"
+      }
+     }
+     CRF_Clothing "{668EF124C56E6CB7}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       ""
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124C56E6CB2}" {
+    m_Role INDIRECT_LEAD
+    m_AdditionalInventoryItems {
+     CRF_Inventory_Item "{668EF124C56E6CB3}" {
+      m_sItemPrefab "{6113990D163E5249}Prefabs/Items/Equipment/BalisticTable/BalisticTable_US.et"
+      m_iItemCount 1
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124C56E6CB1}" {
+    m_Role LOGI_LEAD
+    m_Clothing {
+     CRF_Clothing "{668EF124C56E6CBF}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{DF886C6B22F49828}Prefabs/Items/Equipment/Backpacks/backpack_511_rush12/Backpack_511_rush12_black.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124C56E6CBC}" {
+    m_Role MEDICAL_OFFICER
+    m_Clothing {
+     CRF_Clothing "{668EF124C56E6CBD}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{4805E67E2AE30F8D}Prefabs/Items/Equipment/Backpacks/Backpack_Medical_M5.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124C56E6CA6}" {
+    m_Role MEDIC
+    m_Clothing {
+     CRF_Clothing "{668EF124C56E6CA7}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{DF886C6B22F49828}Prefabs/Items/Equipment/Backpacks/backpack_511_rush12/Backpack_511_rush12_black.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124C56E6CA4}" {
+    m_Role ASSISTANT_AUTOMATIC_RIFLEMAN
+    m_Clothing {
+     CRF_Clothing "{668EF124C56E6CA5}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{DF886C6B22F49828}Prefabs/Items/Equipment/Backpacks/backpack_511_rush12/Backpack_511_rush12_black.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124C56E6CA1}" {
+    m_Role ASSISTANT_HEAVY_ANTITANK
+    m_Clothing {
+     CRF_Clothing "{668EF124C56E1664}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{DF886C6B22F49828}Prefabs/Items/Equipment/Backpacks/backpack_511_rush12/Backpack_511_rush12_black.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124C56E166A}" {
+    m_Role ASSISTANT_MEDIUM_ANTITANK
+    m_Clothing {
+     CRF_Clothing "{668EF124C56E1668}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{DF886C6B22F49828}Prefabs/Items/Equipment/Backpacks/backpack_511_rush12/Backpack_511_rush12_black.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124C56E166F}" {
+    m_Role ASSISTANT_HEAVY_MACHINEGUN
+    m_Clothing {
+     CRF_Clothing "{668EF124C56E166E}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{DF886C6B22F49828}Prefabs/Items/Equipment/Backpacks/backpack_511_rush12/Backpack_511_rush12_black.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124C56E166D}" {
+    m_Role ASSISTANT_MEDIUM_MACHINEGUN
+    m_Clothing {
+     CRF_Clothing "{668EF124C56E166C}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{DF886C6B22F49828}Prefabs/Items/Equipment/Backpacks/backpack_511_rush12/Backpack_511_rush12_black.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124C56E1693}" {
+    m_Role ASSISTANT_ANTI_AIR
+    m_Clothing {
+     CRF_Clothing "{668EF124C56E1692}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{DF886C6B22F49828}Prefabs/Items/Equipment/Backpacks/backpack_511_rush12/Backpack_511_rush12_black.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124C56E1691}" {
+    m_Role VEHICLE_DRIVER
+    m_Clothing {
+     CRF_Clothing "{668EF124C56E1690}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       ""
+      }
+     }
+     CRF_Clothing "{668EF124C56E1696}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{1D99585CF8E34D91}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01.et"
+       "{A4145024AE7084F6}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01_tucked.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124C56E1695}" {
+    m_Role VEHICLE_GUNNER
+    m_Clothing {
+     CRF_Clothing "{668EF124C56E0272}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       ""
+      }
+     }
+     CRF_Clothing "{668EF124C56E0273}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{1D99585CF8E34D91}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01.et"
+       "{A4145024AE7084F6}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01_tucked.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124C56E027C}" {
+    m_Role VEHICLE_LOADER
+    m_Clothing {
+     CRF_Clothing "{668EF124C56E92FA}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       ""
+      }
+     }
+     CRF_Clothing "{668EF124C56E92FB}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{1D99585CF8E34D91}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01.et"
+       "{A4145024AE7084F6}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01_tucked.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124C56E92F8}" {
+    m_Role PILOT
+    m_Clothing {
+     CRF_Clothing "{668EF124C56E92F9}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       ""
+      }
+     }
+     CRF_Clothing "{668EF124C56E92D5}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{B137B7CE988557D2}Prefabs/Characters/Uniforms/Suit_Pilot_US_01/Suit_Pilot_US_01.et"
+      }
+     }
+     CRF_Clothing "{668EF124C56E92D9}" {
+      m_iClothingType HEADGEAR
+      m_ClothingPrefabs {
+       "{483A80042765275F}Prefabs/Characters/HeadGear/Helmet_SPH4_01/Helmet_SPH4_01.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124C56E92DE}" {
+    m_Role CREW_CHIEF
+    m_Clothing {
+     CRF_Clothing "{668EF124C56E92DF}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       ""
+      }
+     }
+     CRF_Clothing "{668EF124C56E92DC}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{B137B7CE988557D2}Prefabs/Characters/Uniforms/Suit_Pilot_US_01/Suit_Pilot_US_01.et"
+      }
+     }
+     CRF_Clothing "{668EF124C56E92DD}" {
+      m_iClothingType HEADGEAR
+      m_ClothingPrefabs {
+       "{483A80042765275F}Prefabs/Characters/HeadGear/Helmet_SPH4_01/Helmet_SPH4_01.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124C56E92C2}" {
+    m_Role LOGI_RUNNER
+    m_Clothing {
+     CRF_Clothing "{668EF124C56E92C3}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{DF886C6B22F49828}Prefabs/Items/Equipment/Backpacks/backpack_511_rush12/Backpack_511_rush12_black.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124C56E92C0}" {
+    m_Role INDIRECT_GUNNER
+    m_Clothing {
+     CRF_Clothing "{668EF124C56E92C1}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{EE53109CB37C43B1}Prefabs/Items/Equipment/Backpacks/M2/Backpack_m252_Mortar_Weapon.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124C56E92C7}" {
+    m_Role INDIRECT_GUNNER
+    m_Clothing {
+     CRF_Clothing "{668EF124C56E92C4}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{A207909C42E58944}Prefabs/Items/Equipment/Backpacks/Backpack_US_Tripod.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124C56E92CB}" {
+    m_Role RIFLEMAN_DEMO
+    m_AdditionalInventoryItems {
+     CRF_Inventory_Item "{668EF124C56E92C8}" {
+      m_sItemPrefab "{D9B1F65D20081DEF}PrefabsEditable/Explosives/E_DemoBlock_M112.et"
+      m_iItemCount 2
+     }
+     CRF_Inventory_Item "{668EF124C56E92CC}" {
+      m_sItemPrefab "{CE0AF733722B3978}Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_M34.et"
+      m_iItemCount 1
+     }
+     CRF_Inventory_Item "{668EF124C56E92B2}" {
+      m_sItemPrefab "{55641F140F92FDCD}Prefabs/Weapons/Explosives/Explosive_Satchels/BLUFOR_Satchel.et"
+      m_iItemCount 1
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124C56E92B0}" {
+    m_Role COMBAT_ENGINEER
+    m_AdditionalInventoryItems {
+     CRF_Inventory_Item "{668EF124C56E92B1}" {
+      m_sItemPrefab "{73F69547963CAEE0}PrefabsEditable/Explosives/E_DemoBlock_TSh400g.et"
+      m_iItemCount 1
+     }
+     CRF_Inventory_Item "{668EF124C56E92B7}" {
+      m_sItemPrefab "{90976DC90A223095}Prefabs/Items/Equipment/Detonators/BlastingMachine_KPM_3U1/BlastingMachine_KPM_3U1.et"
+      m_iItemCount 1
+     }
+     CRF_Inventory_Item "{668EF124C56E92B5}" {
+      m_sItemPrefab "{00515E7AAAFD9CB6}Prefabs/Weapons/Explosives/Explosive_Satchels/INDFOR_Satchel.et"
+      m_iItemCount 3
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF125B61C79ED}" {
+    m_Role ASSISTANT_RIFLEMAN_ANTITANK
+    m_sRoleName "Combat Life Saver"
+    m_AdditionalInventoryItems {
+     CRF_Inventory_Item "{668EF125B9FBD4B6}" {
+      m_sItemPrefab "{A81F501D3EF6F38E}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_US_01.et"
+      m_iItemCount 10
+     }
+     CRF_Inventory_Item "{668EF125BCD1941F}" {
+      m_sItemPrefab "{D70216B1B2889129}Prefabs/Items/Medicine/Tourniquet_01/Tourniquet_US_01.et"
+      m_iItemCount 3
+     }
+     CRF_Inventory_Item "{668EF1258503E59A}" {
+      m_sItemPrefab "{00E36F41CA310E2A}Prefabs/Items/Medicine/SalineBag_01/SalineBag_US_01.et"
+      m_iItemCount 3
+     }
+    }
+   }
+  }
+ }
+}

--- a/Configs/Gearscripts/Custom/Harry/push/CRF_GS_RHSION_Urban_NoOptics_AP_CLS.conf.meta
+++ b/Configs/Gearscripts/Custom/Harry/push/CRF_GS_RHSION_Urban_NoOptics_AP_CLS.conf.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{35262EC7910CA8D8}Configs/Gearscripts/Standard/Modern/Variants/CRF_GS_RHSION_Urban_NoOptics_AP_CLS.conf"
+ Configurations {
+  CONFResourceClass PC {
+  }
+  CONFResourceClass XBOX_ONE : PC {
+  }
+  CONFResourceClass XBOX_SERIES : PC {
+  }
+  CONFResourceClass PS4 : PC {
+  }
+  CONFResourceClass PS5 : PC {
+  }
+  CONFResourceClass HEADLESS : PC {
+  }
+  CONFResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Configs/Gearscripts/Custom/Harry/push/CRF_GS_RHSUSArmyMC_CLS.conf
+++ b/Configs/Gearscripts/Custom/Harry/push/CRF_GS_RHSUSArmyMC_CLS.conf
@@ -1,0 +1,677 @@
+CRF_GearScriptConfig {
+ m_FactionName "US Army"
+ m_FactionIcon "{9415F1FFF6591F8D}UI/Textures/Editor/EditableEntities/Factions/USAF_icon.edds"
+ m_FactionIdentity "{93C4AAA0496F0B42}Configs/Identities/CRF_CharacterIdentity_American.conf"
+ m_FactionWeapons CRF_Weapons "{668EF124F001FA3C}" {
+  m_Rifle {
+   CRF_Weapon_Class "{668EF124F001F9C0}" {
+    m_Weapon "{14BAB2D9F6F782D9}Prefabs/Weapons/Rifles/M4A1/Rifle_M4A1_BLOCK_II_XPS3.et"
+    m_MagazineArray {
+     CRF_Magazine_Class "{668EF124F001F9CD}" {
+      m_Magazine "{A540E8600876C2A2}Prefabs/Weapons/Magazines/Pmag/Magazine_556x45_PmagWindowed_Coy_30rnd_M855A1_last5tracer.et"
+      m_MagazineCount 9
+     }
+    }
+   }
+   CRF_Weapon_Class "{668EF124F001F9CB}" {
+    m_Weapon "{9B40415563B9F281}Prefabs/Weapons/Rifles/M4A1/Rifle_M4A1_BLOCK_II_Black.et"
+    m_MagazineArray {
+     CRF_Magazine_Class "{668EF124F001F9D5}" {
+      m_Magazine "{BD30BE4A3D8B9DAC}Prefabs/Weapons/Magazines/Pmag/Magazine_556x45_PmagWindowed_30rnd_M855A1_last5tracer.et"
+      m_MagazineCount 9
+     }
+    }
+   }
+  }
+  m_RifleUGL {
+   CRF_Weapon_Class "{668EF124F001F9D6}" {
+    m_Weapon "{E9AD164AA3CD8B8D}Prefabs/Weapons/Rifles/M4A1/Rifle_M4A1_BLOCK_II_XPS3_M203.et"
+    m_MagazineArray {
+     CRF_Magazine_Class "{668EF124F00E64B2}" {
+      m_Magazine "{BD30BE4A3D8B9DAC}Prefabs/Weapons/Magazines/Pmag/Magazine_556x45_PmagWindowed_30rnd_M855A1_last5tracer.et"
+      m_MagazineCount 9
+     }
+     CRF_Magazine_Class "{668EF124F00E64B7}" {
+      m_Magazine "{1663496AE5B9F10B}Prefabs/Weapons/Ammo/Ammo_Grenade_HEDP_M433.et"
+      m_MagazineCount 4
+     }
+     CRF_Magazine_Class "{668EF124F00E64BB}" {
+      m_Magazine "{98DB57ECEDC81CC2}Prefabs/Weapons/Ammo/Ammo_Flare_40mm_M583A1_White.et"
+      m_MagazineCount 2
+     }
+     CRF_Magazine_Class "{668EF124F00E64BF}" {
+      m_Magazine "{AABE8FE0BA33DC8A}Prefabs/Weapons/Ammo/US_Ammo_Smoke_White.et"
+      m_MagazineCount 2
+     }
+     CRF_Magazine_Class "{668EF124F00E6480}" {
+      m_Magazine "{0AF10C206CF1A282}Prefabs/Weapons/Ammo/US_Ammo_Smoke_Green.et"
+      m_MagazineCount 1
+     }
+     CRF_Magazine_Class "{668EF124F00E6482}" {
+      m_Magazine "{2B0C4280078D96B6}Prefabs/Weapons/Ammo/US_Ammo_Smoke_Red.et"
+      m_MagazineCount 1
+     }
+    }
+   }
+   CRF_Weapon_Class "{668EF124F00E648C}" {
+    m_Weapon "{ED777DCB94B52A98}Prefabs/Weapons/Rifles/M4A1/Rifle_M4A1_BLOCK_II_XPS3_M203_black.et"
+    m_MagazineArray {
+     CRF_Magazine_Class "{668EF124F00E648F}" {
+      m_Magazine "{BD30BE4A3D8B9DAC}Prefabs/Weapons/Magazines/Pmag/Magazine_556x45_PmagWindowed_30rnd_M855A1_last5tracer.et"
+      m_MagazineCount 9
+     }
+     CRF_Magazine_Class "{668EF124F00E6491}" {
+      m_Magazine "{1663496AE5B9F10B}Prefabs/Weapons/Ammo/Ammo_Grenade_HEDP_M433.et"
+      m_MagazineCount 4
+     }
+     CRF_Magazine_Class "{668EF124F00EB03D}" {
+      m_Magazine "{98DB57ECEDC81CC2}Prefabs/Weapons/Ammo/Ammo_Flare_40mm_M583A1_White.et"
+      m_MagazineCount 2
+     }
+     CRF_Magazine_Class "{668EF124F00EB03C}" {
+      m_Magazine "{AABE8FE0BA33DC8A}Prefabs/Weapons/Ammo/US_Ammo_Smoke_White.et"
+      m_MagazineCount 2
+     }
+     CRF_Magazine_Class "{668EF124F00EB03F}" {
+      m_Magazine "{0AF10C206CF1A282}Prefabs/Weapons/Ammo/US_Ammo_Smoke_Green.et"
+      m_MagazineCount 1
+     }
+     CRF_Magazine_Class "{668EF124F00EB039}" {
+      m_Magazine "{2B0C4280078D96B6}Prefabs/Weapons/Ammo/US_Ammo_Smoke_Red.et"
+      m_MagazineCount 1
+     }
+    }
+   }
+  }
+  m_Carbine {
+   CRF_Weapon_Class "{668EF124F00EB03B}" {
+    m_Weapon "{5024FAC7A4ABCDFD}Prefabs/Weapons/Rifles/M4A1/Variants/Forecon/Rifle_M4A1_RAS_ERGO_Forecon14.et"
+    m_MagazineArray {
+     CRF_Magazine_Class "{668EF124F00EB04B}" {
+      m_Magazine "{BD30BE4A3D8B9DAC}Prefabs/Weapons/Magazines/Pmag/Magazine_556x45_PmagWindowed_30rnd_M855A1_last5tracer.et"
+      m_MagazineCount 7
+     }
+    }
+   }
+   CRF_Weapon_Class "{668EF124F00EB046}" {
+    m_Weapon "{35963585E5E620CF}Prefabs/Weapons/Rifles/M4A1/Variants/Forecon/Rifle_M4A1_RAS_ERGO_Forecon8.et"
+    m_MagazineArray {
+     CRF_Magazine_Class "{668EF124F00EB041}" {
+      m_Magazine "{BD30BE4A3D8B9DAC}Prefabs/Weapons/Magazines/Pmag/Magazine_556x45_PmagWindowed_30rnd_M855A1_last5tracer.et"
+      m_MagazineCount 7
+     }
+    }
+   }
+  }
+  m_Pistol {
+   CRF_Weapon_Class "{668EF124F00EB042}" {
+    m_Weapon "{8069A3DF6410FDDF}Prefabs/Weapons/Handguns/M17/Handgun_M17.et"
+    m_MagazineArray {
+     CRF_Magazine_Class "{668EF124F00EB05D}" {
+      m_Magazine "{8FF49793853DB2F9}Prefabs/Weapons/Magazines/m17_magazines/Magazine_9x19_m17_17rnd_M1152.et"
+      m_MagazineCount 2
+     }
+    }
+   }
+  }
+  m_AR CRF_Spec_Weapon_Class "{668EF124F00EB057}" {
+   m_Weapon "{D2B48DEBEF38D7D7}Prefabs/Weapons/MachineGuns/M249/MG_M249.et"
+   m_MagazineArray {
+    CRF_Spec_Magazine_Class "{668EF124F00EF3C9}" {
+     m_Magazine "{E8E9972833CB4203}Prefabs/Weapons/Magazines/Box_556x45_M249_200rnd_M855A1_Ball.et"
+     m_MagazineCount 4
+     m_AssistantMagazineCount 4
+    }
+   }
+  }
+  m_MMG CRF_Spec_Weapon_Class "{668EF124F00EF3F3}" {
+   m_Weapon "{E233F4F03E05301E}Prefabs/Weapons/MachineGuns/M240/MG_M240_Light_AP.et"
+   m_MagazineArray {
+    CRF_Spec_Magazine_Class "{668EF124F00EF3F2}" {
+     m_Magazine "{AAF51CFA75A9CF8B}Prefabs/Weapons/Magazines/Box_762x51_M60_100rnd_4AP_1Tracer.et"
+     m_MagazineCount 7
+     m_AssistantMagazineCount 8
+    }
+   }
+  }
+  m_AT CRF_Spec_Weapon_Class "{668EF124F00EF3FB}" {
+   m_Weapon "{9C5C20FB0E01E64F}Prefabs/Weapons/Launchers/M72/Launcher_M72A3.et"
+  }
+  m_MAT CRF_Spec_Weapon_Class "{668EF124F00EF3F9}" {
+   m_Weapon "{DA376E83952F1DFD}Prefabs/Weapons/Launchers/M2CG/Launcher_M2CG.et"
+   m_MagazineArray {
+    CRF_Spec_Magazine_Class "{668EF124F00EF3F8}" {
+     m_Magazine "{0B1906A687028974}Prefabs/Weapons/Ammo/Ammo_Rocket_HEDP502.et"
+     m_MagazineCount 2
+     m_AssistantMagazineCount 2
+    }
+    CRF_Spec_Magazine_Class "{668EF124F00EF317}" {
+     m_Magazine "{972E4239C2F8D0DB}Prefabs/Weapons/Ammo/Ammo_Rocket_HE411B.et"
+     m_MagazineCount 1
+     m_AssistantMagazineCount 1
+    }
+   }
+  }
+  m_AA CRF_Spec_Weapon_Class "{668EF124F00EF31B}" {
+   m_Weapon "{3DF204EEE0534EF2}Prefabs/Weapons/Launchers/FIM92_Stinger/Launcher_FIM92_Stinger.et"
+   m_MagazineArray {
+    CRF_Spec_Magazine_Class "{668EF124F00EF31A}" {
+     m_Magazine "{3DF204EEE0534EF2}Prefabs/Weapons/Launchers/FIM92_Stinger/Launcher_FIM92_Stinger.et"
+     m_MagazineCount 1
+     m_AssistantMagazineCount 2
+    }
+   }
+  }
+  m_Sniper CRF_Weapon_Class "{668EF124F00EF318}" {
+   m_Weapon "{56CE827F9AD5880E}Prefabs/Weapons/Rifles/M40/Rifle_M40A5_Optic_PEQ.et"
+   m_MagazineArray {
+    CRF_Magazine_Class "{668EF124F00EF31F}" {
+     m_Magazine "{925F3A6F7FE0DE64}Prefabs/Weapons/Magazines/Magazine_762x51_M40_5rnd_M61AP.et"
+     m_MagazineCount 23
+    }
+   }
+  }
+ }
+ m_DefaultFactionGear CRF_Default_Gear "{668EF124F00EF308}" {
+  m_sLeadershipBinocularsPrefab "{03810BEF182ADA0B}Prefabs/Items/Equipment/Binoculars/Rangefinder_Vector21.et"
+  m_sAssistantBinocularsPrefab "{0CF54B9A85D8E0D4}Prefabs/Items/Equipment/Binoculars/Binoculars_M22/Binoculars_M22.et"
+  m_DefaultMedicMedicalItems {
+   CRF_Inventory_Item "{668EF124F00EF30F}" {
+    m_sItemPrefab "{A81F501D3EF6F38E}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_US_01.et"
+    m_iItemCount 10
+   }
+   CRF_Inventory_Item "{668EF124F00EF332}" {
+    m_sItemPrefab "{D70216B1B2889129}Prefabs/Items/Medicine/Tourniquet_01/Tourniquet_US_01.et"
+    m_iItemCount 3
+   }
+   CRF_Inventory_Item "{668EF124F00EF335}" {
+    m_sItemPrefab "{0D9A5DCF89AE7AA9}Prefabs/Items/Medicine/MorphineInjection_01/MorphineInjection_01.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{668EF124F00EF339}" {
+    m_sItemPrefab "{5B2FD067D70C1E8F}Prefabs/Items/Medicine/EpinephrineInjection/ACE_Medical_EpinephrineInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{668EF124F00EF323}" {
+    m_sItemPrefab "{00E36F41CA310E2A}Prefabs/Items/Medicine/SalineBag_01/SalineBag_US_01.et"
+    m_iItemCount 5
+   }
+   CRF_Inventory_Item "{668EF124F00EF321}" {
+    m_sItemPrefab "{AE578EEA4244D41F}Prefabs/Items/Equipment/Kits/MedicalKit_01/MedicalKit_01_US.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{668EF124F00EF325}" {
+    m_sItemPrefab "{14C1A0F061D9DDEE}Prefabs/Weapons/Grenades/M18/Smoke_M18_Violet.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{668EF124F00EF329}" {
+    m_sItemPrefab "{D41D22DD1B8E921E}Prefabs/Weapons/Grenades/M18/Smoke_M18_Green.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{668EF124F00EF32F}" {
+    m_sItemPrefab "{58CF3AB87C441295}Prefabs/Items/Medicine/AmmoniumCarbonatePackage/ACE_Medical_AmmoniumCarbonatePackage.et"
+    m_iItemCount 10
+   }
+   CRF_Inventory_Item "{668EF124F00EF32C}" {
+    m_sItemPrefab "{02DD34077F51F65E}Prefabs/Items/Medicine/NaloxoneInjection/ACE_Medical_NaloxoneInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{668EF124F00EF352}" {
+    m_sItemPrefab "{9BBA766CD869002C}Prefabs/Items/Medicine/PhenylephrineInjection/ACE_Medical_PhenylephrineInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{668EF124F00EF357}" {
+    m_sItemPrefab "{D0434D5215B54181}Prefabs/Items/Medicine/MetoprololInjection/ACE_Medical_MetoprololInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{668EF124F00EF35B}" {
+    m_sItemPrefab "{9DB69176CEF0EE97}Prefabs/Weapons/Grenades/Smoke_ANM8HC.et"
+    m_iItemCount 2
+   }
+  }
+  m_DefaultClothing {
+   CRF_Clothing "{668EF124F00EF35F}" {
+    m_iClothingType BACKPACK
+    m_ClothingPrefabs {
+     "{CE832B86D234AD62}Prefabs/Items/Equipment/Backpacks/CRF_Backpack_Invisable.et"
+    }
+   }
+   CRF_Clothing "{668EF124F00EF343}" {
+    m_iClothingType HEADGEAR
+    m_ClothingPrefabs {
+     "{3927674D3203BA37}Prefabs/Characters/HeadGear/Helmet_OPSCORE/Helmet_OPSCORE_XP_MC_AMP_nvg.et"
+     "{68466A87948E7B09}Prefabs/Characters/HeadGear/Helmet_OPSCORE/Helmet_OPSCORE_XP_MC_Liberator_NVG.et"
+     "{E642EEE838ADE0B2}Prefabs/Characters/HeadGear/Helmet_OPSCORE/Helmet_OPSCORE_XP_MC_NVG.et"
+     "{9051B4C01408CB2E}Prefabs/Characters/HeadGear/Helmet_OPSCORE/Helmet_OPSCORE_XP_MC_PELTOR_NVG.et"
+    }
+   }
+   CRF_Clothing "{668EF124F00EF345}" {
+    m_iClothingType SHIRT
+    m_ClothingPrefabs {
+     "{7BA7FF3E9F68960E}Prefabs/Characters/Uniforms/Crye_Shirt/Jacket_Crye_Combat_Shirt_MC.et"
+     "{E8EAD526CA6BCA16}Prefabs/Characters/Uniforms/Crye_Shirt/Jacket_Crye_Combat_Shirt_Rolled_multicam.et"
+    }
+   }
+   CRF_Clothing "{668EF124F00EF367}" {
+    m_iClothingType ARMOREDVEST
+    m_ClothingPrefabs {
+     "{F0742759AB82A2AB}Prefabs/Characters/Vests/Vest_AACPC/Vest_AACPC_NeckProtection_Groin_MC.et"
+    }
+   }
+   CRF_Clothing "{668EF124F00EF36B}" {
+    m_iClothingType PANTS
+    m_ClothingPrefabs {
+     "{2FDEBA2FF1B7759E}Prefabs/Characters/Uniforms/Crye_Pants/crye_pants_mc.et"
+    }
+   }
+   CRF_Clothing "{668EF124F00EF369}" {
+    m_iClothingType BOOTS
+    m_ClothingPrefabs {
+     "{21B331B5FA807997}Prefabs/Characters/Footwear/Boots_Rocky_SV2/Footwear_Rocky_SV2.et"
+    }
+   }
+   CRF_Clothing "{668EF124F00EF36C}" {
+    m_iClothingType VEST
+    m_ClothingPrefabs {
+     "{A8866A9389018D3B}Prefabs/Characters/Vests/Vest_JPC/variants/Vest_JPC_okinawa_Coy2.et"
+     "{31F74414C617CAB2}Prefabs/Characters/Vests/Vest_JPC/variants/Vest_JPC_okinawa_Coy.et"
+     "{4D1A266A85E41A50}Prefabs/Characters/Vests/Vest_JPC/variants/Vest_JPC_okinawa_Coy3.et"
+     "{702E0352F0889367}Prefabs/Characters/Vests/Vest_JPC/variants/Vest_JPC_okinawa_Coy4.et"
+     "{95B24FABFC6D040C}Prefabs/Characters/Vests/Vest_JPC/variants/Vest_JPC_okinawa_Coy5.et"
+     "{F9E67B4B40A98B22}Prefabs/Characters/Vests/Vest_JPC/variants/Vest_JPC_okinawa_Coy6.et"
+     "{1C7A37B24C4C1C49}Prefabs/Characters/Vests/Vest_JPC/variants/Vest_JPC_okinawa_Coy7.et"
+     "{838E313BAA70994C}Prefabs/Characters/Vests/Vest_JPC/variants/Vest_JPC_okinawa_Coy8.et"
+     "{EF06F43D51D1E7D7}Prefabs/Characters/Vests/Vest_JPC/variants/Vest_JPC_okinawa_Coy_MG.et"
+     "{38D600B4D232D9D9}Prefabs/Characters/Vests/Vest_JPC/variants/Vest_JPC_okinawa_Coy_sniper.et"
+     "{5954E7E6197D0916}Prefabs/Characters/Vests/Vest_JPC/variants/Vest_JPC_okinawa_Coy_sniper2.et"
+     "{C41C60EA0CD22C53}Prefabs/Characters/Vests/Vest_JPC/variants/Vest_JPC_okinawa_MC.et"
+     "{9E6B8BFB0BFBEC2E}Prefabs/Characters/Vests/Vest_JPC/variants/Vest_JPC_okinawa_MC2.et"
+     "{7BF7C702071E7B45}Prefabs/Characters/Vests/Vest_JPC/variants/Vest_JPC_okinawa_MC3.et"
+    }
+   }
+   CRF_Clothing "{668EF124F00EF294}" {
+    m_iClothingType HANDWEAR
+    m_ClothingPrefabs {
+     ""
+     "{B9FA26F5990CDEDD}Prefabs/Characters/Handwear/Gloves_MechanixMpact/Gloves_mpack_MC.et"
+    }
+   }
+  }
+  m_DefaultInventoryItems {
+   CRF_Inventory_Item "{668EF124F00EF283}" {
+    m_sItemPrefab "{3A421547BC29F679}Prefabs/Items/Equipment/Flashlights/Flashlight_MX991/Flashlight_MX991.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{668EF124F00EF280}" {
+    m_sItemPrefab "{E8F00BF730225B00}Prefabs/Weapons/Grenades/Grenade_M67.et"
+    m_iItemCount 2
+   }
+   CRF_Inventory_Item "{668EF124F00EF285}" {
+    m_sItemPrefab "{9DB69176CEF0EE97}Prefabs/Weapons/Grenades/Smoke_ANM8HC.et"
+    m_iItemCount 2
+   }
+   CRF_Inventory_Item "{668EF124F00EF284}" {
+    m_sItemPrefab "{61D4F80E49BF9B12}Prefabs/Items/Equipment/Compass/Compass_SY183.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{668EF124F00EF289}" {
+    m_sItemPrefab "{13772C903CB5E4F7}Prefabs/Items/Equipment/Maps/PaperMap_01_folded.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{668EF124F00EF28E}" {
+    m_sItemPrefab "{7C53E6DE2E4BD8CB}Prefabs/Items/Equipment/Watches/Watch_GarminTactixBravo.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{668EF124F00EF2B2}" {
+    m_sItemPrefab "{A81F501D3EF6F38E}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_US_01.et"
+    m_iItemCount 2
+   }
+   CRF_Inventory_Item "{668EF124F00EF2B1}" {
+    m_sItemPrefab "{D70216B1B2889129}Prefabs/Items/Medicine/Tourniquet_01/Tourniquet_US_01.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{668EF124F00EF2B0}" {
+    m_sItemPrefab "{6E35D94130954509}Prefabs/Items/Equipment/Accessories/ETool_ALICE/ETool_ALICE_FreeRoamBuilding_Gadget.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{668EF124F00EF2B5}" {
+    m_sItemPrefab "{8554ED3F088BADA6}Prefabs/Items/Core/Wirecutters/wirecutters.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{668EF124F00EF2B9}" {
+    m_sItemPrefab "{CBF9B9942E07B6B8}Prefabs/Items/Equipment/Accessories/ZipCuffs/ACE_Captives_ZipCuffs.et"
+    m_iItemCount 2
+   }
+   CRF_Inventory_Item "{668EF124F00EF2BF}" {
+    m_sItemPrefab "{6676FF9B716402CC}Prefabs/Items/PersonalBelongings/PersonalBelongings_US.et"
+    m_iItemCount 0
+   }
+  }
+ }
+ m_CustomFactionGear CRF_Custom_Gear "{668EF124F00EF2A1}" {
+  m_RolesToSetCustomGear {
+   CRF_Role_Custom_Gear "{668EF124F00EF2A0}" {
+    m_Role VEHICLE_LEAD
+    m_Clothing {
+     CRF_Clothing "{668EF124F00EF2A7}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       ""
+      }
+     }
+     CRF_Clothing "{668EF124F00EF2A6}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{1D99585CF8E34D91}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01.et"
+       "{A4145024AE7084F6}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01_tucked.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124F00EF2AA}" {
+    m_Role INDIRECT_LEAD
+    m_AdditionalInventoryItems {
+     CRF_Inventory_Item "{668EF124F00EF2A9}" {
+      m_sItemPrefab "{6113990D163E5249}Prefabs/Items/Equipment/BalisticTable/BalisticTable_US.et"
+      m_iItemCount 1
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124F00EF2AD}" {
+    m_Role LOGI_LEAD
+    m_Clothing {
+     CRF_Clothing "{668EF124F00EF2AC}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{48602F57998AB597}Prefabs/Items/Equipment/Backpacks/FILBE_Backpack.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124F00EF2D1}" {
+    m_Role MEDICAL_OFFICER
+    m_Clothing {
+     CRF_Clothing "{668EF124F00EF2D0}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{4805E67E2AE30F8D}Prefabs/Items/Equipment/Backpacks/Backpack_Medical_M5.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124F00EF2D6}" {
+    m_Role MEDIC
+    m_Clothing {
+     CRF_Clothing "{668EF124F00EF2D5}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{4805E67E2AE30F8D}Prefabs/Items/Equipment/Backpacks/Backpack_Medical_M5.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124F00EF2D4}" {
+    m_Role ASSISTANT_AUTOMATIC_RIFLEMAN
+    m_Clothing {
+     CRF_Clothing "{668EF124F00EF2DB}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{48602F57998AB597}Prefabs/Items/Equipment/Backpacks/FILBE_Backpack.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124F00EF2DA}" {
+    m_Role ASSISTANT_RIFLEMAN_ANTITANK
+    m_Clothing {
+     CRF_Clothing "{668EF124F00EF2D9}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{48602F57998AB597}Prefabs/Items/Equipment/Backpacks/FILBE_Backpack.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124F00EF2D8}" {
+    m_Role ASSISTANT_HEAVY_ANTITANK
+    m_Clothing {
+     CRF_Clothing "{668EF124F00F61D7}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{48602F57998AB597}Prefabs/Items/Equipment/Backpacks/FILBE_Backpack.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124F00F61D1}" {
+    m_Role ASSISTANT_MEDIUM_ANTITANK
+    m_Clothing {
+     CRF_Clothing "{668EF124F00F6B5B}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{48602F57998AB597}Prefabs/Items/Equipment/Backpacks/FILBE_Backpack.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124F00F6B58}" {
+    m_Role ASSISTANT_HEAVY_MACHINEGUN
+    m_Clothing {
+     CRF_Clothing "{668EF124F00F7EB1}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{48602F57998AB597}Prefabs/Items/Equipment/Backpacks/FILBE_Backpack.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124F00F7EB0}" {
+    m_Role ASSISTANT_MEDIUM_MACHINEGUN
+    m_Clothing {
+     CRF_Clothing "{668EF124F00F7EAF}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{48602F57998AB597}Prefabs/Items/Equipment/Backpacks/FILBE_Backpack.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124F00F7EAE}" {
+    m_Role ASSISTANT_ANTI_AIR
+    m_Clothing {
+     CRF_Clothing "{668EF124F00F7EAD}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{06B68C58B72EAAC6}Prefabs/Items/Equipment/Backpacks/Backpack_ALICE_Medium.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124F00F7EAB}" {
+    m_Role VEHICLE_DRIVER
+    m_Clothing {
+     CRF_Clothing "{668EF124F00F7EAA}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       ""
+      }
+     }
+     CRF_Clothing "{668EF124F00F7EA9}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{1D99585CF8E34D91}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01.et"
+       "{A4145024AE7084F6}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01_tucked.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124F00F7EA8}" {
+    m_Role VEHICLE_GUNNER
+    m_Clothing {
+     CRF_Clothing "{668EF124F00FDC1E}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       ""
+      }
+     }
+     CRF_Clothing "{668EF124F00FDC11}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{1D99585CF8E34D91}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01.et"
+       "{A4145024AE7084F6}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01_tucked.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124F00FDC16}" {
+    m_Role VEHICLE_LOADER
+    m_Clothing {
+     CRF_Clothing "{668EF124F00FF5C9}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       ""
+      }
+     }
+     CRF_Clothing "{668EF124F00FF5F6}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{1D99585CF8E34D91}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01.et"
+       "{A4145024AE7084F6}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01_tucked.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124F00FF5F7}" {
+    m_Role PILOT
+    m_Clothing {
+     CRF_Clothing "{668EF124F00C3BB7}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       ""
+      }
+     }
+     CRF_Clothing "{668EF124F00C3BB4}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{B137B7CE988557D2}Prefabs/Characters/Uniforms/Suit_Pilot_US_01/Suit_Pilot_US_01.et"
+      }
+     }
+     CRF_Clothing "{668EF124F00C3BB0}" {
+      m_iClothingType HEADGEAR
+      m_ClothingPrefabs {
+       "{483A80042765275F}Prefabs/Characters/HeadGear/Helmet_SPH4_01/Helmet_SPH4_01.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124F00C3BBE}" {
+    m_Role CREW_CHIEF
+    m_Clothing {
+     CRF_Clothing "{668EF124F00C3BBF}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       ""
+      }
+     }
+     CRF_Clothing "{668EF124F00C3B57}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{B137B7CE988557D2}Prefabs/Characters/Uniforms/Suit_Pilot_US_01/Suit_Pilot_US_01.et"
+      }
+     }
+     CRF_Clothing "{668EF124F00C3B54}" {
+      m_iClothingType HEADGEAR
+      m_ClothingPrefabs {
+       "{483A80042765275F}Prefabs/Characters/HeadGear/Helmet_SPH4_01/Helmet_SPH4_01.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124F00C3B55}" {
+    m_Role LOGI_RUNNER
+    m_Clothing {
+     CRF_Clothing "{668EF124F00C3B52}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{48602F57998AB597}Prefabs/Items/Equipment/Backpacks/FILBE_Backpack.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124F00C3B5E}" {
+    m_Role INDIRECT_GUNNER
+    m_Clothing {
+     CRF_Clothing "{668EF124F00C3B5F}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{EE53109CB37C43B1}Prefabs/Items/Equipment/Backpacks/M2/Backpack_m252_Mortar_Weapon.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124F00C3B5C}" {
+    m_Role INDIRECT_GUNNER
+    m_Clothing {
+     CRF_Clothing "{668EF124F00C3B5D}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{A207909C42E58944}Prefabs/Items/Equipment/Backpacks/Backpack_US_Tripod.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124F00C3B58}" {
+    m_Role RIFLEMAN_DEMO
+    m_AdditionalInventoryItems {
+     CRF_Inventory_Item "{668EF124F00C3B59}" {
+      m_sItemPrefab "{D9B1F65D20081DEF}PrefabsEditable/Explosives/E_DemoBlock_M112.et"
+      m_iItemCount 2
+     }
+     CRF_Inventory_Item "{668EF124F00C3B45}" {
+      m_sItemPrefab "{CE0AF733722B3978}Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_M34.et"
+      m_iItemCount 1
+     }
+     CRF_Inventory_Item "{668EF124F00C3B43}" {
+      m_sItemPrefab "{55641F140F92FDCD}Prefabs/Weapons/Explosives/Explosive_Satchels/BLUFOR_Satchel.et"
+      m_iItemCount 1
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF124F00C3B41}" {
+    m_Role COMBAT_ENGINEER
+    m_AdditionalInventoryItems {
+     CRF_Inventory_Item "{668EF124F00C3B4E}" {
+      m_sItemPrefab "{D9B1F65D20081DEF}PrefabsEditable/Explosives/E_DemoBlock_M112.et"
+      m_iItemCount 1
+     }
+     CRF_Inventory_Item "{668EF124F00C3B4F}" {
+      m_sItemPrefab "{CE0AF733722B3978}Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_M34.et"
+      m_iItemCount 1
+     }
+     CRF_Inventory_Item "{668EF124F00C3B4C}" {
+      m_sItemPrefab "{55641F140F92FDCD}Prefabs/Weapons/Explosives/Explosive_Satchels/BLUFOR_Satchel.et"
+      m_iItemCount 3
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{668EF1257D4F989C}" {
+    m_Role RIFLEMAN
+    m_sRoleName "Combat Life Saver"
+    m_AdditionalInventoryItems {
+     CRF_Inventory_Item "{668EF12556C3E598}" {
+      m_sItemPrefab "{A81F501D3EF6F38E}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_US_01.et"
+      m_iItemCount 10
+     }
+     CRF_Inventory_Item "{668EF125A0DE54D8}" {
+      m_sItemPrefab "{D70216B1B2889129}Prefabs/Items/Medicine/Tourniquet_01/Tourniquet_US_01.et"
+      m_iItemCount 3
+     }
+     CRF_Inventory_Item "{668EF125ABE9C6D3}" {
+      m_sItemPrefab "{00E36F41CA310E2A}Prefabs/Items/Medicine/SalineBag_01/SalineBag_US_01.et"
+      m_iItemCount 3
+     }
+    }
+   }
+  }
+ }
+}

--- a/Configs/Gearscripts/Custom/Harry/push/CRF_GS_RHSUSArmyMC_CLS.conf.meta
+++ b/Configs/Gearscripts/Custom/Harry/push/CRF_GS_RHSUSArmyMC_CLS.conf.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{CD3912ACF67CA7E5}Configs/Gearscripts/Standard/Modern/CRF_GS_RHSUSArmyMC_CLS.conf"
+ Configurations {
+  CONFResourceClass PC {
+  }
+  CONFResourceClass XBOX_ONE : PC {
+  }
+  CONFResourceClass XBOX_SERIES : PC {
+  }
+  CONFResourceClass PS4 : PC {
+  }
+  CONFResourceClass PS5 : PC {
+  }
+  CONFResourceClass HEADLESS : PC {
+  }
+  CONFResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Missions/Harry_Push109_Push.conf
+++ b/Missions/Harry_Push109_Push.conf
@@ -1,0 +1,14 @@
+SCR_MissionHeader {
+ World "{9C6899D4DEBEED5B}Worlds/COALobby/Rostov/Harry_TVT_Push.ent"
+ m_sName "CRF Push109 Start Pushing"
+ m_sAuthor "Harry"
+ m_sDescription "Blufor must escort their command truck through a tight AO"
+ m_sIcon "{B7385DA4504BD4D5}CRF Images/crflogo.edds"
+ m_sLoadingScreen "{B7385DA4504BD4D5}CRF Images/crflogo.edds"
+ m_sPreviewImage "{B7385DA4504BD4D5}CRF Images/crflogo.edds"
+ m_sGameMode "Push"
+ m_iPlayerCount 128
+ m_iStartingHours 12
+ m_iMapMarkerLimitPerPlayer 120
+ m_sTerrainName "Rostov"
+}

--- a/Missions/Harry_Push109_Push.conf.meta
+++ b/Missions/Harry_Push109_Push.conf.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{E50ED7805CEB40A0}Missions/Harry_Push109_Push.conf"
+ Configurations {
+  CONFResourceClass PC {
+  }
+  CONFResourceClass XBOX_ONE : PC {
+  }
+  CONFResourceClass XBOX_SERIES : PC {
+  }
+  CONFResourceClass PS4 : PC {
+  }
+  CONFResourceClass PS5 : PC {
+  }
+  CONFResourceClass HEADLESS : PC {
+  }
+  CONFResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M923A1/BLUFOR/BLUFOR_COMMAND_PUSH.et
+++ b/Prefabs/Vehicles/Wheeled/M923A1/BLUFOR/BLUFOR_COMMAND_PUSH.et
@@ -1,0 +1,84 @@
+Vehicle : "{9A0D72816DFFDB7F}Prefabs/Vehicles/Wheeled/M923A1/M923A1.et" {
+ ID "BBCBA43A9778AE21"
+ components {
+  SCR_VehicleSoundComponent "{55C2E66AD4EF2CA6}" {
+   SoundPoints {
+    SoundPointInfo MHQ_Deployment {
+     Offset 0 2.2181 -3.26
+    }
+   }
+  }
+  BaseRadioComponent "{51EAE034CD7B7A2C}" {
+   Transceivers {
+    RelayTransceiver "{668D6982E55D4C53}" {
+     "Transmitting Range" 2000
+    }
+   }
+  }
+  SCR_EditableVehicleComponent "{50DEB7C26B5EB312}" {
+   m_UIInfo SCR_EditableVehicleUIInfo "{5298E609432D192D}" {
+    Name "#AR-Vehicle_M934A1_Name"
+    Icon "{69691B5E759C0362}UI/Textures/Editor/EditableEntities/Vehicles/EditableEntity_Vehicle_Truck_Command.edds"
+    IconSetName ""
+    m_Image "{ADF5342179CB2029}UI/Textures/EditorPreviews/Vehicles/Wheeled/M923A1/M923A1_command.edds"
+    m_sFaction "BLUFOR"
+    m_aAuthoredLabels + {
+     35 280 210
+    }
+    m_aAutoLabels {
+     51870 122 54
+    }
+    m_EntityBudgetCost {
+     SCR_EntityBudgetValue "{5EDC86E4AF8908B6}" {
+      m_Value 420
+     }
+    }
+   }
+  }
+  SCR_UniversalInventoryStorageComponent "{5916C580F1DA28BB}" {
+   Attributes SCR_ItemAttributeCollection "{5916C580F04BA310}" {
+    CustomAttributes {
+     PreviewRenderAttributes "{5938C606F80AF9E2}" {
+      CameraOffset -1 -1.75 0
+     }
+    }
+   }
+   MaxCumulativeVolume 100000
+  }
+  SCR_VehicleFactionAffiliationComponent "{5882CBD9AC741CEC}" {
+   "faction affiliation" "BLUFOR"
+  }
+  SCR_WheeledDamageManagerComponent "{141326E9FD94FE40}" {
+   EnableDamage 0
+  }
+  SlotManagerComponent "{55BCE45E438E4CFF}" {
+   Slots {
+    RegisteringComponentSlotInfo Exhaust {
+     Prefab "{F6CC3B71325604A9}Prefabs/Vehicles/Wheeled/M923A1/VehParts/Exhaust/M923A1_exhaust_short.et"
+     RegisterDamage 1
+    }
+    RegisteringComponentSlotInfo Radio {
+     MergePhysics 1
+     Prefab "{DCE16D92C350D64F}Prefabs/Vehicles/Wheeled/M923A1/M923A1_combox.et"
+     RegisterActions 1
+     RegisterDamage 1
+     RegisterCompartments 1
+     RegisterLights 1
+    }
+    RegisteringComponentSlotInfo Arsenal {
+     Prefab "{8A239DEA19509B1B}Prefabs/Vehicles/Core/VirtualSlots/Radio_VirtualArsenalSlot.et"
+     DisablePhysicsInteraction 1
+    }
+   }
+  }
+  ActionsManagerComponent "{C97BE5489221AE18}" {
+   ActionContexts {
+    UserActionContext "{60D889C6E33B775B}" {
+     Radius 6
+    }
+   }
+  }
+ }
+ coords 64 0 64
+ m_eVehicleType COMM_TRUCK
+}

--- a/Prefabs/Vehicles/Wheeled/M923A1/BLUFOR/BLUFOR_COMMAND_PUSH.et.meta
+++ b/Prefabs/Vehicles/Wheeled/M923A1/BLUFOR/BLUFOR_COMMAND_PUSH.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{D9A9F7A9A004F124}Prefabs/Vehicles/Wheeled/M923A1/BLUFOR/BLUFOR_COMMAND_PUSH.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Worlds/COALobby/Rostov/Harry_TVT_Push.ent
+++ b/Worlds/COALobby/Rostov/Harry_TVT_Push.ent
@@ -1,0 +1,3 @@
+SubScene {
+ Parent "{FF61EACF0BDB760C}Worlds/Rostov.ent"
+}

--- a/Worlds/COALobby/Rostov/Harry_TVT_Push.ent.meta
+++ b/Worlds/COALobby/Rostov/Harry_TVT_Push.ent.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{9C6899D4DEBEED5B}Worlds/COALobby/Harry_TVT_Push.ent"
+ Configurations {
+  ENTResourceClass PC {
+  }
+  ENTResourceClass XBOX_ONE : PC {
+  }
+  ENTResourceClass XBOX_SERIES : PC {
+  }
+  ENTResourceClass PS4 : PC {
+  }
+  ENTResourceClass PS5 : PC {
+  }
+  ENTResourceClass HEADLESS : PC {
+  }
+  ENTResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Worlds/COALobby/Rostov/Harry_TVT_Push_Layers/aaInit.layer
+++ b/Worlds/COALobby/Rostov/Harry_TVT_Push_Layers/aaInit.layer
@@ -1,0 +1,127 @@
+SCR_MapEntity SCR_MapEntity1 {
+ coords 7172.633 252.745 2757.538
+ "Map Geometry Data" "{4D13DC42EAA6321E}Terrain/WCS_Rostov_Conflict_NEvSW_Layout1.topo"
+ "Satellite background image" "{4CDC017532F1D3F5}UI/Textures/Map/Worlds/Rostov/Rostov.edds"
+}
+SCR_AIWorld : "{998834C2F010C11A}Prefabs/AI/SCR_AIWorld_Rostov.et" {
+ coords 7204.129 493.678 2426.001
+}
+CRF_Gamemode CRF_Lobby1 : "{6A996BBFCEB37E78}Prefabs/MP/Modes/Lobby/CRF_Lobby.et" {
+ components {
+  CRF_HighValueTargetGamemodeManager "{668EF1218D251A20}" {
+   m_timeBetweenPings 300
+   m_filterFaction 1
+   m_hvtPrefab "{D9A9F7A9A004F124}Prefabs/Vehicles/Wheeled/M923A1/BLUFOR/BLUFOR_COMMAND_PUSH.et"
+  }
+ }
+ coords 7167.574 464.447 2485.062
+ m_iTimeLimitMinutes 40
+ m_aMissionDescriptors {
+  CRF_MissionDescriptor "{644250503DF684C0}" {
+   m_sTextData "This is a new gamemode, Push. Blufor must bring the command truck to the transmission tower, and then activate the radio there. Opfor will receive a respawn wave once the radio is activated, and Blufor must then defend the truck during the counterattack. The command truck can be penned but not destroyed."\
+   ""\
+   "BLUFOR Composition: Moto inf"\
+   "BLUFOR Assets: Vehicle Depot, weapons teams"\
+   ""\
+   "OPFOR Composition: Inf"\
+   "OPFOR Assets: MMG"\
+   ""\
+   "Time: 40"\
+   "Weather: Clear"
+  }
+  CRF_MissionDescriptor "{64425051F2E00216}" {
+   m_sTextData "Bring the command truck to the marked transmission tower, trigger the radio there, and then defend the truck during the counterattack."
+  }
+  CRF_MissionDescriptor "{64425051B9B5AF67}" {
+   m_sTextData "Prevent the command truck from being brought to the marked transmission tower, then counterattack once the radio has been triggered."
+  }
+ }
+ m_iFactionOneRatio 3
+ m_sFactionOneKey "BLU"
+ m_iFactionTwoRatio 2
+ m_sFactionTwoKey "OPF"
+ m_BLUFORGearScriptSettings CRF_GearScriptContainer "{64570ACB9B419A7B}" {
+  m_rGearScript "{CD3912ACF67CA7E5}Configs/Gearscripts/Custom/Harry/push/CRF_GS_RHSUSArmyMC_CLS.conf"
+ }
+ m_OPFORGearScriptSettings CRF_GearScriptContainer "{64570ACB9B11EAAD}" {
+  m_rGearScript "{35262EC7910CA8D8}Configs/Gearscripts/Custom/Harry/push/CRF_GS_RHSION_Urban_NoOptics_AP_CLS.conf"
+ }
+ m_INDFORGearScriptSettings CRF_GearScriptContainer "{64570ACB9AE1C9ED}" {
+ }
+ {
+  SCR_FactionManager {
+   ID "632A77473B3CC3A8"
+   Factions {
+    SCR_Faction "{628B22E9B4056C88}" {
+     m_CallsignInfo SCR_FactionCallsignInfo "{5DA0F2A6677ADA9E}" {
+      m_aSquadNames {
+       SCR_CallsignInfo "{55CCB792D10AD8F4}" {
+        m_sCallsign "COY"
+       }
+       SCR_CallsignInfo "{55CCB792D13759D8}" {
+        m_sCallsign "Medical"
+       }
+       SCR_CallsignInfo "{55CCB792D1218E95}" {
+        m_sCallsign "1PLT"
+       }
+       SCR_CallsignInfo "{55CCB792D0C8B3CE}" {
+        m_sCallsign "1-1"
+       }
+       SCR_CallsignInfo "{668F693CA12D4FEC}" {
+        m_sCallsign "1-2"
+       }
+       SCR_CallsignInfo "{668F693CA1D0AF14}" {
+        m_sCallsign "1-3"
+       }
+       SCR_CallsignInfo "{668F693CA073308F}" {
+        m_sCallsign "MMG-1"
+       }
+       SCR_CallsignInfo "{668F693CA095C8AE}" {
+        m_sCallsign "Humvee-1"
+       }
+       SCR_CallsignInfo "{668F693CA7061551}" {
+        m_sCallsign "2PLT"
+       }
+       SCR_CallsignInfo "{668F693CA65FF34C}" {
+        m_sCallsign "2-1"
+       }
+       SCR_CallsignInfo "{668F693CA6EFBD0D}" {
+        m_sCallsign "2-2"
+       }
+       SCR_CallsignInfo "{668F693CA50C8711}" {
+        m_sCallsign "2-3"
+       }
+       SCR_CallsignInfo "{668F693CA5F36521}" {
+        m_sCallsign "MMG-2"
+       }
+       SCR_CallsignInfo "{668F693CA41F2C68}" {
+        m_sCallsign "Humvee-2"
+       }
+      }
+     }
+    }
+    SCR_Faction "{628C2D2BFC8C6447}" {
+     m_CallsignInfo SCR_FactionCallsignInfo "{5DA0F2A67DFB8809}" {
+      m_aSquadNames {
+       SCR_CallsignInfo "{55CCB79287936EBD}" {
+        m_sCallsign "Medical"
+       }
+       SCR_CallsignInfo "{55CCB79287BAFBD6}" {
+        m_sCallsign "1-1"
+       }
+       SCR_CallsignInfo "{55CCB79287A4D7B6}" {
+        m_sCallsign "1-2"
+       }
+       SCR_CallsignInfo "{668F693C8C6FA82B}" {
+        m_sCallsign "1-3"
+       }
+       SCR_CallsignInfo "{668F693C924B9C5D}" {
+        m_sCallsign "MMG"
+       }
+      }
+     }
+    }
+   }
+  }
+ }
+}

--- a/Worlds/COALobby/Rostov/Harry_TVT_Push_Layers/blufor.layer
+++ b/Worlds/COALobby/Rostov/Harry_TVT_Push_Layers/blufor.layer
@@ -1,0 +1,180 @@
+Vehicle M997_maxi_ambulance1 : "{00C9BBE426F7D459}Prefabs/Vehicles/Wheeled/M998/M997_maxi_ambulance.et" {
+ coords 6365.322 181.16 3101.59
+ angleY 92.031
+}
+GenericEntity : "{02D89CB8A159DDF0}Prefabs/Systems/VehicleDepot/VehicleDepot_Cache.et" {
+ components {
+  CRF_VehicleDepot "{664C7C2465880153}" {
+   m_iSpawnPointCount 8
+   m_eSpawnPattern GRID
+   m_aVehicles {
+    CRF_VehicleDepotVehicle "{664C7C2458016B5B}" {
+     m_sVehicleName "Unarmed Humvee"
+     m_sVehiclePrefab "{4A71F755A4513227}Prefabs/Vehicles/Wheeled/M998/M1025.et"
+     m_iCost 25
+    }
+    CRF_VehicleDepotVehicle "{668D6981B3EBB347}" {
+     m_sVehicleName "Minigun Humvee"
+     m_sVehiclePrefab "{3696BFB0D5D19417}Prefabs/Vehicles/Wheeled/M998/M1025_armed_M134.et"
+     m_eCostType SUPPLIES
+     m_iCost 500
+    }
+    CRF_VehicleDepotVehicle "{668D69819E0AB648}" {
+     m_sVehicleName "M2 Humvee"
+     m_sVehiclePrefab "{3EA6F47D95867114}Prefabs/Vehicles/Wheeled/M998/M1025_armed_M2HB.et"
+     m_eCostType SUPPLIES
+     m_iCost 500
+    }
+    CRF_VehicleDepotVehicle "{668D6981F303F80A}" {
+     m_sVehicleName "M240 Humvee"
+     m_sVehiclePrefab "{8EA8FDD8A8625B2A}Prefabs/Vehicles/Wheeled/M998/M1025_armed_M240B.et"
+     m_eCostType SUPPLIES
+     m_iCost 300
+    }
+   }
+   m_bRestrictToLeadership 1
+  }
+ }
+ coords 6401.211 180.918 3044.071
+ angleY -1.058
+ {
+  GenericEntity {
+   ID "664C7C261783AF93"
+   coords -0.865 -0.049 -0.274
+   angleY 13.475
+   {
+    GenericEntity {
+     ID "5216C470CA8AD60B"
+     coords -0.05 -0.002 0.007
+     angleX -0.03
+     angleY 0.033
+     angleZ -0.085
+    }
+    GenericEntity {
+     ID "5216C470CA8AD618"
+     coords 0.004 0 -0.002
+     angleX -0.06
+     angleY 0.628
+     angleZ -0.044
+    }
+   }
+  }
+  GenericEntity {
+   ID "664C7C261783AF9D"
+   components {
+    SCR_ResourceComponent "{5D247A59598D71AE}" {
+     m_aContainers {
+      SCR_ResourceContainer "{5D3CDAE74F1A6127}" {
+       m_fResourceValueCurrent 1000
+       m_fResourceValueMax 1000
+      }
+     }
+    }
+   }
+   coords 0.418 0.036 -0.573
+   angleX 0.49
+   angleY -3.402
+   angleZ -1.34
+  }
+ }
+}
+SCR_AIGroup : "{EE91BF23FBC94408}Prefabs/Groups/BLUFOR/Standard/Command/CRF_BLUFOR_Company_p.et" {
+ coords 6388.279 182.375 3056.269
+ angleY 91.941
+ {
+  SCR_AIGroup : "{D0B17EDF43465305}Prefabs/Groups/BLUFOR/Standard/Support/CRF_BLUFOR_MedicTeam_p.et" {
+   coords -17.48 0.177 -1.237
+   angleY 87.287
+   {
+    SCR_AIGroup : "{3D4D53B053964445}Prefabs/Groups/BLUFOR/Standard/Command/CRF_BLUFOR_Platoon_p.et" {
+     coords -0.847 -0.03 10.844
+     angleY -81.316
+     {
+      $grp SCR_AIGroup : "{9C45BAF40F909576}Prefabs/Groups/BLUFOR/Standard/Infantry/CRF_BLUFOR_RifleSquad_p.et" {
+       {
+        coords 10.959 -1.226 22.593
+        angleY 81.316
+        m_aUnitPrefabSlots {
+         "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{6F99DE8453E6B423}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_Rifleman_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{690B6588C8F675A4}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AR_P.et" "{F8F683DD0F361239}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AAR_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et"
+        }
+       }
+       {
+        coords 8.322 -1.186 22.19
+        angleY 81.316
+        m_aUnitPrefabSlots {
+         "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{6F99DE8453E6B423}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_Rifleman_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{690B6588C8F675A4}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AR_P.et" "{F8F683DD0F361239}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AAR_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et"
+        }
+       }
+       {
+        coords 6.069 -1.131 21.846
+        angleY 81.316
+        m_aUnitPrefabSlots {
+         "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{6F99DE8453E6B423}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_Rifleman_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{690B6588C8F675A4}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AR_P.et" "{F8F683DD0F361239}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AAR_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et"
+        }
+        {
+         SCR_AIGroup : "{2F07AC5EE3DE3921}Prefabs/Groups/BLUFOR/Standard/Support/CRF_BLUFOR_MMGTeam_p.et" {
+          coords -21.78 1.108 7.019
+          m_aUnitPrefabSlots {
+           "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{232780260F9004E6}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_MMG_P.et" "{0CF6A9358BCE5E57}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AMMG_P.et" "{0B9A19205D71AD61}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_MAT_P.et" "{244B3033D92FF7D0}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AMAT_P.et"
+          }
+          {
+           SCR_AIGroup : "{679BC3454FEDD0EE}Prefabs/Groups/BLUFOR/Standard/Vehicle/CRF_BLUFOR_2manCrew_p.et" {
+            coords 43.573 -0.259 -0.713
+            angleY -83.807
+            {
+             SCR_AIGroup : "{3D4D53B053964445}Prefabs/Groups/BLUFOR/Standard/Command/CRF_BLUFOR_Platoon_p.et" {
+              coords -21.632 0.409 -1.325
+              angleY 2.491
+              {
+               $grp SCR_AIGroup : "{9C45BAF40F909576}Prefabs/Groups/BLUFOR/Standard/Infantry/CRF_BLUFOR_RifleSquad_p.et" {
+                {
+                 coords 6.157 -1.129 21.959
+                 angleY 81.316
+                 m_aUnitPrefabSlots {
+                  "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{6F99DE8453E6B423}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_Rifleman_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{690B6588C8F675A4}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AR_P.et" "{F8F683DD0F361239}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AAR_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et"
+                 }
+                }
+                {
+                 coords 3.214 -1.067 21.51
+                 angleY 81.316
+                 m_aUnitPrefabSlots {
+                  "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{6F99DE8453E6B423}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_Rifleman_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{690B6588C8F675A4}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AR_P.et" "{F8F683DD0F361239}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AAR_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et"
+                 }
+                }
+                {
+                 coords 0.46 -1.032 21.089
+                 angleY 81.316
+                 m_aUnitPrefabSlots {
+                  "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{6F99DE8453E6B423}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_Rifleman_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{690B6588C8F675A4}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AR_P.et" "{F8F683DD0F361239}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AAR_P.et" "{1E08ED0385C765CC}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_TL_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et" "{D4DB370FB7ED69BA}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AT_P.et"
+                 }
+                 {
+                  SCR_AIGroup : "{2F07AC5EE3DE3921}Prefabs/Groups/BLUFOR/Standard/Support/CRF_BLUFOR_MMGTeam_p.et" {
+                   coords -21.847 0.928 7.975
+                   m_aUnitPrefabSlots {
+                    "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{232780260F9004E6}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_MMG_P.et" "{0CF6A9358BCE5E57}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AMMG_P.et" "{0B9A19205D71AD61}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_MAT_P.et" "{244B3033D92FF7D0}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AMAT_P.et"
+                   }
+                   {
+                    SCR_AIGroup : "{679BC3454FEDD0EE}Prefabs/Groups/BLUFOR/Standard/Vehicle/CRF_BLUFOR_2manCrew_p.et" {
+                     coords 39.508 -2.02 5.139
+                     angleY -83.807
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+          }
+         }
+        }
+       }
+      }
+     }
+    }
+   }
+  }
+ }
+}

--- a/Worlds/COALobby/Rostov/Harry_TVT_Push_Layers/markers.layer
+++ b/Worlds/COALobby/Rostov/Harry_TVT_Push_Layers/markers.layer
@@ -1,0 +1,7 @@
+CRF_ManualMarker : "{7B677FB61E410D0D}PrefabsEditable/Markers/ObjectiveMarker.et" {
+ coords 7216.821 180.585 2745.672
+ m_MarkerColor 0 0 0 1
+ m_sDescription "Transmission Tower"
+ m_bVisibleForEmptyFaction 1
+ m_bShowForAnyFaction 1
+}

--- a/Worlds/COALobby/Rostov/Harry_TVT_Push_Layers/obj.layer
+++ b/Worlds/COALobby/Rostov/Harry_TVT_Push_Layers/obj.layer
@@ -1,0 +1,17 @@
+SCR_BaseTriggerEntity transponder {
+ coords 6446.001 183.693 3082.391
+ angleY 0.938
+}
+GenericEntity : "{A9CF5E8C5D91C476}Prefabs/Compositions/Misc/SubCompositions/Decorations/Barrel_Group_Crate_01.et" {
+ coords 7223.143 180.551 2747.36
+}
+GenericEntity : "{D4375F10B6F2BE81}Prefabs/MP/Campaign/Assets/Radio_Interactable.et" {
+ components {
+  CRF_RadioPhaseManager "{6605652AC71F4A2E}" {
+   requireHVT 1
+   respawnOpfor 1
+  }
+ }
+ coords 7223.222 181.483 2746.939
+ angleY 169.539
+}

--- a/Worlds/COALobby/Rostov/Harry_TVT_Push_Layers/opfor.layer
+++ b/Worlds/COALobby/Rostov/Harry_TVT_Push_Layers/opfor.layer
@@ -1,0 +1,50 @@
+GenericEntity : "{0B3312C6940005B9}Prefabs/Structures/FlagPoles/RespawnPoles/OPFOR_Respawn.et" {
+ coords 6466.729 162.311 2080.733
+}
+$grp Vehicle : "{43C4AF1EEBD001CE}Prefabs/Vehicles/Wheeled/UAZ452/UAZ452_ambulance.et" {
+ UAZ452_ambulance2 {
+  coords 6491.761 162.751 2076.297
+  angleY 88.345
+ }
+ UAZ452_ambulance1 {
+  coords 7151.473 180.994 2788.67
+  angleY -92.987
+ }
+}
+SCR_AIGroup : "{6524B6A6C69BD3EE}Prefabs/Groups/OPFOR/Standard/Command/CRF_OPFOR_Platoon_p.et" {
+ coords 7147.993 180.793 2776.244
+ {
+  SCR_AIGroup : "{24DA56B34E727840}Prefabs/Groups/OPFOR/Standard/Support/CRF_OPFOR_MedicTeam_p.et" {
+   coords -1.784 0.146 4.751
+   {
+    SCR_AIGroup : "{92F50F60726EB86D}Prefabs/Groups/OPFOR/Standard/Infantry/CRF_OPFOR_RifleSquad_p.et" {
+     coords -0.864 -0.349 -6.784
+     m_aUnitPrefabSlots {
+      "{9CB623C7B62F4955}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_SL_P.et" "{C1E0691A952831E7}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AAT_P.et" "{4E3013C12F58ED57}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_TL_P.et" "{39339B4A6269FD3F}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AR_P.et" "{7C303B9DEA332DF9}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AAR_P.et" "{4E3013C12F58ED57}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_TL_P.et" "{84E3C9CD1D72E121}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AT_P.et" "{FC0904D71EF8DB6A}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_Rifleman_P.et"
+     }
+     {
+      SCR_AIGroup : "{92F50F60726EB86D}Prefabs/Groups/OPFOR/Standard/Infantry/CRF_OPFOR_RifleSquad_p.et" {
+       coords 0 0 -4.287
+       m_aUnitPrefabSlots {
+        "{9CB623C7B62F4955}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_SL_P.et" "{C1E0691A952831E7}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AAT_P.et" "{4E3013C12F58ED57}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_TL_P.et" "{39339B4A6269FD3F}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AR_P.et" "{7C303B9DEA332DF9}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AAR_P.et" "{4E3013C12F58ED57}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_TL_P.et" "{84E3C9CD1D72E121}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AT_P.et" "{FC0904D71EF8DB6A}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_Rifleman_P.et"
+       }
+       {
+        SCR_AIGroup : "{92F50F60726EB86D}Prefabs/Groups/OPFOR/Standard/Infantry/CRF_OPFOR_RifleSquad_p.et" {
+         coords 0 0 -4.177
+         m_aUnitPrefabSlots {
+          "{9CB623C7B62F4955}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_SL_P.et" "{C1E0691A952831E7}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AAT_P.et" "{4E3013C12F58ED57}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_TL_P.et" "{39339B4A6269FD3F}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AR_P.et" "{7C303B9DEA332DF9}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AAR_P.et" "{4E3013C12F58ED57}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_TL_P.et" "{84E3C9CD1D72E121}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AT_P.et" "{FC0904D71EF8DB6A}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_Rifleman_P.et"
+         }
+         {
+          SCR_AIGroup : "{E323E3D2E4952AF5}Prefabs/Groups/OPFOR/Standard/Support/CRF_OPFOR_MMGTeam_p.et" {
+           coords 0.634 -1.035 -3.768
+          }
+         }
+        }
+       }
+      }
+     }
+    }
+   }
+  }
+ }
+}

--- a/Worlds/COALobby/Rostov/Harry_TVT_Push_Layers/polyzones.layer
+++ b/Worlds/COALobby/Rostov/Harry_TVT_Push_Layers/polyzones.layer
@@ -1,0 +1,62 @@
+CRF_ManualMarker : "{10F92A3FD09DA1C5}PrefabsEditable/Markers/OPFORSpawnMarker.et" {
+ coords 6462.615 162.358 2081.809
+ angleY 0
+ m_sDescription "OPFOR Repawn"
+}
+PolylineShapeEntity : "{318DDE6633C34CF1}PrefabsEditable/PolyZone/GameBoundry.et" {
+ coords 6866.481 179.402 2765.728
+ Points {
+  ShapePoint "{6690014F426CFF18}" {
+   Position -490.177 -18.672 -836.424
+  }
+  ShapePoint "{6690014F46DA0733}" {
+   Position -504.833 5 449.863
+  }
+  ShapePoint "{6690014F448A24B5}" {
+   Position 541.88 13.178 427.038
+  }
+  ShapePoint "{6690014F4BCCC3F7}" {
+   Position 608.022 -8.915 -589.012
+  }
+ }
+}
+PolylineShapeEntity : "{8AE1D02BC25C93C5}PrefabsEditable/PolyZone/BLUFORSafestartBoundry.et" {
+ coords 6392.11 181.357 3086.246
+ Points {
+  ShapePoint "{6690014F579C3585}" {
+   Position -78.666 -3.247 -71.82
+  }
+  ShapePoint "{6690014F56157C88}" {
+   Position -66.353 -0.8 23.696
+  }
+  ShapePoint "{6690014F56C35EA1}" {
+   Position 64.456 3.13 18.237
+  }
+  ShapePoint "{6690014F55914D22}" {
+   Position 63.411 2.465 -55.735
+  }
+ }
+}
+PolylineShapeEntity : "{D8E7812AC12E29EB}PrefabsEditable/PolyZone/OPFORSafestartBoundry.et" {
+ coords 7096.294 181.468 2794.08
+ Points {
+  ShapePoint "{6690014F5FD4D7E7}" {
+   Position 138.263 0.197 25.441
+  }
+  ShapePoint "{6690014F5E1760B2}" {
+   Position 44.945 0 27.286
+  }
+  ShapePoint "{6690014F5E4FBF8A}" {
+   Position 38.915 -3.082 -42.785
+  }
+  ShapePoint "{6690014F5E8B06C5}" {
+   Position 73.93 -1.192 -106.516
+  }
+  ShapePoint "{6690014F5D3AF685}" {
+   Position 152.024 -0.786 -81.374
+  }
+  ShapePoint "{6690014F5DF4A6CF}" {
+   Position 173.069 -0.487 -10.655
+  }
+ }
+}

--- a/scripts/Game/GameMode/Radio Phase/CRF_Radio_Interact.c
+++ b/scripts/Game/GameMode/Radio Phase/CRF_Radio_Interact.c
@@ -3,6 +3,11 @@ class CRF_Radio_Interact : ScriptedUserAction
 {	
 	SCR_FactionManager factionManager;
 	CRF_RadioPhaseManager rp;
+	CRF_HighValueTargetGamemodeManager hvtm;
+	IEntity radio;
+	vector radioPos;
+	IEntity hvt;
+	vector hvtPos;
 	
 	bool m_fired = false;
 	
@@ -13,6 +18,8 @@ class CRF_Radio_Interact : ScriptedUserAction
 		
 		factionManager = SCR_FactionManager.Cast(GetGame().GetFactionManager());
 		rp = CRF_RadioPhaseManager.Cast(pOwnerEntity.FindComponent(CRF_RadioPhaseManager));
+		radio = pOwnerEntity;
+		
 	}
 	
 	//------------------------------------------------------------------------------------------------
@@ -45,6 +52,21 @@ class CRF_Radio_Interact : ScriptedUserAction
 		
 		if (m_fired)
 			return false;
+		
+		if (rp.requireHVT)
+		{
+			hvtm = CRF_HighValueTargetGamemodeManager.Cast(CRF_Gamemode.GetInstance().FindComponent(CRF_HighValueTargetGamemodeManager));
+			hvt = hvtm.m_eHvtEntity;
+			hvtPos = hvt.GetOrigin();
+			radioPos = radio.GetOrigin();
+			float distance = vector.Distance(hvtPos, radioPos);
+			
+			if (distance <50)
+				return true;
+			else 
+				return false;
+		}
+		
 		
 		// else true
 		return true;

--- a/scripts/Game/GameMode/Radio Phase/CRF_Radio_Phase.c
+++ b/scripts/Game/GameMode/Radio Phase/CRF_Radio_Phase.c
@@ -9,6 +9,9 @@ class CRF_RadioPhaseManager: ScriptComponent
 	[Attribute("BLUFOR", "auto", "The side what interacts")]
 	FactionKey interactingSide;
 	
+	[Attribute("false", "auto", "Checks if you need an HVT for the Push gamemode")]
+	bool requireHVT;
+	
 	[Attribute("false", "auto", "The object with the script")]
 	bool respawnBlufor;
 	


### PR DESCRIPTION
Mission Pull Request Template

This Pull Request will:

Add the mission Start Pushing made by Harry to the repository.

**Mission Creation Checklist:**
- [x] Mission File
- [x] Gearscripts Tested
- [x] Ingame Play Area Markers
- [x] Ingame Briefings to all players
- [x] Side-based briefings  
- [x] Mission .conf file


**Faction(s):**

BLUFOR - US Modern Attacking
BLUFOR Comp: Moto Inf
BLUFOR Assets: Vehicle depot, weapons teams

OPFOR - ION modern defending
OPFOR Comp: Inf
OPFOR Assets: MMG


**Objectives/Win Conditions:**

Blufor must bring the command truck to the transmission tower, then interact with the radio there, and defend the truck. Opfor will receive a respawn wave at that time, and then must attack Blufor.

**Terrain:**
Rostov

**Short mission description:**

This is a new gamemode, Push. Blufor must bring the command truck to the transmission tower, and then activate the radio there. Opfor will receive a respawn wave once the radio is activated, and Blufor must then defend the truck during the counterattack. The command truck can be penned but not destroyed.

**Slotting Ratio:**

2:1

**Time limit:**
40 min

**Mission Briefing Screenshot:**

<img width="942" height="714" alt="image" src="https://github.com/user-attachments/assets/fb2a3717-3583-42d4-bfc7-dce1fbb4e37a" />

**Design concept/thoughts:**

Tanaka pitched a new escort style mission for a vehicle. It's the push game mode from something like OW, but made for reforger. The command truck can't be destroyed, but can be penned.

**Other Notes:**

Updated the radio action to accept requiring an HVT nearby. So this uses the existing radio phase object, and the hvt gamemode together.
