### PR TITLE
Fixing M203 attachment problem, update SCARH standard gearscripts

### DIFF
--- a/Configs/Gearscripts/Custom/Harry/push/CRF_GS_RHSION_Urban_NoOptics_AP_CLS.conf
+++ b/Configs/Gearscripts/Custom/Harry/push/CRF_GS_RHSION_Urban_NoOptics_AP_CLS.conf
@@ -8,6 +8,7 @@ CRF_GearScriptConfig {
     m_Weapon "{442D3A4317CE6D7D}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_plain.et"
     m_Attachments {
      "{3D4B54552E600505}Prefabs/Weapons/Attachments/Optics/Collimators/Optic_EotechEXPS3/Collim_EXPS3_BLK.et"
+     "{B2B3DB66A987648F}Prefabs/Weapons/Attachments/Foregrips/Magpul_RVG/Magpul_RVG_SCARH_BLK.et"
     }
     m_MagazineArray {
      CRF_Magazine_Class "{668EF124C56E6BB3}" {
@@ -19,10 +20,9 @@ CRF_GearScriptConfig {
   }
   m_RifleUGL {
    CRF_Weapon_Class "{668EF124C56E6BA5}" {
-    m_Weapon "{442D3A4317CE6D7D}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_plain.et"
+    m_Weapon "{2A390E6E55F3F11D}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_M203_plain.et"
     m_Attachments {
      "{DBE8F7374A320BDF}Prefabs/Weapons/Attachments/Optics/Collimators/Optic_EotechEXPS3/Collim_EXPS3_base.et"
-     "{43FDAF3FA0FF2299}Prefabs/Weapons/Attachments/Underbarrel/UGL_M203_long.et"
     }
     m_MagazineArray {
      CRF_Magazine_Class "{668EF124C56E6BA2}" {
@@ -55,9 +55,6 @@ CRF_GearScriptConfig {
   m_Carbine {
    CRF_Weapon_Class "{668EF124C56E6B5D}" {
     m_Weapon "{20DDB7ABE9F2FC00}Prefabs/Weapons/Rifles/MPX/Rifle_MPX_MOD1.et"
-    m_Attachments {
-     ""
-    }
     m_MagazineArray {
      CRF_Magazine_Class "{668EF124C56E6B5A}" {
       m_Magazine "{49A107C35547BC4B}Prefabs/Weapons/Magazines/9x19_MPX_41rnd/Magazine_9x19_MPX_41rnd_4Ball_1Tracer_M1152_M1156.et"
@@ -165,6 +162,26 @@ CRF_GearScriptConfig {
    CRF_Inventory_Item "{668EF124C56E6B2E}" {
     m_sItemPrefab "{D41D22DD1B8E921E}Prefabs/Weapons/Grenades/M18/Smoke_M18_Green.et"
     m_iItemCount 1
+   }
+   CRF_Inventory_Item "{669AF2B3AFF4461C}" {
+    m_sItemPrefab "{58CF3AB87C441295}Prefabs/Items/Medicine/AmmoniumCarbonatePackage/ACE_Medical_AmmoniumCarbonatePackage.et"
+    m_iItemCount 10
+   }
+   CRF_Inventory_Item "{669AF2B3B974772E}" {
+    m_sItemPrefab "{02DD34077F51F65E}Prefabs/Items/Medicine/NaloxoneInjection/ACE_Medical_NaloxoneInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{669AF2B38E85D8E7}" {
+    m_sItemPrefab "{9BBA766CD869002C}Prefabs/Items/Medicine/PhenylephrineInjection/ACE_Medical_PhenylephrineInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{669AF2B39B8D2131}" {
+    m_sItemPrefab "{D0434D5215B54181}Prefabs/Items/Medicine/MetoprololInjection/ACE_Medical_MetoprololInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{669AF2B3E8A14E2C}" {
+    m_sItemPrefab "{9DB69176CEF0EE97}Prefabs/Weapons/Grenades/Smoke_ANM8HC.et"
+    m_iItemCount 2
    }
   }
   m_DefaultClothing {

--- a/Configs/Gearscripts/Standard/Modern/Variants/CRF_GS_RHSION_SCARs.conf
+++ b/Configs/Gearscripts/Standard/Modern/Variants/CRF_GS_RHSION_SCARs.conf
@@ -5,13 +5,14 @@ CRF_GearScriptConfig {
  m_FactionWeapons CRF_Weapons "{6442772EE4056D8E}" {
   m_Rifle {
    CRF_Weapon_Class "{6442772EE4056DF0}" {
-    m_Weapon "{35B39B1F8883291C}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_CQC_FDE.et"
+    m_Weapon "{6325E78EE0925A4A}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_FDE_plain.et"
     m_Attachments {
      "{5B6DD3BEAD512002}Prefabs/Weapons/Attachments/Foregrips/Magpul_RVG/Magpul_RVG_SCARL_FDE.et"
+     "{B8BE3D139591CA3D}Prefabs/Weapons/Attachments/Optics/exps/Optic_EXPS3-2_tan.et"
     }
     m_MagazineArray {
      CRF_Magazine_Class "{6442772EE4056DF7}" {
-      m_Magazine "{B175D02EA717E36B}Prefabs/Weapons/Magazines/Magazine_762x51_SCARH_20rnd_M80A1_FDE.et"
+      m_Magazine "{C27B62CD736C267A}Prefabs/Weapons/Magazines/762x51_SCARH_FDE_20rnd/Magazine_762x51_SCARH_FDE_20rnd_4Ball_1Tracer_M80A1_M62.et"
       m_MagazineCount 12
      }
     }
@@ -19,13 +20,13 @@ CRF_GearScriptConfig {
   }
   m_RifleUGL {
    CRF_Weapon_Class "{6442772EE4056DF8}" {
-    m_Weapon "{FDBFE789CC58D64E}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_FDE_M203.et"
+    m_Weapon "{99091B7E143DFF06}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_FDE_M203_plain.et"
     m_Attachments {
      "{B8BE3D139591CA3D}Prefabs/Weapons/Attachments/Optics/exps/Optic_EXPS3-2_tan.et"
     }
     m_MagazineArray {
      CRF_Magazine_Class "{6442772EE4056DFF}" {
-      m_Magazine "{B175D02EA717E36B}Prefabs/Weapons/Magazines/Magazine_762x51_SCARH_20rnd_M80A1_FDE.et"
+      m_Magazine "{C27B62CD736C267A}Prefabs/Weapons/Magazines/762x51_SCARH_FDE_20rnd/Magazine_762x51_SCARH_FDE_20rnd_4Ball_1Tracer_M80A1_M62.et"
       m_MagazineCount 12
      }
      CRF_Magazine_Class "{6442772EE4056DFE}" {
@@ -53,13 +54,13 @@ CRF_GearScriptConfig {
   }
   m_Carbine {
    CRF_Weapon_Class "{6442772EE4056DE9}" {
-    m_Weapon "{35B39B1F8883291C}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_CQC_FDE.et"
+    m_Weapon "{6325E78EE0925A4A}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_FDE_plain.et"
     m_Attachments {
      "{5B6DD3BEAD512002}Prefabs/Weapons/Attachments/Foregrips/Magpul_RVG/Magpul_RVG_SCARL_FDE.et"
     }
     m_MagazineArray {
      CRF_Magazine_Class "{6442772EE4056DE8}" {
-      m_Magazine "{B175D02EA717E36B}Prefabs/Weapons/Magazines/Magazine_762x51_SCARH_20rnd_M80A1_FDE.et"
+      m_Magazine "{C27B62CD736C267A}Prefabs/Weapons/Magazines/762x51_SCARH_FDE_20rnd/Magazine_762x51_SCARH_FDE_20rnd_4Ball_1Tracer_M80A1_M62.et"
       m_MagazineCount 10
      }
     }
@@ -164,6 +165,26 @@ CRF_GearScriptConfig {
    CRF_Inventory_Item "{6442772EE4057219}" {
     m_sItemPrefab "{D41D22DD1B8E921E}Prefabs/Weapons/Grenades/M18/Smoke_M18_Green.et"
     m_iItemCount 1
+   }
+   CRF_Inventory_Item "{669AF2B3B2E4D168}" {
+    m_sItemPrefab "{58CF3AB87C441295}Prefabs/Items/Medicine/AmmoniumCarbonatePackage/ACE_Medical_AmmoniumCarbonatePackage.et"
+    m_iItemCount 10
+   }
+   CRF_Inventory_Item "{669AF2B3B73276B3}" {
+    m_sItemPrefab "{02DD34077F51F65E}Prefabs/Items/Medicine/NaloxoneInjection/ACE_Medical_NaloxoneInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{669AF2B3BBC2C586}" {
+    m_sItemPrefab "{9BBA766CD869002C}Prefabs/Items/Medicine/PhenylephrineInjection/ACE_Medical_PhenylephrineInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{669AF2B390746640}" {
+    m_sItemPrefab "{D0434D5215B54181}Prefabs/Items/Medicine/MetoprololInjection/ACE_Medical_MetoprololInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{669AF2B3EDD74CC5}" {
+    m_sItemPrefab "{9DB69176CEF0EE97}Prefabs/Weapons/Grenades/Smoke_ANM8HC.et"
+    m_iItemCount 2
    }
   }
   m_DefaultClothing {

--- a/Configs/Gearscripts/Standard/Modern/Variants/CRF_GS_RHSION_Urban.conf
+++ b/Configs/Gearscripts/Standard/Modern/Variants/CRF_GS_RHSION_Urban.conf
@@ -5,13 +5,14 @@ CRF_GearScriptConfig {
  m_FactionWeapons CRF_Weapons "{64F8230DD9E7CE5E}" {
   m_Rifle {
    CRF_Weapon_Class "{64F8230DD9E7CE59}" {
-    m_Weapon "{3BC80AAE900EC0B7}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_Suppressed.et"
+    m_Weapon "{442D3A4317CE6D7D}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_plain.et"
     m_Attachments {
-     "{3158264E43B14C07}Prefabs/Weapons/Attachments/Optics/Collimators/Optic_EotechEXPS3/Collim_EXPS3_G33_BLK.et"
+     "{3D4B54552E600505}Prefabs/Weapons/Attachments/Optics/Collimators/Optic_EotechEXPS3/Collim_EXPS3_BLK.et"
+     "{B2B3DB66A987648F}Prefabs/Weapons/Attachments/Foregrips/Magpul_RVG/Magpul_RVG_SCARH_BLK.et"
     }
     m_MagazineArray {
      CRF_Magazine_Class "{64F8230DD9E7CE58}" {
-      m_Magazine "{A36FC079DFAC2B55}Prefabs/Weapons/Magazines/Magazine_762x51_SCARH_20rnd_M80A1_BLK.et"
+      m_Magazine "{77AAEEB1D221D79A}Prefabs/Weapons/Magazines/762x51_SCARH_20rnd/Magazine_762x51_SCARH_20rnd_4Ball_1Tracer_M80A1_M62.et"
       m_MagazineCount 14
      }
     }
@@ -19,14 +20,13 @@ CRF_GearScriptConfig {
   }
   m_RifleUGL {
    CRF_Weapon_Class "{64F8230DD9E7CE54}" {
-    m_Weapon "{3BC80AAE900EC0B8}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_Suppressed.et"
+    m_Weapon "{2A390E6E55F3F11D}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_M203_plain.et"
     m_Attachments {
-     "{3158264E43B14C07}Prefabs/Weapons/Attachments/Optics/Collimators/Optic_EotechEXPS3/Collim_EXPS3_G33_BLK.et"
-     "{43FDAF3FA0FF2299}Prefabs/Weapons/Attachments/Underbarrel/UGL_M203_long.et"
+     "{3D4B54552E600505}Prefabs/Weapons/Attachments/Optics/Collimators/Optic_EotechEXPS3/Collim_EXPS3_BLK.et"
     }
     m_MagazineArray {
      CRF_Magazine_Class "{64F8230DD9E7CE53}" {
-      m_Magazine "{A36FC079DFAC2B55}Prefabs/Weapons/Magazines/Magazine_762x51_SCARH_20rnd_M80A1_BLK.et"
+      m_Magazine "{77AAEEB1D221D79A}Prefabs/Weapons/Magazines/762x51_SCARH_20rnd/Magazine_762x51_SCARH_20rnd_4Ball_1Tracer_M80A1_M62.et"
       m_MagazineCount 14
      }
      CRF_Magazine_Class "{64F8230DD9E7CE52}" {
@@ -55,9 +55,6 @@ CRF_GearScriptConfig {
   m_Carbine {
    CRF_Weapon_Class "{64F8230DD9E7CE47}" {
     m_Weapon "{20DDB7ABE9F2FC00}Prefabs/Weapons/Rifles/MPX/Rifle_MPX_MOD1.et"
-    m_Attachments {
-     ""
-    }
     m_MagazineArray {
      CRF_Magazine_Class "{64F8230DD9E7EEF3}" {
       m_Magazine "{35C35DD311E92C06}Prefabs/Weapons/Magazines/Magazine_9x19_MPX_41rnd_Ball.et"
@@ -165,6 +162,26 @@ CRF_GearScriptConfig {
    CRF_Inventory_Item "{64F8230DD9E7EF3E}" {
     m_sItemPrefab "{D41D22DD1B8E921E}Prefabs/Weapons/Grenades/M18/Smoke_M18_Green.et"
     m_iItemCount 1
+   }
+   CRF_Inventory_Item "{669AF2B353BC3957}" {
+    m_sItemPrefab "{58CF3AB87C441295}Prefabs/Items/Medicine/AmmoniumCarbonatePackage/ACE_Medical_AmmoniumCarbonatePackage.et"
+    m_iItemCount 10
+   }
+   CRF_Inventory_Item "{669AF2B3AA458B28}" {
+    m_sItemPrefab "{02DD34077F51F65E}Prefabs/Items/Medicine/NaloxoneInjection/ACE_Medical_NaloxoneInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{669AF2B3869C8EA3}" {
+    m_sItemPrefab "{9BBA766CD869002C}Prefabs/Items/Medicine/PhenylephrineInjection/ACE_Medical_PhenylephrineInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{669AF2B3E30A816E}" {
+    m_sItemPrefab "{D0434D5215B54181}Prefabs/Items/Medicine/MetoprololInjection/ACE_Medical_MetoprololInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{669AF2B3E60645F6}" {
+    m_sItemPrefab "{9DB69176CEF0EE97}Prefabs/Weapons/Grenades/Smoke_ANM8HC.et"
+    m_iItemCount 2
    }
   }
   m_DefaultClothing {

--- a/Configs/Gearscripts/Standard/Modern/Variants/CRF_GS_RHSION_Urban_NoOptics_AP.conf
+++ b/Configs/Gearscripts/Standard/Modern/Variants/CRF_GS_RHSION_Urban_NoOptics_AP.conf
@@ -5,13 +5,14 @@ CRF_GearScriptConfig {
  m_FactionWeapons CRF_Weapons "{65BD5C8778F9AACF}" {
   m_Rifle {
    CRF_Weapon_Class "{65BD5C8778F9AAD0}" {
-    m_Weapon "{3BC80AAE900EC0B7}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_Suppressed.et"
+    m_Weapon "{442D3A4317CE6D7D}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_plain.et"
     m_Attachments {
      "{3D4B54552E600505}Prefabs/Weapons/Attachments/Optics/Collimators/Optic_EotechEXPS3/Collim_EXPS3_BLK.et"
+     "{B2B3DB66A987648F}Prefabs/Weapons/Attachments/Foregrips/Magpul_RVG/Magpul_RVG_SCARH_BLK.et"
     }
     m_MagazineArray {
      CRF_Magazine_Class "{65BD5C8778F9AAD3}" {
-      m_Magazine "{A36FC079DFAC2B55}Prefabs/Weapons/Magazines/Magazine_762x51_SCARH_20rnd_M80A1_BLK.et"
+      m_Magazine "{77AAEEB1D221D79A}Prefabs/Weapons/Magazines/762x51_SCARH_20rnd/Magazine_762x51_SCARH_20rnd_4Ball_1Tracer_M80A1_M62.et"
       m_MagazineCount 14
      }
     }
@@ -19,14 +20,13 @@ CRF_GearScriptConfig {
   }
   m_RifleUGL {
    CRF_Weapon_Class "{65BD5C8778F9AADE}" {
-    m_Weapon "{3BC80AAE900EC0B8}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_Suppressed.et"
+    m_Weapon "{2A390E6E55F3F11D}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_M203_plain.et"
     m_Attachments {
      "{DBE8F7374A320BDF}Prefabs/Weapons/Attachments/Optics/Collimators/Optic_EotechEXPS3/Collim_EXPS3_base.et"
-     "{43FDAF3FA0FF2299}Prefabs/Weapons/Attachments/Underbarrel/UGL_M203_long.et"
     }
     m_MagazineArray {
      CRF_Magazine_Class "{65BD5C8778F9AAD9}" {
-      m_Magazine "{A36FC079DFAC2B55}Prefabs/Weapons/Magazines/Magazine_762x51_SCARH_20rnd_M80A1_BLK.et"
+      m_Magazine "{77AAEEB1D221D79A}Prefabs/Weapons/Magazines/762x51_SCARH_20rnd/Magazine_762x51_SCARH_20rnd_4Ball_1Tracer_M80A1_M62.et"
       m_MagazineCount 14
      }
      CRF_Magazine_Class "{65BD5C8778F9AAD8}" {
@@ -55,9 +55,6 @@ CRF_GearScriptConfig {
   m_Carbine {
    CRF_Weapon_Class "{65BD5C8778F9AAEE}" {
     m_Weapon "{20DDB7ABE9F2FC00}Prefabs/Weapons/Rifles/MPX/Rifle_MPX_MOD1.et"
-    m_Attachments {
-     ""
-    }
     m_MagazineArray {
      CRF_Magazine_Class "{65BD5C8778F9AAE9}" {
       m_Magazine "{35C35DD311E92C06}Prefabs/Weapons/Magazines/Magazine_9x19_MPX_41rnd_Ball.et"
@@ -165,6 +162,26 @@ CRF_GearScriptConfig {
    CRF_Inventory_Item "{65BD5C8778F9AA46}" {
     m_sItemPrefab "{D41D22DD1B8E921E}Prefabs/Weapons/Grenades/M18/Smoke_M18_Green.et"
     m_iItemCount 1
+   }
+   CRF_Inventory_Item "{669AF2B356335FF4}" {
+    m_sItemPrefab "{58CF3AB87C441295}Prefabs/Items/Medicine/AmmoniumCarbonatePackage/ACE_Medical_AmmoniumCarbonatePackage.et"
+    m_iItemCount 10
+   }
+   CRF_Inventory_Item "{669AF2B3BE22CE4E}" {
+    m_sItemPrefab "{02DD34077F51F65E}Prefabs/Items/Medicine/NaloxoneInjection/ACE_Medical_NaloxoneInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{669AF2B383414F99}" {
+    m_sItemPrefab "{9BBA766CD869002C}Prefabs/Items/Medicine/PhenylephrineInjection/ACE_Medical_PhenylephrineInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{669AF2B39F293356}" {
+    m_sItemPrefab "{D0434D5215B54181}Prefabs/Items/Medicine/MetoprololInjection/ACE_Medical_MetoprololInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{669AF2B3EBF92F35}" {
+    m_sItemPrefab "{9DB69176CEF0EE97}Prefabs/Weapons/Grenades/Smoke_ANM8HC.et"
+    m_iItemCount 2
    }
   }
   m_DefaultClothing {

--- a/Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_M203_plain.et
+++ b/Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_M203_plain.et
@@ -1,0 +1,29 @@
+GenericEntity : "{9BC591047D1E5EAD}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK.et" {
+ ID "CFBAA4B725411E45"
+ components {
+  WeaponComponent "{CFBAA4B706BA66E8}" {
+   components {
+    AttachmentSlotComponent "{61785E090D534961}" {
+     AttachmentSlot InventoryStorageSlot Foregrip {
+      Offset 0 0.037 -0.1622
+      Prefab "{852FB88E8AD446C8}Prefabs/Weapons/Attachments/Underbarrel/UGL_RHS_M203_NoSight.et"
+     }
+    }
+    AttachmentSlotComponent "{61785E090D53496F}" {
+     AttachmentSlot RHS_SlidingInventoryStorageSlot Optic {
+      Prefab ""
+     }
+    }
+    MuzzleComponent "{CA6BE4D6B867541F}" {
+     components {
+      AttachmentSlotComponent "{626E2147F1287008}" {
+       AttachmentSlot InventoryStorageSlot "{626E2147FFDB258A}" {
+       }
+      }
+     }
+    }
+   }
+  }
+ }
+ coords 0 0 0.022
+}

--- a/Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_M203_plain.et.meta
+++ b/Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_M203_plain.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{2A390E6E55F3F11D}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_BLK_M203_plain.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_FDE_M203_plain.et
+++ b/Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_FDE_M203_plain.et
@@ -1,0 +1,32 @@
+GenericEntity : "{EC0B2A922E4AD1AB}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_Base.et" {
+ ID "CFBAA4B725411E45"
+ components {
+  WeaponComponent "{CFBAA4B706BA66E8}" {
+   components {
+    AttachmentSlotComponent "{61785E090D534961}" {
+     AttachmentSlot InventoryStorageSlot Foregrip {
+      Offset 0 0.0324 -0.12
+      Prefab "{852FB88E8AD446C8}Prefabs/Weapons/Attachments/Underbarrel/UGL_RHS_M203_NoSight.et"
+     }
+    }
+    AttachmentSlotComponent "{61785E090D53496B}" {
+     AttachmentSlot RHS_SlidingInventoryStorageSlot TopRail {
+     }
+    }
+    AttachmentSlotComponent "{61785E090D53496F}" {
+     AttachmentSlot RHS_SlidingInventoryStorageSlot Optic {
+     }
+    }
+    MuzzleComponent "{CA6BE4D6B867541F}" {
+     components {
+      AttachmentSlotComponent "{626E2147F1287008}" {
+       AttachmentSlot InventoryStorageSlot "{626E2147FFDB258A}" {
+       }
+      }
+     }
+     MagazineTemplate "{C27B62CD736C267A}Prefabs/Weapons/Magazines/762x51_SCARH_FDE_20rnd/Magazine_762x51_SCARH_FDE_20rnd_4Ball_1Tracer_M80A1_M62.et"
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_FDE_M203_plain.et.meta
+++ b/Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_FDE_M203_plain.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{99091B7E143DFF06}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_FDE_M203_plain.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_FDE_plain.et
+++ b/Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_FDE_plain.et
@@ -1,0 +1,31 @@
+GenericEntity : "{EC0B2A922E4AD1AB}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_Base.et" {
+ ID "CFBAA4B725411E45"
+ components {
+  WeaponComponent "{CFBAA4B706BA66E8}" {
+   components {
+    AttachmentSlotComponent "{61785E090D534961}" {
+     AttachmentSlot InventoryStorageSlot Foregrip {
+      Offset 0 0.0324 -0.12
+     }
+    }
+    AttachmentSlotComponent "{61785E090D53496B}" {
+     AttachmentSlot RHS_SlidingInventoryStorageSlot TopRail {
+     }
+    }
+    AttachmentSlotComponent "{61785E090D53496F}" {
+     AttachmentSlot RHS_SlidingInventoryStorageSlot Optic {
+     }
+    }
+    MuzzleComponent "{CA6BE4D6B867541F}" {
+     components {
+      AttachmentSlotComponent "{626E2147F1287008}" {
+       AttachmentSlot InventoryStorageSlot "{626E2147FFDB258A}" {
+       }
+      }
+     }
+     MagazineTemplate "{C27B62CD736C267A}Prefabs/Weapons/Magazines/762x51_SCARH_FDE_20rnd/Magazine_762x51_SCARH_FDE_20rnd_4Ball_1Tracer_M80A1_M62.et"
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_FDE_plain.et.meta
+++ b/Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_FDE_plain.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{6325E78EE0925A4A}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_FDE_plain.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}


### PR DESCRIPTION
- Removes M203 from gearscript attachment slots, and makes "plain" prefabs of weapon variants to apply attachments to
- Updates standard SCARH gearscripts with current medic equipment, fixes lingering mag issues
- Reflects these updates in the push gearscript