### PR TITLE
Push Hot Fix

### DIFF
--- a/Configs/Gearscripts/Custom/Harry/push/CRF_GS_RHSION_Urban_NoOptics_AP_CLS.conf
+++ b/Configs/Gearscripts/Custom/Harry/push/CRF_GS_RHSION_Urban_NoOptics_AP_CLS.conf
@@ -5,7 +5,7 @@ CRF_GearScriptConfig {
  m_FactionWeapons CRF_Weapons "{668EF124C56E6B8B}" {
   m_Rifle {
    CRF_Weapon_Class "{668EF124C56E6BB2}" {
-    m_Weapon "{3BC80AAE900EC0B7}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_Suppressed.et"
+    m_Weapon "{442D3A4317CE6D7D}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_plain.et"
     m_Attachments {
      "{3D4B54552E600505}Prefabs/Weapons/Attachments/Optics/Collimators/Optic_EotechEXPS3/Collim_EXPS3_BLK.et"
     }
@@ -19,7 +19,7 @@ CRF_GearScriptConfig {
   }
   m_RifleUGL {
    CRF_Weapon_Class "{668EF124C56E6BA5}" {
-    m_Weapon "{3BC80AAE900EC0B8}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_Suppressed.et"
+    m_Weapon "{442D3A4317CE6D7D}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_plain.et"
     m_Attachments {
      "{DBE8F7374A320BDF}Prefabs/Weapons/Attachments/Optics/Collimators/Optic_EotechEXPS3/Collim_EXPS3_base.et"
      "{43FDAF3FA0FF2299}Prefabs/Weapons/Attachments/Underbarrel/UGL_M203_long.et"

--- a/Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_plain.et
+++ b/Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_plain.et
@@ -1,0 +1,43 @@
+GenericEntity : "{EC0B2A922E4AD1AB}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_Base.et" {
+ ID "CFBAA4B725411E45"
+ components {
+  MeshObject "{CFBAA4B701F95D69}" {
+   Materials {
+    MaterialAssignClass "{669575698D78D608}" {
+     SourceMaterial "SCARH_buttstock"
+     AssignedMaterial "{0A862D187FBF611D}Assets/Weapons/Rifles/SCAR/Data/BLK/SCARH_buttstock_BLK.emat"
+    }
+    MaterialAssignClass "{669575698D78D635}" {
+     SourceMaterial "SCARH_receiver"
+     AssignedMaterial "{B64D4EFF19307B53}Assets/Weapons/Rifles/SCAR/Data/BLK/SCARH_receiver_BLK.emat"
+    }
+    MaterialAssignClass "{669575698D78D638}" {
+     SourceMaterial "pistol_grip_A2"
+     AssignedMaterial "{1323E022549572CF}Assets/Weapons/Rifles/SCAR/Data/BLK/pistol_grip_A2_BLK.emat"
+    }
+   }
+  }
+  SCR_WeaponAttachmentsStorageComponent "{51F080D5CE45A1A2}" {
+   Attributes SCR_ItemAttributeCollection "{51F080D5C64F12C5}" {
+    ItemDisplayName SCR_InventoryUIInfo "{5222CB07CFF6712A}" {
+     Name "#WCS-Weapon_SCARH_Name - #WCS-Camo_Black"
+    }
+   }
+  }
+  WeaponComponent "{CFBAA4B706BA66E8}" {
+   components {
+    MuzzleComponent "{CA6BE4D6B867541F}" {
+     components {
+      AttachmentSlotComponent "{626E2147F1287008}" {
+       AttachmentSlot InventoryStorageSlot "{626E2147FFDB258A}" {
+       }
+      }
+     }
+    }
+   }
+   UIInfo WeaponUIInfo "{CC3BA6A2C42F09F4}" {
+    Name "#WCS-Weapon_SCARH_Name #WCS-Camo_Black"
+   }
+  }
+ }
+}

--- a/Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_plain.et.meta
+++ b/Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_plain.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{442D3A4317CE6D7D}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_plain.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}


### PR DESCRIPTION
Changes the ion weapon prefab to not have attachments before application. There are other weapons with attachments in the script, but don't have attachments trying to be applied to them. Unsure if this'll work, probably want to test. 