### PR TITLE
New Mission- Harry SO Pressure Change

### DIFF
--- a/Configs/Gearscripts/Custom/Harry/PressureChange/CRF_GS_FIA_Modern_.conf
+++ b/Configs/Gearscripts/Custom/Harry/PressureChange/CRF_GS_FIA_Modern_.conf
@@ -1,0 +1,650 @@
+CRF_GearScriptConfig {
+ m_FactionName "FIA"
+ m_FactionIcon "{FB266CDD4502D60B}UI/Textures/Editor/EditableEntities/Factions/EditableEntity_Faction_Fia.edds"
+ m_FactionIdentity "{11CAD6C8909CE567}Configs/Identities/CRF_CharacterIdentity_European.conf"
+ m_FactionWeapons CRF_Weapons "{66A8ECE45F3F10BE}" {
+  m_Rifle {
+   CRF_Weapon_Class "{66A8ECE45F3F1047}" {
+    m_Weapon "{BD5CA2EFE337C23A}Prefabs/Weapons/Rifles/AKM/Rifle_AKMN_Dong.et"
+    m_MagazineArray {
+     CRF_Magazine_Class "{66A8ECE45F3F1041}" {
+      m_Magazine "{E59692BC9B15C00D}Prefabs/Weapons/Magazines/762x39_AKM_6L10_30rnd/Magazine_762x39_AKM_6L10_30rnd_Last_5Tracer_57N231_57T231P.et"
+      m_MagazineCount 9
+     }
+    }
+   }
+   CRF_Weapon_Class "{66A8ECE28D69DEBF}" {
+    m_Weapon "{41AD4E19A9BDBDCE}Prefabs/Weapons/Rifles/AK47/BC_Rifle_AK47.et"
+    m_MagazineArray {
+     CRF_Magazine_Class "{66A8ECE2EE951866}" {
+      m_Magazine "{D66B57C62D7D503C}Prefabs/Weapons/Magazines/AK/BC_Magazine_762x39_AK_30rnd_Last_5Tracer.et"
+      m_MagazineCount 9
+     }
+    }
+   }
+  }
+  m_RifleUGL {
+   CRF_Weapon_Class "{66A8ECE45F3F1042}" {
+    m_Weapon "{6EAF4683B809C51A}Prefabs/Weapons/Rifles/AKM/CRF_Rifle_AKMN_UGL.et"
+    m_MagazineArray {
+     CRF_Magazine_Class "{66A8ECE45F3F104D}" {
+      m_Magazine "{262F0D09C4130826}Prefabs/Weapons/Ammo/Ammo_Grenade_HE_VOG25.et"
+      m_MagazineCount 4
+     }
+     CRF_Magazine_Class "{66A8ECE45F3F1048}" {
+      m_Magazine "{906F07BD0366E08F}Prefabs/Weapons/Ammo/Ammo_Flare_40mm_VG40OP_White.et"
+      m_MagazineCount 2
+     }
+     CRF_Magazine_Class "{66A8ECE45F3F1051}" {
+      m_Magazine "{21335500CF96B660}Prefabs/Weapons/Ammo/SOV_Ammo_Smoke_Green.et"
+      m_MagazineCount 1
+     }
+     CRF_Magazine_Class "{66A8ECE45F3F1052}" {
+      m_Magazine "{4D358DC7649B5CEA}Prefabs/Weapons/Ammo/SOV_Ammo_Smoke_Red.et"
+      m_MagazineCount 1
+     }
+     CRF_Magazine_Class "{66A8ECE45F3F105F}" {
+      m_Magazine "{B4CFBAF48A598F45}Prefabs/Weapons/Ammo/SOV_Ammo_Smoke_White.et"
+      m_MagazineCount 2
+     }
+     CRF_Magazine_Class "{66A8ECE45F3F1059}" {
+      m_Magazine "{E59692BC9B15C00D}Prefabs/Weapons/Magazines/762x39_AKM_6L10_30rnd/Magazine_762x39_AKM_6L10_30rnd_Last_5Tracer_57N231_57T231P.et"
+      m_MagazineCount 9
+     }
+    }
+   }
+  }
+  m_Carbine {
+   CRF_Weapon_Class "{66A8ECE45F3F105B}" {
+    m_Weapon "{A585AE947C87E6E3}Prefabs/Weapons/Rifles/9A91/Rifle_9A91_base.et"
+    m_MagazineArray {
+     CRF_Magazine_Class "{66A8ECE45F3F105A}" {
+      m_Magazine "{CB1E3A66D1070D92}Prefabs/Weapons/Magazines/9x39_9A91_20rnd/Magazine_9x39_9A91_20rnd_AP_SP6.et"
+      m_MagazineCount 9
+     }
+    }
+   }
+   CRF_Weapon_Class "{66A8ECED3D26EBBD}" {
+    m_Weapon "{177CF9EA974446D1}Prefabs/Weapons/Rifles/AN94/Rifle_AN94.et"
+    m_MagazineArray {
+     CRF_Magazine_Class "{66A8ECE4F1B254E3}" {
+      m_Magazine "{DFEBDFD73BFD9501}Prefabs/Weapons/Magazines/6l23_plum/Magazine_545x39_plum_AK_30rnd_Last_5Tracer.et"
+      m_MagazineCount 9
+     }
+    }
+   }
+  }
+  m_Pistol {
+   CRF_Weapon_Class "{66A8ECE45F3F1066}" {
+    m_Weapon "{C0F7DD85A86B2900}Prefabs/Weapons/Handguns/PM/Handgun_PM.et"
+    m_MagazineArray {
+     CRF_Magazine_Class "{66A8ECE45F30B3B0}" {
+      m_Magazine "{8B853CDD11BA916E}Prefabs/Weapons/Magazines/Magazine_9x18_PM_8rnd_Ball.et"
+      m_MagazineCount 4
+     }
+    }
+   }
+  }
+  m_AR CRF_Spec_Weapon_Class "{66A8ECE45F30B3A1}" {
+   m_Weapon "{A7AF84C6C58BA3E8}Prefabs/Weapons/MachineGuns/RPK74/MG_RPK74.et"
+   m_MagazineArray {
+    CRF_Spec_Magazine_Class "{66A8ECE45F30B3A0}" {
+     m_Magazine "{5897D01F41DB5D2D}Prefabs/Weapons/Magazines/Magazine_545x39_RPK_45rnd_Tracer.et"
+     m_MagazineCount 15
+     m_AssistantMagazineCount 15
+    }
+   }
+  }
+  m_MMG CRF_Spec_Weapon_Class "{66A8ECE45F30B3A9}" {
+   m_Weapon "{657CBBDE781ED4A0}Prefabs/Weapons/MachineGuns/UK59/MG_UK59_AP.et"
+   m_Attachments {
+    "{886A96EF3F14BCD2}Prefabs/Weapons/Attachments/Optics/UK59_4x8/Optic_UK59_4x8.et"
+   }
+   m_MagazineArray {
+    CRF_Spec_Magazine_Class "{66A8ECE45F30B3A8}" {
+     m_Magazine "{2579361F40CE337C}Prefabs/Weapons/Magazines/UK59/Box_762x54_UK59_50rnd_4AP_1Tracer.et"
+     m_MagazineCount 12
+     m_AssistantMagazineCount 12
+    }
+   }
+  }
+  m_AT CRF_Spec_Weapon_Class "{66A8ECE45F30B3D2}" {
+   m_Weapon "{3FEEC75992196DAC}Prefabs/Weapons/Launchers/RPG18/Launcher_RPG18.et"
+  }
+  m_MAT CRF_Spec_Weapon_Class "{66A8ECE45F30B3D0}" {
+   m_Weapon "{AC4C33E8AE72A9F9}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7_rhs_CRF.et"
+   m_MagazineArray {
+    CRF_Spec_Magazine_Class "{66A8ECE45F3023CC}" {
+     m_Magazine "{86A7681BD1D4E4BB}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VR.et"
+     m_MagazineCount 0
+     m_AssistantMagazineCount 1
+    }
+    CRF_Spec_Magazine_Class "{66A8ECE45F3023C8}" {
+     m_Magazine "{4A3B196E4EA820E9}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_OG7V.et"
+     m_MagazineCount 1
+     m_AssistantMagazineCount 1
+    }
+    CRF_Spec_Magazine_Class "{66A8ECE45F3023C6}" {
+     m_Magazine "{FBBF84E3B447D822}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VL.et"
+     m_MagazineCount 1
+     m_AssistantMagazineCount 2
+    }
+   }
+  }
+  m_AA CRF_Spec_Weapon_Class "{66A8ECE45F3023C2}" {
+   m_Weapon "{962C400354E4BD6C}Prefabs/Weapons/Launchers/9K38_IGLA/Launcher_9K38_IGLA.et"
+   m_MagazineArray {
+    CRF_Spec_Magazine_Class "{66A8ECE45F3023C1}" {
+     m_Magazine "{962C400354E4BD6C}Prefabs/Weapons/Launchers/9K38_IGLA/Launcher_9K38_IGLA.et"
+     m_MagazineCount 1
+     m_AssistantMagazineCount 2
+    }
+   }
+  }
+  m_Sniper CRF_Weapon_Class "{66A8ECE45F3023EF}" {
+   m_Weapon "{6415B7923DE28C1B}Prefabs/Weapons/Rifles/SVD/Rifle_SVD_PSO.et"
+   m_MagazineArray {
+    CRF_Magazine_Class "{66A8ECE45F3023EE}" {
+     m_Magazine "{9CCB46C6EE632C1A}Prefabs/Weapons/Magazines/Magazine_762x54_SVD_10rnd_Sniper.et"
+     m_MagazineCount 11
+    }
+   }
+  }
+ }
+ m_DefaultFactionGear CRF_Default_Gear "{66A8ECE45F3023EA}" {
+  m_sLeadershipBinocularsPrefab "{243948B23D90BECB}Prefabs/Items/Equipment/Binoculars/Binoculars_B8/Binoculars_B8.et"
+  m_sAssistantBinocularsPrefab "{243948B23D90BECB}Prefabs/Items/Equipment/Binoculars/Binoculars_B8/Binoculars_B8.et"
+  m_DefaultMedicMedicalItems {
+   CRF_Inventory_Item "{66A8ECE45F3023E9}" {
+    m_sItemPrefab "{C3F1FA1E2EC2B345}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_USSR_01.et"
+    m_iItemCount 10
+   }
+   CRF_Inventory_Item "{66A8ECE45F3023E6}" {
+    m_sItemPrefab "{80E75A71C29190DB}Prefabs/Items/Medicine/Tourniquet_01/Tourniquet_USSR_01.et"
+    m_iItemCount 3
+   }
+   CRF_Inventory_Item "{66A8ECE45F3023E3}" {
+    m_sItemPrefab "{0D9A5DCF89AE7AA9}Prefabs/Items/Medicine/MorphineInjection_01/MorphineInjection_01.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{66A8ECE45F3023E0}" {
+    m_sItemPrefab "{5B2FD067D70C1E8F}Prefabs/Items/Medicine/EpinephrineInjection/ACE_Medical_EpinephrineInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{66A8ECE45F3023FD}" {
+    m_sItemPrefab "{527D7C5D2E476BDC}Prefabs/Items/Medicine/SalineBag_01/SalineBag_USSR_01.et"
+    m_iItemCount 5
+   }
+   CRF_Inventory_Item "{66A8ECE45F3023FB}" {
+    m_sItemPrefab "{21EF98BFC1EB3793}Prefabs/Items/Equipment/Kits/MedicalKit_01/MedicalKit_01_USSR.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{66A8ECE45F3023F9}" {
+    m_sItemPrefab "{58CF3AB87C441295}Prefabs/Items/Medicine/AmmoniumCarbonatePackage/ACE_Medical_AmmoniumCarbonatePackage.et"
+    m_iItemCount 10
+   }
+   CRF_Inventory_Item "{66A8ECE45F3023F7}" {
+    m_sItemPrefab "{02DD34077F51F65E}Prefabs/Items/Medicine/NaloxoneInjection/ACE_Medical_NaloxoneInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{66A8ECE45F3023F5}" {
+    m_sItemPrefab "{9BBA766CD869002C}Prefabs/Items/Medicine/PhenylephrineInjection/ACE_Medical_PhenylephrineInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{66A8ECE45F3023F2}" {
+    m_sItemPrefab "{D0434D5215B54181}Prefabs/Items/Medicine/MetoprololInjection/ACE_Medical_MetoprololInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{66A8ECE45F3023F0}" {
+    m_sItemPrefab "{77EAE5E07DC4678A}Prefabs/Weapons/Grenades/Smoke_RDG2.et"
+    m_iItemCount 2
+   }
+  }
+  m_DefaultClothing {
+   CRF_Clothing "{66A8ECE45F302409}" {
+    m_iClothingType BACKPACK
+    m_ClothingPrefabs {
+     "{CE832B86D234AD62}Prefabs/Items/Equipment/Backpacks/CRF_Backpack_Invisable.et"
+    }
+   }
+   CRF_Clothing "{66A8ECE45F302407}" {
+    m_iClothingType HEADGEAR
+    m_ClothingPrefabs {
+     "{6B2256EBB8E267DD}Prefabs/Characters/HeadGear/Hat_Knitted_01/Hat_Knitted_01_blue.et"
+     "{D8D9EE7F3966589E}Prefabs/Characters/HeadGear/Hat_Knitted_01/Hat_Knitted_01_red.et"
+     "{B02281435AED8274}Prefabs/Characters/HeadGear/Hat_M70_01/Hat_M70_01.et"
+     "{B9687B8829272E14}Prefabs/Characters/HeadGear/Hat_Knitted_01/Hat_Knitted_01_brown.et"
+    }
+   }
+   CRF_Clothing "{66A8ECE45F302402}" {
+    m_iClothingType SHIRT
+    m_ClothingPrefabs {
+     "{CC2BAD4EACC9B2CA}Prefabs/Characters/Uniforms/Jacket_TAZ83/Jacket_TAZ83_01.et"
+     "{BBA08EC4EC40FA94}Prefabs/Characters/Uniforms/Jacket_M70.et"
+    }
+   }
+   CRF_Clothing "{66A8ECE45F30241E}" {
+    m_iClothingType ARMOREDVEST
+    m_ClothingPrefabs {
+     "{4CBDC206FEF9897C}Prefabs/Characters/Vests/Vest_6B3/Vest_6B3.et"
+    }
+   }
+   CRF_Clothing "{66A8ECE45F30241C}" {
+    m_iClothingType PANTS
+    m_ClothingPrefabs {
+     "{27364244288DA83B}Prefabs/Characters/Uniforms/Pants_TAZ83/Pants_TAZ83_01.et"
+     "{4DC4FD2F6D353B12}Prefabs/Characters/Uniforms/Pants_M70_Dirty.et"
+     "{06BC3F18B47799AE}Prefabs/Characters/Uniforms/Pants_M70.et"
+    }
+   }
+   CRF_Clothing "{66A8ECE45F302419}" {
+    m_iClothingType BOOTS
+    m_ClothingPrefabs {
+     "{C7923961D7235D70}Prefabs/Characters/Footwear/CombatBoots_Soviet_01.et"
+     "{4C6029AB8BF5C044}Prefabs/Characters/Footwear/CombatBoots_Soviet_01_Dirty.et"
+    }
+   }
+   CRF_Clothing "{66A8ECE45F302417}" {
+    m_iClothingType VEST
+    m_ClothingPrefabs {
+     "{ED5574EA7F63B457}Prefabs/Characters/Vests/Vest_Type56/Vest_Type56.et"
+    }
+   }
+  }
+  m_DefaultInventoryItems {
+   CRF_Inventory_Item "{66A8ECE45F302415}" {
+    m_sItemPrefab "{575EA58E67448C2A}Prefabs/Items/Equipment/Flashlights/Flashlight_Soviet_01/Flashlight_Soviet_01.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{66A8ECE45F30243B}" {
+    m_sItemPrefab "{645C73791ECA1698}Prefabs/Weapons/Grenades/Grenade_RGD5.et"
+    m_iItemCount 2
+   }
+   CRF_Inventory_Item "{66A8ECE45F302438}" {
+    m_sItemPrefab "{77EAE5E07DC4678A}Prefabs/Weapons/Grenades/Smoke_RDG2.et"
+    m_iItemCount 2
+   }
+   CRF_Inventory_Item "{66A8ECE45F302437}" {
+    m_sItemPrefab "{7CEF68E2BC68CE71}Prefabs/Items/Equipment/Compass/Compass_Adrianov.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{66A8ECE45F302435}" {
+    m_sItemPrefab "{13772C903CB5E4F7}Prefabs/Items/Equipment/Maps/PaperMap_01_folded.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{66A8ECE45F302433}" {
+    m_sItemPrefab "{C3F1FA1E2EC2B345}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_USSR_01.et"
+    m_iItemCount 2
+   }
+   CRF_Inventory_Item "{66A8ECE45F303D9F}" {
+    m_sItemPrefab "{80E75A71C29190DB}Prefabs/Items/Medicine/Tourniquet_01/Tourniquet_USSR_01.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{66A8ECE45F303D9E}" {
+    m_sItemPrefab "{6E35D94130954509}Prefabs/Items/Equipment/Accessories/ETool_ALICE/ETool_ALICE_FreeRoamBuilding_Gadget.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{66A8ECE45F303DE3}" {
+    m_sItemPrefab "{8554ED3F088BADA6}Prefabs/Items/Core/Wirecutters/wirecutters.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{66A8ECE45F303DE1}" {
+    m_sItemPrefab "{AE2B7341B5A82545}Prefabs/Items/PersonalBelongings/PersonalBelongings_FIA.et"
+    m_iItemCount 0
+   }
+  }
+ }
+ m_CustomFactionGear CRF_Custom_Gear "{66A8ECE45F303DE5}" {
+  m_RolesToSetCustomGear {
+   CRF_Role_Custom_Gear "{66A8ECE45F31F9B1}" {
+    m_Role VEHICLE_LEAD
+    m_Clothing {
+     CRF_Clothing "{66A8ECE45F31F9BF}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       ""
+      }
+     }
+     CRF_Clothing "{66A8ECE45F31F9BD}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{1D99585CF8E34D91}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01.et"
+       "{A4145024AE7084F6}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01_tucked.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE45F31F9BA}" {
+    m_Role INDIRECT_LEAD
+    m_AdditionalInventoryItems {
+     CRF_Inventory_Item "{66A8ECE45F31AF6F}" {
+      m_sItemPrefab "{B41607EAB58A4252}Prefabs/Items/Equipment/BalisticTable/BalisticTable_USSR.et"
+      m_iItemCount 1
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE45F31AF7F}" {
+    m_Role LOGI_LEAD
+    m_Clothing {
+     CRF_Clothing "{66A8ECE45F31AF7C}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{FDA7B6630DB87991}Prefabs/Items/Equipment/Backpacks/Backpack_M70_Swiss.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE45F31AF42}" {
+    m_Role MEDICAL_OFFICER
+    m_Clothing {
+     CRF_Clothing "{66A8ECE45F317711}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{7AC107CA7AFC9B59}Prefabs/Items/Equipment/Backpacks/Backpack_Medical_Soviet.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE45F317712}" {
+    m_Role MEDIC
+    m_Clothing {
+     CRF_Clothing "{66A8ECE45F317715}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{7AC107CA7AFC9B59}Prefabs/Items/Equipment/Backpacks/Backpack_Medical_Soviet.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE45F317714}" {
+    m_Role ASSISTANT_AUTOMATIC_RIFLEMAN
+    m_Clothing {
+     CRF_Clothing "{66A8ECE45F317717}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{FDA7B6630DB87991}Prefabs/Items/Equipment/Backpacks/Backpack_M70_Swiss.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE45F317716}" {
+    m_Role ASSISTANT_RIFLEMAN_ANTITANK
+    m_Clothing {
+     CRF_Clothing "{66A8ECE45F317718}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{6A39B5843B3F36DA}Prefabs/Items/Equipment/Backpacks/Backpack_RPG_Assistant.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE45F31771A}" {
+    m_Role RIFLEMAN_ANTITANK
+    m_Clothing {
+     CRF_Clothing "{66A8ECE45F3102E2}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{0D39750E5695B9D8}Prefabs/Items/Equipment/Backpacks/Backpack_RPG_Gunner.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE45F3102E4}" {
+    m_Role HEAVY_ANTITANK
+    m_Clothing {
+     CRF_Clothing "{66A8ECE45F3102E7}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{FDA7B6630DB87991}Prefabs/Items/Equipment/Backpacks/Backpack_M70_Swiss.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE45F3102E6}" {
+    m_Role MEDIUM_ANTITANK
+    m_Clothing {
+     CRF_Clothing "{66A8ECE45F3102F9}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{0D39750E5695B9D8}Prefabs/Items/Equipment/Backpacks/Backpack_RPG_Gunner.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE45F3102F8}" {
+    m_Role ASSISTANT_HEAVY_ANTITANK
+    m_Clothing {
+     CRF_Clothing "{66A8ECE45F3102FB}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{6A39B5843B3F36DA}Prefabs/Items/Equipment/Backpacks/Backpack_RPG_Assistant.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE45F3102FA}" {
+    m_Role ASSISTANT_MEDIUM_ANTITANK
+    m_Clothing {
+     CRF_Clothing "{66A8ECE45F3102FD}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{6A39B5843B3F36DA}Prefabs/Items/Equipment/Backpacks/Backpack_RPG_Assistant.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE45F3102FC}" {
+    m_Role ASSISTANT_HEAVY_MACHINEGUN
+    m_Clothing {
+     CRF_Clothing "{66A8ECE45F32F96E}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{FDA7B6630DB87991}Prefabs/Items/Equipment/Backpacks/Backpack_M70_Swiss.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE45F32F967}" {
+    m_Role ASSISTANT_MEDIUM_MACHINEGUN
+    m_Clothing {
+     CRF_Clothing "{66A8ECE45F32F966}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{FDA7B6630DB87991}Prefabs/Items/Equipment/Backpacks/Backpack_M70_Swiss.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE45F326010}" {
+    m_Role ASSISTANT_ANTI_AIR
+    m_Clothing {
+     CRF_Clothing "{66A8ECE45F326013}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{6A39B5843B3F36DA}Prefabs/Items/Equipment/Backpacks/Backpack_RPG_Assistant.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE45F326012}" {
+    m_Role VEHICLE_DRIVER
+    m_Clothing {
+     CRF_Clothing "{66A8ECE45F3260ED}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       ""
+      }
+     }
+     CRF_Clothing "{66A8ECE45F3260EC}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{1D99585CF8E34D91}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01.et"
+       "{A4145024AE7084F6}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01_tucked.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE45F3260EF}" {
+    m_Role VEHICLE_GUNNER
+    m_Clothing {
+     CRF_Clothing "{66A8ECE45F3260F7}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       ""
+      }
+     }
+     CRF_Clothing "{66A8ECE45F3260F6}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{1D99585CF8E34D91}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01.et"
+       "{A4145024AE7084F6}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01_tucked.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE45F3260F1}" {
+    m_Role VEHICLE_LOADER
+    m_Clothing {
+     CRF_Clothing "{66A8ECE45F3260F0}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       ""
+      }
+     }
+     CRF_Clothing "{66A8ECE45F3260F3}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{1D99585CF8E34D91}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01.et"
+       "{A4145024AE7084F6}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01_tucked.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE45F3260F2}" {
+    m_Role PILOT
+    m_Clothing {
+     CRF_Clothing "{66A8ECE45F3260CD}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{6835DAF42A09E23C}Prefabs/Characters/Uniforms/Jacket_Pilot_USSR_01/Jacket_Pilot_USSR_01.et"
+      }
+     }
+     CRF_Clothing "{66A8ECE45F3260CE}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       "{83DFA8F68CA40B10}Prefabs/Characters/Uniforms/Pants_Pilot_USSR_01/Pants_Pilot_USSR_01.et"
+       "{6B7F32F1F8A191B0}Prefabs/Characters/Uniforms/Pants_Pilot_USSR_01/Pants_Pilot_USSR_01_tucked.et"
+      }
+     }
+     CRF_Clothing "{66A8ECE45F3260C8}" {
+      m_iClothingType HEADGEAR
+      m_ClothingPrefabs {
+       "{E49D9EE7E2B3016C}Prefabs/Characters/HeadGear/Helmet_ZSh5_01/Helmet_ZSh5_01.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE45F3260CA}" {
+    m_Role CREW_CHIEF
+    m_Clothing {
+     CRF_Clothing "{66A8ECE45F3260C5}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{6835DAF42A09E23C}Prefabs/Characters/Uniforms/Jacket_Pilot_USSR_01/Jacket_Pilot_USSR_01.et"
+      }
+     }
+     CRF_Clothing "{66A8ECE45F3260C4}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       "{83DFA8F68CA40B10}Prefabs/Characters/Uniforms/Pants_Pilot_USSR_01/Pants_Pilot_USSR_01.et"
+       "{6B7F32F1F8A191B0}Prefabs/Characters/Uniforms/Pants_Pilot_USSR_01/Pants_Pilot_USSR_01_tucked.et"
+      }
+     }
+     CRF_Clothing "{66A8ECE45F3260C7}" {
+      m_iClothingType HEADGEAR
+      m_ClothingPrefabs {
+       "{E49D9EE7E2B3016C}Prefabs/Characters/HeadGear/Helmet_ZSh5_01/Helmet_ZSh5_01.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE45F32474F}" {
+    m_Role LOGI_RUNNER
+    m_Clothing {
+     CRF_Clothing "{66A8ECE45F32474E}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{FDA7B6630DB87991}Prefabs/Items/Equipment/Backpacks/Backpack_M70_Swiss.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE45F324749}" {
+    m_Role INDIRECT_GUNNER
+    m_Clothing {
+     CRF_Clothing "{66A8ECE45F324748}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{2E965A1D8DD5D27B}Prefabs/Items/Equipment/Backpacks/NSV/Backpack_2b14_mortar_Weapon.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE45F32474B}" {
+    m_Role INDIRECT_GUNNER
+    m_Clothing {
+     CRF_Clothing "{66A8ECE45F32474A}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{7611D0DAE5796941}Prefabs/Items/Equipment/Backpacks/Backpack_USSR_Bipod.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE45F324756}" {
+    m_Role RIFLEMAN_DEMO
+    m_AdditionalInventoryItems {
+     CRF_Inventory_Item "{66A8ECE45F324751}" {
+      m_sItemPrefab "{73F69547963CAEE0}PrefabsEditable/Explosives/E_DemoBlock_TSh400g.et"
+      m_iItemCount 2
+     }
+     CRF_Inventory_Item "{66A8ECE45F324752}" {
+      m_sItemPrefab "{90976DC90A223095}Prefabs/Items/Equipment/Detonators/BlastingMachine_KPM_3U1/BlastingMachine_KPM_3U1.et"
+      m_iItemCount 2
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE45F324759}" {
+    m_Role COMBAT_ENGINEER
+    m_AdditionalInventoryItems {
+     CRF_Inventory_Item "{66A8ECE45F324758}" {
+      m_sItemPrefab "{73F69547963CAEE0}PrefabsEditable/Explosives/E_DemoBlock_TSh400g.et"
+      m_iItemCount 1
+     }
+     CRF_Inventory_Item "{66A8ECE45F32475B}" {
+      m_sItemPrefab "{90976DC90A223095}Prefabs/Items/Equipment/Detonators/BlastingMachine_KPM_3U1/BlastingMachine_KPM_3U1.et"
+      m_iItemCount 1
+     }
+     CRF_Inventory_Item "{66A8ECE45F322352}" {
+      m_sItemPrefab "{00515E7AAAFD9CB6}Prefabs/Weapons/Explosives/Explosive_Satchels/INDFOR_Satchel.et"
+      m_iItemCount 3
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE1F78B2644}" {
+    m_Role TEAM_LEAD
+    m_sRoleName "Team Lead & CLS"
+    m_AdditionalInventoryItems {
+     CRF_Inventory_Item "{66A8ECE1F82DBB18}" {
+      m_sItemPrefab "{C3F1FA1E2EC2B345}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_USSR_01.et"
+      m_iItemCount 5
+     }
+     CRF_Inventory_Item "{66A8ECE1F86DDD5A}" {
+      m_sItemPrefab "{527D7C5D2E476BDC}Prefabs/Items/Medicine/SalineBag_01/SalineBag_USSR_01.et"
+      m_iItemCount 3
+     }
+    }
+   }
+  }
+ }
+}

--- a/Configs/Gearscripts/Custom/Harry/PressureChange/CRF_GS_FIA_Modern_.conf.meta
+++ b/Configs/Gearscripts/Custom/Harry/PressureChange/CRF_GS_FIA_Modern_.conf.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{AC1CC557967D9AC9}Configs/Gearscripts/Standard/80s/Variants/CRF_GS_FIA_Modern_.conf"
+ Configurations {
+  CONFResourceClass PC {
+  }
+  CONFResourceClass XBOX_ONE : PC {
+  }
+  CONFResourceClass XBOX_SERIES : PC {
+  }
+  CONFResourceClass PS4 : PC {
+  }
+  CONFResourceClass PS5 : PC {
+  }
+  CONFResourceClass HEADLESS : PC {
+  }
+  CONFResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Configs/Gearscripts/Custom/Harry/PressureChange/CRF_GS_Modern_Rebels_Harry_.conf
+++ b/Configs/Gearscripts/Custom/Harry/PressureChange/CRF_GS_Modern_Rebels_Harry_.conf
@@ -1,0 +1,691 @@
+CRF_GearScriptConfig {
+ m_FactionName "Russian Army"
+ m_FactionIcon "{07C963E7DDA6341D}Prefabs/Assets/Props/Fabric/Data/Flags/Arma2-flag-chdkz.edds"
+ m_FactionIdentity "{E13982CDA81E8F0C}Configs/Identities/CRF_CharacterIdentity_Asian.conf"
+ m_FactionWeapons CRF_Weapons "{66A8ECE4F1B2550B}" {
+  m_Rifle {
+   CRF_Weapon_Class "{66A8ECE4F1B25500}" {
+    m_Weapon "{5BFF97EFD0BF6D9F}Prefabs/Weapons/Rifles/AKM/Rifle_AKMN.et"
+    m_MagazineArray {
+     CRF_Magazine_Class "{66A8ECE4F1B25501}" {
+      m_Magazine "{E59692BC9B15C00D}Prefabs/Weapons/Magazines/762x39_AKM_6L10_30rnd/Magazine_762x39_AKM_6L10_30rnd_Last_5Tracer_57N231_57T231P.et"
+      m_MagazineCount 9
+     }
+    }
+   }
+   CRF_Weapon_Class "{66A8ECE3E4E86768}" {
+    m_Weapon "{FC8027B1C8278441}Prefabs/Weapons/Rifles/Mosin/Rifle_Mosin_Nagant_B30_Bayonet.et"
+    m_MagazineArray {
+     CRF_Magazine_Class "{66A8ECE3F7FF7D33}" {
+      m_Magazine "{CA96DF808C7F2269}Prefabs/Weapons/Magazines/Magazine_762x54_B30_Mosin_Nagant.et"
+      m_MagazineCount 60
+     }
+    }
+   }
+  }
+  m_RifleUGL {
+   CRF_Weapon_Class "{66A8ECE4F1B25519}" {
+    m_Weapon "{ED777DCB94B52A98}Prefabs/Weapons/Rifles/M4A1/Rifle_M4A1_BLOCK_II_XPS3_M203_black.et"
+    m_MagazineArray {
+     CRF_Magazine_Class "{66A8ECE4F1B2551A}" {
+      m_Magazine "{BAFFFFA31DC85DF7}Prefabs/Weapons/Magazines/556x45_PMAG_Window_30rnd/Magazine_556x45_PMAG_Window_30rnd_Last_5Tracer_M855A1_M856.et"
+      m_MagazineCount 9
+     }
+     CRF_Magazine_Class "{66A8ECE4F1B25515}" {
+      m_Magazine "{2A8586964D22492A}Prefabs/Weapons/Ammo/Ammo_Grenade_HEDP_M433_LS.et"
+      m_MagazineCount 4
+     }
+     CRF_Magazine_Class "{66A8ECE4F1B25510}" {
+      m_Magazine "{98DB57ECEDC81CC2}Prefabs/Weapons/Ammo/Ammo_Flare_40mm_M583A1_White.et"
+      m_MagazineCount 2
+     }
+     CRF_Magazine_Class "{66A8ECE4F1B254EC}" {
+      m_Magazine "{0AF10C206CF1A282}Prefabs/Weapons/Ammo/US_Ammo_Smoke_Green.et"
+      m_MagazineCount 1
+     }
+     CRF_Magazine_Class "{66A8ECE4F1B254EF}" {
+      m_Magazine "{2B0C4280078D96B6}Prefabs/Weapons/Ammo/US_Ammo_Smoke_Red.et"
+      m_MagazineCount 1
+     }
+     CRF_Magazine_Class "{66A8ECE4F1B254E6}" {
+      m_Magazine "{AABE8FE0BA33DC8A}Prefabs/Weapons/Ammo/US_Ammo_Smoke_White.et"
+      m_MagazineCount 2
+     }
+    }
+   }
+  }
+  m_Carbine {
+   CRF_Weapon_Class "{66A8ECE4F1B254E2}" {
+    m_Weapon "{177CF9EA974446D1}Prefabs/Weapons/Rifles/AN94/Rifle_AN94.et"
+    m_MagazineArray {
+     CRF_Magazine_Class "{66A8ECE4F1B254E3}" {
+      m_Magazine "{DFEBDFD73BFD9501}Prefabs/Weapons/Magazines/6l23_plum/Magazine_545x39_plum_AK_30rnd_Last_5Tracer.et"
+      m_MagazineCount 9
+     }
+    }
+   }
+   CRF_Weapon_Class "{66A8ECE3C81D2758}" {
+    m_Weapon "{563C338A655857B7}Prefabs/Weapons/Shotguns/Remington 870/BC_Shotgun_Remington_870_V2.et"
+    m_MagazineArray {
+     CRF_Magazine_Class "{66A8ECE3D55F1853}" {
+      m_Magazine "{B0DFDF7AAA9C5D39}Prefabs/Weapons/Magazines/BC_Shell_12ga_Buckshot.et"
+      m_MagazineCount 60
+     }
+    }
+   }
+  }
+  m_Pistol {
+   CRF_Weapon_Class "{66A8ECE4F1B254FA}" {
+    m_Weapon "{618FC913FB743625}Prefabs/Weapons/Handguns/M1911/Handgun_M1911.et"
+    m_MagazineArray {
+     CRF_Magazine_Class "{66A8ECE4F1B254FB}" {
+      m_Magazine "{992FE07B99E7FC43}Prefabs/Weapons/Magazines/Magazine_45_M1911_7rnd_Ball.et"
+      m_MagazineCount 3
+     }
+    }
+   }
+  }
+  m_AR CRF_Spec_Weapon_Class "{66A8ECE4F1B254CA}" {
+   m_Weapon "{A7AF84C6C58BA3E8}Prefabs/Weapons/MachineGuns/RPK74/MG_RPK74.et"
+   m_MagazineArray {
+    CRF_Spec_Magazine_Class "{66A8ECE4F1B254C4}" {
+     m_Magazine "{D78C667F59829717}Prefabs/Weapons/Magazines/Magazine_545x39_RPK_45rnd_4Ball_1Tracer.et"
+     m_MagazineCount 15
+     m_AssistantMagazineCount 15
+    }
+   }
+  }
+  m_MMG CRF_Spec_Weapon_Class "{66A8ECE4F1B254C0}" {
+   m_Weapon "{A87B0A22462E20B1}Prefabs/Weapons/MachineGuns/M240/MG_M240.et"
+   m_Attachments {
+    "{E35250A515F71A22}Prefabs/Weapons/Attachments/Optics/1p87/Optic_1P87_1P90.et"
+   }
+   m_MagazineArray {
+    CRF_Spec_Magazine_Class "{66A8ECE4F1B254C1}" {
+     m_Magazine "{AD8AB93729348C3E}Prefabs/Weapons/Magazines/Box_762x51_M60_100rnd_Tracer.et"
+     m_MagazineCount 6
+     m_AssistantMagazineCount 6
+    }
+   }
+  }
+  m_AT CRF_Spec_Weapon_Class "{66A8ECE4F1B254D8}" {
+   m_Weapon "{F20B218D270B2368}Prefabs/Weapons/Launchers/M72/Launcher_M72A3_LS.et"
+  }
+  m_MAT CRF_Spec_Weapon_Class "{66A8ECE4F1B254DA}" {
+   m_Weapon "{DA376E83952F1DFD}Prefabs/Weapons/Launchers/M2CG/Launcher_M2CG.et"
+   m_MagazineArray {
+    CRF_Spec_Magazine_Class "{66A8ECE4F1B254DB}" {
+     m_Magazine "{0B1906A687028974}Prefabs/Weapons/Ammo/Ammo_Rocket_HEDP502.et"
+     m_MagazineCount 2
+     m_AssistantMagazineCount 2
+    }
+   }
+  }
+  m_AA CRF_Spec_Weapon_Class "{66A8ECE4F1B254D3}" {
+   m_Weapon "{962C400354E4BD6C}Prefabs/Weapons/Launchers/9K38_IGLA/Launcher_9K38_IGLA.et"
+   m_MagazineArray {
+    CRF_Spec_Magazine_Class "{66A8ECE4F1B254AC}" {
+     m_Magazine "{962C400354E4BD6C}Prefabs/Weapons/Launchers/9K38_IGLA/Launcher_9K38_IGLA.et"
+     m_MagazineCount 1
+     m_AssistantMagazineCount 2
+    }
+   }
+  }
+  m_Sniper CRF_Weapon_Class "{66A8ECE4F1B254AF}" {
+   m_Weapon "{37EF62B03C169D18}Prefabs/Weapons/Rifles/MK14MOD1/Rifle_MK14MOD1_BLK_Suppressed.et"
+   m_MagazineArray {
+    CRF_Magazine_Class "{66A8ECE4F1B254A8}" {
+     m_Magazine "{C319540BC96AE9BB}Prefabs/Weapons/Magazines/Magazine_762x51_M14_20rnd_M61_AP.et"
+     m_MagazineCount 8
+    }
+   }
+  }
+ }
+ m_DefaultFactionGear CRF_Default_Gear "{66A8ECE4F1B254B9}" {
+  m_sLeadershipBinocularsPrefab "{F2539FA5706E51E4}Prefabs/Items/Equipment/Binoculars/Binoculars_B12/Binoculars_B12.et"
+  m_sAssistantBinocularsPrefab "{F2539FA5706E51E4}Prefabs/Items/Equipment/Binoculars/Binoculars_B12/Binoculars_B12.et"
+  m_DefaultMedicMedicalItems {
+   CRF_Inventory_Item "{66A8ECE4F1B254BA}" {
+    m_sItemPrefab "{C3F1FA1E2EC2B345}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_USSR_01.et"
+    m_iItemCount 10
+   }
+   CRF_Inventory_Item "{66A8ECE4F1B254B6}" {
+    m_sItemPrefab "{80E75A71C29190DB}Prefabs/Items/Medicine/Tourniquet_01/Tourniquet_USSR_01.et"
+    m_iItemCount 3
+   }
+   CRF_Inventory_Item "{66A8ECE4F1B254B1}" {
+    m_sItemPrefab "{0D9A5DCF89AE7AA9}Prefabs/Items/Medicine/MorphineInjection_01/MorphineInjection_01.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{66A8ECE4F1B2548C}" {
+    m_sItemPrefab "{5B2FD067D70C1E8F}Prefabs/Items/Medicine/EpinephrineInjection/ACE_Medical_EpinephrineInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{66A8ECE4F1B2548E}" {
+    m_sItemPrefab "{527D7C5D2E476BDC}Prefabs/Items/Medicine/SalineBag_01/SalineBag_USSR_01.et"
+    m_iItemCount 5
+   }
+   CRF_Inventory_Item "{66A8ECE4F1B25488}" {
+    m_sItemPrefab "{21EF98BFC1EB3793}Prefabs/Items/Equipment/Kits/MedicalKit_01/MedicalKit_01_USSR.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{66A8ECE4F1B2548B}" {
+    m_sItemPrefab "{58CF3AB87C441295}Prefabs/Items/Medicine/AmmoniumCarbonatePackage/ACE_Medical_AmmoniumCarbonatePackage.et"
+    m_iItemCount 10
+   }
+   CRF_Inventory_Item "{66A8ECE4F1B25485}" {
+    m_sItemPrefab "{02DD34077F51F65E}Prefabs/Items/Medicine/NaloxoneInjection/ACE_Medical_NaloxoneInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{66A8ECE4F1B25487}" {
+    m_sItemPrefab "{9BBA766CD869002C}Prefabs/Items/Medicine/PhenylephrineInjection/ACE_Medical_PhenylephrineInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{66A8ECE4F1B25482}" {
+    m_sItemPrefab "{D0434D5215B54181}Prefabs/Items/Medicine/MetoprololInjection/ACE_Medical_MetoprololInjection.et"
+    m_iItemCount 6
+   }
+   CRF_Inventory_Item "{66A8ECE4F1B2549C}" {
+    m_sItemPrefab "{77EAE5E07DC4678A}Prefabs/Weapons/Grenades/Smoke_RDG2.et"
+    m_iItemCount 2
+   }
+  }
+  m_DefaultClothing {
+   CRF_Clothing "{66A8ECE4F1B2549E}" {
+    m_iClothingType BACKPACK
+    m_ClothingPrefabs {
+     "{CE832B86D234AD62}Prefabs/Items/Equipment/Backpacks/CRF_Backpack_Invisable.et"
+    }
+   }
+   CRF_Clothing "{66A8ECE4F1B2549A}" {
+    m_iClothingType HEADGEAR
+    m_ClothingPrefabs {
+     "{32A9B6C3F80142A2}Prefabs/Characters/HeadGear/Helmet_ECH/Helmet_ECH_hc_v_r_p_cd.et"
+     "{0B262DD9B6D67DFE}Prefabs/Characters/HeadGear/Hat_Boonie_US_01/Hat_Boonie_US_DPM_01.et"
+     "{6E3CF6FD00EEDA1D}Prefabs/Characters/HeadGear/Hat_Knitted_01/Cap_Comforter_OD_02.et"
+     "{3DB2720B303DF396}Prefabs/Characters/HeadGear/Helmet_ECH/Helmet_ECH_lc_r.et"
+    }
+   }
+   CRF_Clothing "{66A8ECE4F1B2546D}" {
+    m_iClothingType SHIRT
+    m_ClothingPrefabs {
+     "{5167171CEE14E291}Prefabs/Characters/Uniforms/Smock_Combat_Rolled_84Pat_DPM_01.et"
+     "{C0FF8A6F0EE9ECB0}Prefabs/Characters/Uniforms/Smock_Combat_84Pat_DPM_01.et"
+    }
+   }
+   CRF_Clothing "{66A8ECE4F1B25469}" {
+    m_iClothingType PANTS
+    m_ClothingPrefabs {
+     "{20D80A4DAA97F6CF}Prefabs/Characters/Uniforms/Trousers_Combat_84Pat_DPM_01.et"
+    }
+   }
+   CRF_Clothing "{66A8ECE4F1B2546B}" {
+    m_iClothingType BOOTS
+    m_ClothingPrefabs {
+     "{AB9E3D5524876346}Prefabs/Characters/Footwear/Boots_Faradey_1085/Footware_Faradey_1085.et"
+    }
+   }
+   CRF_Clothing "{66A8ECE4F1B25466}" {
+    m_iClothingType VEST
+    m_ClothingPrefabs {
+     "{9713FE6DDCC9510D}Prefabs/Characters/Vests/Vest_Lifchik/Vest_Lifchik.et"
+    }
+   }
+   CRF_Clothing "{66A8ECEC17EB9A17}" {
+    m_iClothingType ARMOREDVEST
+    m_ClothingPrefabs {
+     "{ADE19B33DCBB9005}Prefabs/Characters/Vests/Vest_6B2/Vest_6B2.et"
+    }
+   }
+  }
+  m_DefaultInventoryItems {
+   CRF_Inventory_Item "{66A8ECE4F1B25460}" {
+    m_sItemPrefab "{575EA58E67448C2A}Prefabs/Items/Equipment/Flashlights/Flashlight_Soviet_01/Flashlight_Soviet_01.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{66A8ECE4F1B25463}" {
+    m_sItemPrefab "{645C73791ECA1698}Prefabs/Weapons/Grenades/Grenade_RGD5.et"
+    m_iItemCount 2
+   }
+   CRF_Inventory_Item "{66A8ECE4F1B2547F}" {
+    m_sItemPrefab "{77EAE5E07DC4678A}Prefabs/Weapons/Grenades/Smoke_RDG2.et"
+    m_iItemCount 2
+   }
+   CRF_Inventory_Item "{66A8ECE4F1B25478}" {
+    m_sItemPrefab "{7CEF68E2BC68CE71}Prefabs/Items/Equipment/Compass/Compass_Adrianov.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{66A8ECE4F1B25441}" {
+    m_sItemPrefab "{13772C903CB5E4F7}Prefabs/Items/Equipment/Maps/PaperMap_01_folded.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{66A8ECE4F1B25443}" {
+    m_sItemPrefab "{7C53E6DE2E4BD8CB}Prefabs/Items/Equipment/Watches/Watch_GarminTactixBravo.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{66A8ECE4F1B2545F}" {
+    m_sItemPrefab "{C3F1FA1E2EC2B345}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_USSR_01.et"
+    m_iItemCount 2
+   }
+   CRF_Inventory_Item "{66A8ECE4F1B25458}" {
+    m_sItemPrefab "{80E75A71C29190DB}Prefabs/Items/Medicine/Tourniquet_01/Tourniquet_USSR_01.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{66A8ECE4F1B25459}" {
+    m_sItemPrefab "{6E35D94130954509}Prefabs/Items/Equipment/Accessories/ETool_ALICE/ETool_ALICE_FreeRoamBuilding_Gadget.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{66A8ECE4F1B25454}" {
+    m_sItemPrefab "{8554ED3F088BADA6}Prefabs/Items/Core/Wirecutters/wirecutters.et"
+    m_iItemCount 1
+   }
+   CRF_Inventory_Item "{66A8ECE4F1B25457}" {
+    m_sItemPrefab "{CBF9B9942E07B6B8}Prefabs/Items/Equipment/Accessories/ZipCuffs/ACE_Captives_ZipCuffs.et"
+    m_iItemCount 2
+   }
+   CRF_Inventory_Item "{66A8ECE4F1B25453}" {
+    m_sItemPrefab "{AE2B7341B5A82545}Prefabs/Items/PersonalBelongings/PersonalBelongings_FIA.et"
+    m_iItemCount 0
+   }
+  }
+ }
+ m_CustomFactionGear CRF_Custom_Gear "{66A8ECE4F1B2542F}" {
+  m_RolesToSetCustomGear {
+   CRF_Role_Custom_Gear "{66A8ECE4F1B25428}" {
+    m_Role VEHICLE_LEAD
+    m_Clothing {
+     CRF_Clothing "{66A8ECE4F1B2542A}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{78C9B02C0CBD594C}Prefabs/Characters/Uniforms/Jacket_Tanker_USSR_01/Jacket_Tanker_USSR_01.et"
+      }
+     }
+     CRF_Clothing "{66A8ECE4F1B25426}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       "{27494A16F172A97B}Prefabs/Characters/Uniforms/Pants_Tanker_USSR_01/Pants_Tanker_USSR_01.et"
+       "{DC91A67E1074AAC0}Prefabs/Characters/Uniforms/Pants_Tanker_USSR_01/Pants_Tanker_USSR_01_tucked.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B2543D}" {
+    m_Role INDIRECT_LEAD
+    m_AdditionalInventoryItems {
+     CRF_Inventory_Item "{66A8ECE4F1B2543E}" {
+      m_sItemPrefab "{B41607EAB58A4252}Prefabs/Items/Equipment/BalisticTable/BalisticTable_USSR.et"
+      m_iItemCount 1
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B25439}" {
+    m_Role LOGI_LEAD
+    m_Clothing {
+     CRF_Clothing "{66A8ECE4F1B2543A}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{CAEDE923EF4071AE}Prefabs/Items/Equipment/Backpacks/Backpack_Suharka_type1.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B25435}" {
+    m_Role MEDICAL_OFFICER
+    m_Clothing {
+     CRF_Clothing "{66A8ECE4F1B25437}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{7AC107CA7AFC9B59}Prefabs/Items/Equipment/Backpacks/Backpack_Medical_Soviet.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B25432}" {
+    m_Role MEDIC
+    m_Clothing {
+     CRF_Clothing "{66A8ECE4F1B2540C}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{7AC107CA7AFC9B59}Prefabs/Items/Equipment/Backpacks/Backpack_Medical_Soviet.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B2540D}" {
+    m_Role ASSISTANT_AUTOMATIC_RIFLEMAN
+    m_Clothing {
+     CRF_Clothing "{66A8ECE4F1B2540F}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{CAEDE923EF4071AE}Prefabs/Items/Equipment/Backpacks/Backpack_Suharka_type1.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B25409}" {
+    m_Role ASSISTANT_RIFLEMAN_ANTITANK
+    m_Clothing {
+     CRF_Clothing "{66A8ECE4F1B2540A}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{6A39B5843B3F36DA}Prefabs/Items/Equipment/Backpacks/Backpack_RPG_Assistant.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B25405}" {
+    m_Role RIFLEMAN_ANTITANK
+    m_Clothing {
+     CRF_Clothing "{66A8ECE4F1B25406}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{0D39750E5695B9D8}Prefabs/Items/Equipment/Backpacks/Backpack_RPG_Gunner.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B25401}" {
+    m_Role HEAVY_ANTITANK
+    m_Clothing {
+     CRF_Clothing "{66A8ECE4F1B25402}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{41A9C55B61F375F0}Prefabs/Items/Equipment/Backpacks/Backpack_Kolobok.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B25418}" {
+    m_Role MEDIUM_ANTITANK
+    m_Clothing {
+     CRF_Clothing "{66A8ECE4F1B2541A}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{0D39750E5695B9D8}Prefabs/Items/Equipment/Backpacks/Backpack_RPG_Gunner.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B2541B}" {
+    m_Role ASSISTANT_HEAVY_ANTITANK
+    m_Clothing {
+     CRF_Clothing "{66A8ECE4F1B25415}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{6A39B5843B3F36DA}Prefabs/Items/Equipment/Backpacks/Backpack_RPG_Assistant.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B25417}" {
+    m_Role ASSISTANT_MEDIUM_ANTITANK
+    m_Clothing {
+     CRF_Clothing "{66A8ECE4F1B25411}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{6A39B5843B3F36DA}Prefabs/Items/Equipment/Backpacks/Backpack_RPG_Assistant.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B25412}" {
+    m_Role ASSISTANT_HEAVY_MACHINEGUN
+    m_Clothing {
+     CRF_Clothing "{66A8ECE4F1B253EC}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{CAEDE923EF4071AE}Prefabs/Items/Equipment/Backpacks/Backpack_Suharka_type1.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B253EE}" {
+    m_Role ASSISTANT_MEDIUM_MACHINEGUN
+    m_Clothing {
+     CRF_Clothing "{66A8ECE4F1B253EF}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{CAEDE923EF4071AE}Prefabs/Items/Equipment/Backpacks/Backpack_Suharka_type1.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B253E9}" {
+    m_Role ASSISTANT_ANTI_AIR
+    m_Clothing {
+     CRF_Clothing "{66A8ECE4F1B253EB}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{6A39B5843B3F36DA}Prefabs/Items/Equipment/Backpacks/Backpack_RPG_Assistant.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B253E5}" {
+    m_Role VEHICLE_DRIVER
+    m_Clothing {
+     CRF_Clothing "{66A8ECE4F1B253E7}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{78C9B02C0CBD594C}Prefabs/Characters/Uniforms/Jacket_Tanker_USSR_01/Jacket_Tanker_USSR_01.et"
+      }
+     }
+     CRF_Clothing "{66A8ECE4F1B253E0}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       "{27494A16F172A97B}Prefabs/Characters/Uniforms/Pants_Tanker_USSR_01/Pants_Tanker_USSR_01.et"
+       "{DC91A67E1074AAC0}Prefabs/Characters/Uniforms/Pants_Tanker_USSR_01/Pants_Tanker_USSR_01_tucked.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B253E2}" {
+    m_Role VEHICLE_GUNNER
+    m_Clothing {
+     CRF_Clothing "{66A8ECE4F1B253FC}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{78C9B02C0CBD594C}Prefabs/Characters/Uniforms/Jacket_Tanker_USSR_01/Jacket_Tanker_USSR_01.et"
+      }
+     }
+     CRF_Clothing "{66A8ECE4F1B253DA}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       "{27494A16F172A97B}Prefabs/Characters/Uniforms/Pants_Tanker_USSR_01/Pants_Tanker_USSR_01.et"
+       "{DC91A67E1074AAC0}Prefabs/Characters/Uniforms/Pants_Tanker_USSR_01/Pants_Tanker_USSR_01_tucked.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B253D4}" {
+    m_Role VEHICLE_LOADER
+    m_Clothing {
+     CRF_Clothing "{66A8ECE4F1B253D6}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{78C9B02C0CBD594C}Prefabs/Characters/Uniforms/Jacket_Tanker_USSR_01/Jacket_Tanker_USSR_01.et"
+      }
+     }
+     CRF_Clothing "{66A8ECE4F1B253D0}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       "{27494A16F172A97B}Prefabs/Characters/Uniforms/Pants_Tanker_USSR_01/Pants_Tanker_USSR_01.et"
+       "{DC91A67E1074AAC0}Prefabs/Characters/Uniforms/Pants_Tanker_USSR_01/Pants_Tanker_USSR_01_tucked.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B253D1}" {
+    m_Role PILOT
+    m_Clothing {
+     CRF_Clothing "{66A8ECE4F1B253D3}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{6835DAF42A09E23C}Prefabs/Characters/Uniforms/Jacket_Pilot_USSR_01/Jacket_Pilot_USSR_01.et"
+      }
+     }
+     CRF_Clothing "{66A8ECE4F1B253A8}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       "{83DFA8F68CA40B10}Prefabs/Characters/Uniforms/Pants_Pilot_USSR_01/Pants_Pilot_USSR_01.et"
+       "{6B7F32F1F8A191B0}Prefabs/Characters/Uniforms/Pants_Pilot_USSR_01/Pants_Pilot_USSR_01_tucked.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B253AA}" {
+    m_Role CREW_CHIEF
+    m_Clothing {
+     CRF_Clothing "{66A8ECE4F1B253AB}" {
+      m_iClothingType SHIRT
+      m_ClothingPrefabs {
+       "{6835DAF42A09E23C}Prefabs/Characters/Uniforms/Jacket_Pilot_USSR_01/Jacket_Pilot_USSR_01.et"
+      }
+     }
+     CRF_Clothing "{66A8ECE4F1B253A4}" {
+      m_iClothingType PANTS
+      m_ClothingPrefabs {
+       "{83DFA8F68CA40B10}Prefabs/Characters/Uniforms/Pants_Pilot_USSR_01/Pants_Pilot_USSR_01.et"
+       "{6B7F32F1F8A191B0}Prefabs/Characters/Uniforms/Pants_Pilot_USSR_01/Pants_Pilot_USSR_01_tucked.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B253A5}" {
+    m_Role LOGI_RUNNER
+    m_Clothing {
+     CRF_Clothing "{66A8ECE4F1B253A6}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{CAEDE923EF4071AE}Prefabs/Items/Equipment/Backpacks/Backpack_Suharka_type1.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B253A0}" {
+    m_Role INDIRECT_GUNNER
+    m_Clothing {
+     CRF_Clothing "{66A8ECE4F1B253A1}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{EE53109CB37C43B1}Prefabs/Items/Equipment/Backpacks/M2/Backpack_m252_Mortar_Weapon.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B253BC}" {
+    m_Role INDIRECT_LOADER
+    m_Clothing {
+     CRF_Clothing "{66A8ECE4F1B253BD}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{A207909C42E58944}Prefabs/Items/Equipment/Backpacks/Backpack_US_Tripod.et"
+      }
+     }
+    }
+    m_AdditionalInventoryItems {
+     CRF_Inventory_Item "{66A8ECE65C55DACF}" {
+      m_sItemPrefab "{38BAE094333E31BF}Prefabs/Weapons/Ammo/Ammo_Shell_81mm_HE_M821.et"
+      m_iItemCount 40
+     }
+     CRF_Inventory_Item "{66A8ECE68F049437}" {
+      m_sItemPrefab "{DD2065AE34D8DFA9}Prefabs/Weapons/Ammo/Ammo_Shell_81mm_Illum_M853A1.et"
+      m_iItemCount 20
+     }
+     CRF_Inventory_Item "{66A8ECE6969826B8}" {
+      m_sItemPrefab "{F7807293E94D3C88}Prefabs/Weapons/Ammo/Ammo_Shell_81mm_Smoke_M819.et"
+      m_iItemCount 20
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B253B9}" {
+    m_Role RIFLEMAN_DEMO
+    m_AdditionalInventoryItems {
+     CRF_Inventory_Item "{66A8ECE4F1B253BB}" {
+      m_sItemPrefab "{73F69547963CAEE0}PrefabsEditable/Explosives/E_DemoBlock_TSh400g.et"
+      m_iItemCount 2
+     }
+     CRF_Inventory_Item "{66A8ECE4F1B253B7}" {
+      m_sItemPrefab "{90976DC90A223095}Prefabs/Items/Equipment/Detonators/BlastingMachine_KPM_3U1/BlastingMachine_KPM_3U1.et"
+      m_iItemCount 2
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B2538D}" {
+    m_Role COMBAT_ENGINEER
+    m_AdditionalInventoryItems {
+     CRF_Inventory_Item "{66A8ECE4F1B2538F}" {
+      m_sItemPrefab "{73F69547963CAEE0}PrefabsEditable/Explosives/E_DemoBlock_TSh400g.et"
+      m_iItemCount 1
+     }
+     CRF_Inventory_Item "{66A8ECE4F1B25388}" {
+      m_sItemPrefab "{90976DC90A223095}Prefabs/Items/Equipment/Detonators/BlastingMachine_KPM_3U1/BlastingMachine_KPM_3U1.et"
+      m_iItemCount 1
+     }
+     CRF_Inventory_Item "{66A8ECE4F1B2538A}" {
+      m_sItemPrefab "{2E5BFBBBC0AD79CE}Prefabs/Weapons/Explosives/Explosive_Satchels/OPFOR_Satchel.et"
+      m_iItemCount 3
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B2538B}" {
+    m_Role HEAVY_MACHINEGUN
+    m_Clothing {
+     CRF_Clothing "{66A8ECE4F1B25385}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{B4C47869B0B37699}Prefabs/Items/Equipment/Backpacks/NSV/Backpack_NSV_Weapon.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B25381}" {
+    m_Role ASSISTANT_HEAVY_MACHINEGUN
+    m_Clothing {
+     CRF_Clothing "{66A8ECE4F1B25383}" {
+      m_iClothingType BACKPACK
+      m_ClothingPrefabs {
+       "{7611D0DAE5796941}Prefabs/Items/Equipment/Backpacks/Backpack_USSR_Bipod.et"
+      }
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE4F1B2539D}" {
+    m_Role RIFLEMAN
+    m_sRoleName "Combat Life Saver"
+    m_AdditionalInventoryItems {
+     CRF_Inventory_Item "{66A8ECE4F1B2539F}" {
+      m_sItemPrefab "{527D7C5D2E476BDC}Prefabs/Items/Medicine/SalineBag_01/SalineBag_USSR_01.et"
+      m_iItemCount 4
+     }
+     CRF_Inventory_Item "{66A8ECE4F1B25398}" {
+      m_sItemPrefab "{C3F1FA1E2EC2B345}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_USSR_01.et"
+      m_iItemCount 10
+     }
+     CRF_Inventory_Item "{66A8ECE4F1B25399}" {
+      m_sItemPrefab "{80E75A71C29190DB}Prefabs/Items/Medicine/Tourniquet_01/Tourniquet_USSR_01.et"
+      m_iItemCount 3
+     }
+     CRF_Inventory_Item "{66A8ECE4F1B27E74}" {
+      m_sItemPrefab "{58CF3AB87C441295}Prefabs/Items/Medicine/AmmoniumCarbonatePackage/ACE_Medical_AmmoniumCarbonatePackage.et"
+      m_iItemCount 10
+     }
+    }
+   }
+   CRF_Role_Custom_Gear "{66A8ECE6FDF6C36D}" {
+    m_Role TEAM_LEAD
+    m_sRoleName "Team Lead & CLS"
+    m_AdditionalInventoryItems {
+     CRF_Inventory_Item "{66A8ECE6CB2DECDD}" {
+      m_sItemPrefab "{C3F1FA1E2EC2B345}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_USSR_01.et"
+      m_iItemCount 5
+     }
+     CRF_Inventory_Item "{66A8ECE6CB454087}" {
+      m_sItemPrefab "{527D7C5D2E476BDC}Prefabs/Items/Medicine/SalineBag_01/SalineBag_USSR_01.et"
+      m_iItemCount 3
+     }
+    }
+   }
+  }
+ }
+}

--- a/Configs/Gearscripts/Custom/Harry/PressureChange/CRF_GS_Modern_Rebels_Harry_.conf.meta
+++ b/Configs/Gearscripts/Custom/Harry/PressureChange/CRF_GS_Modern_Rebels_Harry_.conf.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{9A5DE8646E2297A5}Configs/Gearscripts/Custom/Harry/Circumstance/CRF_GS_Modern_Rebels_Harry_.conf"
+ Configurations {
+  CONFResourceClass PC {
+  }
+  CONFResourceClass XBOX_ONE : PC {
+  }
+  CONFResourceClass XBOX_SERIES : PC {
+  }
+  CONFResourceClass PS4 : PC {
+  }
+  CONFResourceClass PS5 : PC {
+  }
+  CONFResourceClass HEADLESS : PC {
+  }
+  CONFResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Missions/Harry_SO113_PressureChange.conf
+++ b/Missions/Harry_SO113_PressureChange.conf
@@ -1,0 +1,14 @@
+SCR_MissionHeader {
+ World "{43F3DCE0995D4C3A}Worlds/COALobby/Ruha/Harry_SO_PressureChange.ent"
+ m_sName "CRF SO113 Pressure Change"
+ m_sAuthor "Harry"
+ m_sDescription "It takes two to tango."
+ m_sIcon "{B7385DA4504BD4D5}CRF Images/crflogo.edds"
+ m_sLoadingScreen "{B7385DA4504BD4D5}CRF Images/crflogo.edds"
+ m_sPreviewImage "{B7385DA4504BD4D5}CRF Images/crflogo.edds"
+ m_sGameMode "Strike Objective"
+ m_iPlayerCount 113
+ m_iStartingHours 12
+ m_iMapMarkerLimitPerPlayer 120
+ m_sTerrainName "Ruha"
+}

--- a/Missions/Harry_SO113_PressureChange.conf.meta
+++ b/Missions/Harry_SO113_PressureChange.conf.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{DFEDD42705A8B029}Missions/Harry_SO113_PressureChange.conf"
+ Configurations {
+  CONFResourceClass PC {
+  }
+  CONFResourceClass XBOX_ONE : PC {
+  }
+  CONFResourceClass XBOX_SERIES : PC {
+  }
+  CONFResourceClass PS4 : PC {
+  }
+  CONFResourceClass PS5 : PC {
+  }
+  CONFResourceClass HEADLESS : PC {
+  }
+  CONFResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M923A1/VehParts/M923A1_engineer_box_test.et
+++ b/Prefabs/Vehicles/Wheeled/M923A1/VehParts/M923A1_engineer_box_test.et
@@ -8,9 +8,10 @@ GenericEntity : "{0CD6E71D33E1CCD0}Prefabs/Vehicles/Core/Vehicle_EngineerBox_Bas
   }
   SCR_CampaignBuildingProviderComponent "{5DF54421B01A7FF8}" {
    m_bUserActionActivationOnly 0
+   m_fBuildingRadius 50
    m_iRank RENEGADE
    m_aAvailableTraits {
-    0 0 108
+    0 28 108
    }
   }
   SCR_DamageManagerComponent "{3EBB276D48AFFF41}" {
@@ -20,6 +21,11 @@ GenericEntity : "{0CD6E71D33E1CCD0}Prefabs/Vehicles/Core/Vehicle_EngineerBox_Bas
       m_sWreckModel "{A98B342A8B226409}Assets/Vehicles/Wheeled/M923A1/M923A1_Cargo_Wreck.xob"
      }
     }
+   }
+  }
+  SCR_ResourceComponent "{5D82E3A391ED9E1F}" {
+   m_aDisabledResourceTypes {
+    0
    }
   }
   SlotManagerComponent "{64F52C1673613887}" {

--- a/Worlds/COALobby/Ruha/Harry_SO_PressureChange.ent
+++ b/Worlds/COALobby/Ruha/Harry_SO_PressureChange.ent
@@ -1,0 +1,3 @@
+SubScene {
+ Parent "{31A1248EA401F22C}worlds/Ruha.ent"
+}

--- a/Worlds/COALobby/Ruha/Harry_SO_PressureChange.ent.meta
+++ b/Worlds/COALobby/Ruha/Harry_SO_PressureChange.ent.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{43F3DCE0995D4C3A}Worlds/COALobby/Ruha/Harry_SO_PressureChange.ent"
+ Configurations {
+  ENTResourceClass PC {
+  }
+  ENTResourceClass XBOX_ONE : PC {
+  }
+  ENTResourceClass XBOX_SERIES : PC {
+  }
+  ENTResourceClass PS4 : PC {
+  }
+  ENTResourceClass PS5 : PC {
+  }
+  ENTResourceClass HEADLESS : PC {
+  }
+  ENTResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Worlds/COALobby/Ruha/Harry_SO_PressureChange_Layers/aaInit.layer
+++ b/Worlds/COALobby/Ruha/Harry_SO_PressureChange_Layers/aaInit.layer
@@ -15,7 +15,7 @@ CRF_Gamemode CRF_Lobby1 : "{6A996BBFCEB37E78}Prefabs/MP/Modes/Lobby/CRF_Lobby.et
  m_iTimeLimitMinutes 60
  m_aMissionDescriptors {
   CRF_MissionDescriptor "{644250503DF684C0}" {
-   m_sTextData "Competing seperatist groups are vying for contorl in the area. Blufor has deployed recon teams to find, and destroy two targets in the area by calling in indirect fire. "\
+   m_sTextData "Competing separatist groups are vying for control in the area. Blufor has deployed recon teams to find, and destroy two targets in the area by calling in indirect fire. "\
    ""\
    "BLUFOR Composition: Inf"\
    "BLUFOR Assets: MMGs, Mortars, Eng Trucks"\

--- a/Worlds/COALobby/Ruha/Harry_SO_PressureChange_Layers/aaInit.layer
+++ b/Worlds/COALobby/Ruha/Harry_SO_PressureChange_Layers/aaInit.layer
@@ -1,0 +1,147 @@
+SCR_AIWorld : "{65DEC16960498027}Prefabs/AI/SCR_AIWorld_Ruha.et" {
+ coords 5918.651 129.34 7994.963
+}
+CRF_Gamemode CRF_Lobby1 : "{6A996BBFCEB37E78}Prefabs/MP/Modes/Lobby/CRF_Lobby.et" {
+ components {
+  SCR_InitWeatherComponent "{64427EEC0AFF43EE}" {
+   m_sInitialStartingWeatherId "Dry Thunder (Overcast)"
+  }
+  SCR_TimeAndWeatherHandlerComponent "{64427EEC304DD9A0}" {
+   m_iStartingHours 2
+   m_iStartingMinutes 25
+  }
+ }
+ coords 5915.288 327.839 7983.258
+ m_iTimeLimitMinutes 60
+ m_aMissionDescriptors {
+  CRF_MissionDescriptor "{644250503DF684C0}" {
+   m_sTextData "Competing seperatist groups are vying for contorl in the area. Blufor has deployed recon teams to find, and destroy two targets in the area by calling in indirect fire. "\
+   ""\
+   "BLUFOR Composition: Inf"\
+   "BLUFOR Assets: MMGs, Mortars, Eng Trucks"\
+   ""\
+   "OPFOR Composition: Moto inf"\
+   "OPFOR Assets: Armed humvee, MMGs, MAT"\
+   ""\
+   "Time: 60 min"\
+   "Weather: Night Overcast"
+  }
+  CRF_MissionDescriptor "{64425051F2E00216}" {
+   m_sTextData "Find the targets, and destroy them with mortar fire. You have two engineering trucks that do not consume supplies, do not build any defenses containing assets."\
+   ""\
+   "Targets:"\
+   "- Ammo depot"\
+   "- Urban command structure"
+  }
+  CRF_MissionDescriptor "{64425051B9B5AF67}" {
+   m_sTextData "Locate, and destroy the blufor mortar base before recon can locate the targets, and destroy them with indirect fire. Blufor has approximate locations of possible target locations."\
+   ""\
+   "Targets:"\
+   "- Ammo depot"\
+   "- Urban command post"
+  }
+  CRF_MissionDescriptor "{6442505149CF6C93}" {
+   m_sTextData "Team lead has been combined with the CLS role. Rifleman demo have had their satchel removed, and given a second detonator. "
+   m_bShowForAnyFaction 1
+  }
+ }
+ m_sFactionOneKey "BLU"
+ m_sFactionTwoKey "OPF"
+ m_BLUFORGearScriptSettings CRF_GearScriptContainer "{64570ACB9B419A7B}" {
+  m_rGearScript "{9A5DE8646E2297A5}Configs/Gearscripts/Custom/Harry/PressureChange/CRF_GS_Modern_Rebels_Harry_.conf"
+ }
+ m_OPFORGearScriptSettings CRF_GearScriptContainer "{64570ACB9B11EAAD}" {
+  m_rGearScript "{AC1CC557967D9AC9}Configs/Gearscripts/Custom/Harry/PressureChange/CRF_GS_FIA_Modern_.conf"
+ }
+ {
+  SCR_FactionManager {
+   ID "632A77473B3CC3A8"
+   Factions {
+    SCR_Faction "{628B22E9B4056C88}" {
+     m_CallsignInfo SCR_FactionCallsignInfo "{5DA0F2A6677ADA9E}" {
+      m_aSquadNames {
+       SCR_CallsignInfo "{55CCB792D10AD8F4}" {
+        m_sCallsign "COY"
+       }
+       SCR_CallsignInfo "{55CCB792D13759D8}" {
+        m_sCallsign "Medical"
+       }
+       SCR_CallsignInfo "{55CCB792D1218E95}" {
+        m_sCallsign "1PLT"
+       }
+       SCR_CallsignInfo "{55CCB792D0C8B3CE}" {
+        m_sCallsign "1-1"
+       }
+       SCR_CallsignInfo "{66A8ECE556B6C9BD}" {
+        m_sCallsign "1-2"
+       }
+       SCR_CallsignInfo "{66A8ECE556D89BD9}" {
+        m_sCallsign "MMG-1"
+       }
+       SCR_CallsignInfo "{66A8ECE555A7E39F}" {
+        m_sCallsign "2PLT"
+       }
+       SCR_CallsignInfo "{66A8ECE5543A6F6C}" {
+        m_sCallsign "2-1"
+       }
+       SCR_CallsignInfo "{66A8ECE554807077}" {
+        m_sCallsign "2-2"
+       }
+       SCR_CallsignInfo "{66A8ECE55B29E4E9}" {
+        m_sCallsign "MMG-2"
+       }
+       SCR_CallsignInfo "{66A8ECE55BCCF3D8}" {
+        m_sCallsign "Mortars"
+       }
+       SCR_CallsignInfo "{66A8ECE55A93964D}" {
+        m_sCallsign "Recon-1"
+       }
+       SCR_CallsignInfo "{66A8ECE5592437A2}" {
+        m_sCallsign "Recon-2"
+       }
+      }
+     }
+    }
+    SCR_Faction "{628C2D2BFC8C6447}" {
+     m_CallsignInfo SCR_FactionCallsignInfo "{5DA0F2A67DFB8809}" {
+      m_aSquadNames {
+       SCR_CallsignInfo "{55CCB79287E901BC}" {
+        m_sCallsign "COY"
+       }
+       SCR_CallsignInfo "{55CCB79287936EBD}" {
+        m_sCallsign "Medical"
+       }
+       SCR_CallsignInfo "{55CCB79287BAFBD6}" {
+        m_sCallsign "1PLT"
+       }
+       SCR_CallsignInfo "{55CCB79287A4D7B6}" {
+        m_sCallsign "1-1"
+       }
+       SCR_CallsignInfo "{66A8ECE597BD4FE5}" {
+        m_sCallsign "1-2"
+       }
+       SCR_CallsignInfo "{66A8ECE59590B01D}" {
+        m_sCallsign "Weapons-1"
+       }
+       SCR_CallsignInfo "{66A8ECE5946CF8EB}" {
+        m_sCallsign "2PLT"
+       }
+       SCR_CallsignInfo "{66A8ECE594EBB6E1}" {
+        m_sCallsign "2-1"
+       }
+       SCR_CallsignInfo "{66A8ECE59B02F6FB}" {
+        m_sCallsign "2-2"
+       }
+       SCR_CallsignInfo "{66A8ECE59BB669E9}" {
+        m_sCallsign "Weapons-2"
+       }
+       SCR_CallsignInfo "{66A8ECE5E085CF5A}" {
+        m_sCallsign "Humvee"
+       }
+      }
+     }
+    }
+   }
+  }
+ }
+}

--- a/Worlds/COALobby/Ruha/Harry_SO_PressureChange_Layers/blufor.layer
+++ b/Worlds/COALobby/Ruha/Harry_SO_PressureChange_Layers/blufor.layer
@@ -1,0 +1,103 @@
+$grp SCR_VehicleSpawn {
+ {
+  coords 5917.68 55.534 7989.495
+  m_rnPrefab "{C4ED6708B5B79777}Prefabs/Vehicles/Wheeled/M923A1/M923A1_engineer_BLUFOR.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+ {
+  coords 5924.909 55.507 7989.097
+  m_rnPrefab "{C4ED6708B5B79777}Prefabs/Vehicles/Wheeled/M923A1/M923A1_engineer_BLUFOR.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+ {
+  coords 6019.331 54.818 7952.254
+  angleY 179.303
+  m_rnPrefab "{5555DCAFADB8CE2A}Prefabs/Vehicles/Wheeled/S105/S105_rally.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+ {
+  coords 6011.372 54.916 7951.688
+  angleY 179.303
+  m_rnPrefab "{5555DCAFADB8CE2A}Prefabs/Vehicles/Wheeled/S105/S105_rally.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+}
+SCR_AIGroup : "{EE91BF23FBC94408}Prefabs/Groups/BLUFOR/Standard/Command/CRF_BLUFOR_Company_p.et" {
+ coords 6019.077 54.19 8018.77
+ {
+  SCR_AIGroup : "{D0B17EDF43465305}Prefabs/Groups/BLUFOR/Standard/Support/CRF_BLUFOR_MedicTeam_p.et" {
+   coords -41.66 0.104 -1.586
+   {
+    SCR_AIGroup : "{3D4D53B053964445}Prefabs/Groups/BLUFOR/Standard/Command/CRF_BLUFOR_Platoon_p.et" {
+     coords 41.514 -0.138 5.953
+     {
+      $grp SCR_AIGroup : "{9C45BAF40F909576}Prefabs/Groups/BLUFOR/Standard/Infantry/CRF_BLUFOR_RifleSquad_p.et" {
+       {
+        coords -16.201 0.125 -6.721
+       }
+       {
+        coords -16.201 0.125 -4.034
+        {
+         SCR_AIGroup : "{2F07AC5EE3DE3921}Prefabs/Groups/BLUFOR/Standard/Support/CRF_BLUFOR_MMGTeam_p.et" {
+          coords -16.856 0.063 12.888
+          m_aUnitPrefabSlots {
+           "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{232780260F9004E6}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_MMG_P.et" "{0CF6A9358BCE5E57}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AMMG_P.et"
+          }
+          {
+           SCR_AIGroup : "{3D4D53B053964445}Prefabs/Groups/BLUFOR/Standard/Command/CRF_BLUFOR_Platoon_p.et" {
+            coords 33.604 -0.178 -5.357
+            {
+             $grp SCR_AIGroup : "{9C45BAF40F909576}Prefabs/Groups/BLUFOR/Standard/Infantry/CRF_BLUFOR_RifleSquad_p.et" {
+              {
+               coords -16.747 0.115 0.606
+              }
+              {
+               coords -16.747 0.115 4.265
+               {
+                SCR_AIGroup : "{2F07AC5EE3DE3921}Prefabs/Groups/BLUFOR/Standard/Support/CRF_BLUFOR_MMGTeam_p.et" {
+                 coords -15.158 0.032 -9.937
+                 m_aUnitPrefabSlots {
+                  "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{232780260F9004E6}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_MMG_P.et" "{0CF6A9358BCE5E57}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_AMMG_P.et"
+                 }
+                 {
+                  SCR_AIGroup : "{3CF105AFDCEA45A3}Prefabs/Groups/BLUFOR/Standard/Support/CRF_BLUFOR_IndirectTeam_p.et" {
+                   coords -10.016 0.044 6.331
+                   {
+                    $grp SCR_AIGroup : "{677549B9DAF416D1}Prefabs/Groups/BLUFOR/Standard/Support/CRF_BLUFOR_SniperTeam_p.et" {
+                     {
+                      coords 35.741 -0.129 15.334
+                      m_aUnitPrefabSlots {
+                       "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{49CC52FEE609771E}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_Spotter_P.et"
+                      }
+                     }
+                     {
+                      coords 28.083 -0.101 14.344
+                      m_aUnitPrefabSlots {
+                       "{CC8EDD051CB0C1CE}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_SL_P.et" "{49CC52FEE609771E}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_Spotter_P.et"
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+          }
+         }
+        }
+       }
+      }
+     }
+    }
+   }
+  }
+ }
+}

--- a/Worlds/COALobby/Ruha/Harry_SO_PressureChange_Layers/mortars.layer
+++ b/Worlds/COALobby/Ruha/Harry_SO_PressureChange_Layers/mortars.layer
@@ -1,0 +1,394 @@
+$grp GenericEntity : "{2323F9E4C524F047}Prefabs/Compositions/Slotted/SlotFlatSmall/MortarPlacement_S_US_01.et" {
+ {
+  coords 5888.07 55.469 8007.125
+  angleY 177.271
+ }
+ {
+  coords 5899.276 55.443 8007.66
+  angleY 175.802
+ }
+}
+$grp GenericEntity : "{52E67D46C7855822}Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_Large_01/SupplyStack_Large_01_storage_US_covered.et" {
+ {
+  components {
+   SCR_ResourceComponent "{5D247A59598D71AE}" {
+    m_aContainers {
+     SCR_ResourceContainer "{5D3CDAE74F1A6127}" {
+      m_fResourceValueCurrent 500
+      m_fResourceValueMax 500
+     }
+    }
+   }
+  }
+  coords 5893.777 55.44 8009.626
+  angleY -88.7
+  {
+   GenericEntity {
+    ID "5D3085BCA5EF72EE"
+    coords 0 0 0
+   }
+  }
+ }
+ {
+  components {
+   SCR_ResourceComponent "{5D247A59598D71AE}" {
+    m_aContainers {
+     SCR_ResourceContainer "{5D3CDAE74F1A6127}" {
+      m_fResourceValueCurrent 500
+      m_fResourceValueMax 500
+     }
+    }
+   }
+  }
+  coords 5894.916 55.44 8004.593
+  angleY -88.7
+  {
+   GenericEntity {
+    ID "5D3085BCA5EF72EE"
+    coords 0 0 0
+   }
+  }
+ }
+ {
+  components {
+   SCR_ResourceComponent "{5D247A59598D71AE}" {
+    m_aContainers {
+     SCR_ResourceContainer "{5D3CDAE74F1A6127}" {
+      m_fResourceValueCurrent 500
+      m_fResourceValueMax 500
+     }
+    }
+   }
+  }
+  coords 5893.854 55.44 8006.927
+  angleY -88.7
+  {
+   GenericEntity {
+    ID "5D3085BCA5EF72EE"
+    coords 0 0 0
+   }
+  }
+ }
+ {
+  components {
+   SCR_ResourceComponent "{5D247A59598D71AE}" {
+    m_aContainers {
+     SCR_ResourceContainer "{5D3CDAE74F1A6127}" {
+      m_fResourceValueCurrent 500
+      m_fResourceValueMax 500
+     }
+    }
+   }
+  }
+  coords 5893.602 55.44 8003.377
+  angleY -88.7
+  {
+   GenericEntity {
+    ID "5D3085BCA5EF72EE"
+    coords 0 0 0
+   }
+  }
+ }
+}
+$grp GenericEntity : "{73F8306941E09593}Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_01/SupplyStack_01_V6_storage_US_covered.et" {
+ {
+  coords 5894.954 55.44 8009.604
+  angleY -88.7
+  {
+   GenericEntity {
+    ID "5D30E783815E7DC1"
+    coords 0 0 0
+   }
+  }
+ }
+ {
+  coords 5892.669 55.44 8008.304
+  angleY 93.266
+  {
+   GenericEntity {
+    ID "5D30E783815E7DC1"
+    coords 0 0 0
+   }
+  }
+ }
+ {
+  coords 5892.852 55.44 8005.741
+  angleY 94.848
+  {
+   GenericEntity {
+    ID "5D30E783815E7DC1"
+    coords 0 0 0
+   }
+  }
+ }
+}
+$grp StaticModelEntity : "{94FB3A1BFFFF1A19}Prefabs/Structures/Military/Camps/TentUS_01/TentUS_01_Assembled_foundation.et" {
+ {
+  coords 5880.318 55.44 8036.762
+  angleY 14.352
+ }
+ {
+  coords 5871.73 55.44 8039.3
+  angleY 14.352
+ }
+}
+$grp GenericEntity : "{A2CBA1E941BC1EA5}Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_01/SupplyStack_01_V2.et" {
+ {
+  components {
+   SCR_ResourceComponent "{5D247A59598D71AE}" {
+    m_aContainers {
+     SCR_ResourceContainer "{5D3CDAE74F1A6127}" {
+      m_fResourceValueCurrent 100
+      m_fResourceValueMax 100
+     }
+    }
+   }
+  }
+  coords 5892.757 55.44 8010.819
+  angleY 95.329
+ }
+ {
+  components {
+   SCR_ResourceComponent "{5D247A59598D71AE}" {
+    m_aContainers {
+     SCR_ResourceContainer "{5D3CDAE74F1A6127}" {
+      m_fResourceValueCurrent 100
+      m_fResourceValueMax 100
+     }
+    }
+   }
+  }
+  coords 5892.645 55.44 8006.958
+  angleY 95.329
+ }
+ {
+  components {
+   SCR_ResourceComponent "{5D247A59598D71AE}" {
+    m_aContainers {
+     SCR_ResourceContainer "{5D3CDAE74F1A6127}" {
+      m_fResourceValueCurrent 100
+      m_fResourceValueMax 100
+     }
+    }
+   }
+  }
+  coords 5894.988 55.44 8007.005
+  angleY -88.7
+ }
+ {
+  components {
+   SCR_ResourceComponent "{5D247A59598D71AE}" {
+    m_aContainers {
+     SCR_ResourceContainer "{5D3CDAE74F1A6127}" {
+      m_fResourceValueCurrent 100
+      m_fResourceValueMax 100
+     }
+    }
+   }
+  }
+  coords 5892.907 55.44 8004.619
+  angleY 95.329
+ }
+ {
+  components {
+   SCR_ResourceComponent "{5D247A59598D71AE}" {
+    m_aContainers {
+     SCR_ResourceContainer "{5D3CDAE74F1A6127}" {
+      m_fResourceValueCurrent 100
+      m_fResourceValueMax 100
+     }
+    }
+   }
+  }
+  coords 5894.929 55.44 8005.823
+  angleY -88.7
+ }
+}
+GenericEntity : "{CDD0712FD6215F04}Prefabs/Compositions/Slotted/SlotFlatMedium/FieldHospital_M_US_01.et" {
+ coords 5937.765 55.688 7964.854
+ angleY -96.59
+}
+$grp GenericEntity : "{CE9F9509FD78918B}Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_01/SupplyStack_01_V1.et" {
+ {
+  components {
+   SCR_ResourceComponent "{5D247A59598D71AE}" {
+    m_aContainers {
+     SCR_ResourceContainer "{5D3CDAE74F1A6127}" {
+      m_fResourceValueCurrent 400
+      m_fResourceValueMax 400
+     }
+    }
+   }
+  }
+  coords 5894.802 55.44 8003.449
+  angleY -88.7
+ }
+ {
+  components {
+   SCR_ResourceComponent "{5D247A59598D71AE}" {
+    m_aContainers {
+     SCR_ResourceContainer "{5D3CDAE74F1A6127}" {
+      m_fResourceValueCurrent 400
+      m_fResourceValueMax 400
+     }
+    }
+   }
+  }
+  coords 5893.834 55.44 8005.704
+  angleY -88.7
+ }
+ {
+  components {
+   SCR_ResourceComponent "{5D247A59598D71AE}" {
+    m_aContainers {
+     SCR_ResourceContainer "{5D3CDAE74F1A6127}" {
+      m_fResourceValueCurrent 400
+      m_fResourceValueMax 400
+     }
+    }
+   }
+  }
+  coords 5893.779 55.44 8008.282
+  angleY -88.7
+ }
+ {
+  components {
+   SCR_ResourceComponent "{5D247A59598D71AE}" {
+    m_aContainers {
+     SCR_ResourceContainer "{5D3CDAE74F1A6127}" {
+      m_fResourceValueCurrent 400
+      m_fResourceValueMax 400
+     }
+    }
+   }
+  }
+  coords 5892.705 55.44 8007.018
+  angleY -88.7
+ }
+ {
+  components {
+   SCR_ResourceComponent "{5D247A59598D71AE}" {
+    m_aContainers {
+     SCR_ResourceContainer "{5D3CDAE74F1A6127}" {
+      m_fResourceValueCurrent 400
+      m_fResourceValueMax 400
+     }
+    }
+   }
+  }
+  coords 5892.652 55.44 8008.346
+  angleY -88.7
+ }
+ {
+  components {
+   SCR_ResourceComponent "{5D247A59598D71AE}" {
+    m_aContainers {
+     SCR_ResourceContainer "{5D3CDAE74F1A6127}" {
+      m_fResourceValueCurrent 400
+      m_fResourceValueMax 400
+     }
+    }
+   }
+  }
+  coords 5892.651 55.44 8009.655
+  angleY -88.7
+ }
+ {
+  components {
+   SCR_ResourceComponent "{5D247A59598D71AE}" {
+    m_aContainers {
+     SCR_ResourceContainer "{5D3CDAE74F1A6127}" {
+      m_fResourceValueCurrent 400
+      m_fResourceValueMax 400
+     }
+    }
+   }
+  }
+  coords 5892.893 55.44 8005.729
+  angleY -88.7
+ }
+ {
+  components {
+   SCR_ResourceComponent "{5D247A59598D71AE}" {
+    m_aContainers {
+     SCR_ResourceContainer "{5D3CDAE74F1A6127}" {
+      m_fResourceValueCurrent 400
+      m_fResourceValueMax 400
+     }
+    }
+   }
+  }
+  coords 5893.828 55.44 8005.599
+  angleY -88.7
+ }
+ {
+  components {
+   SCR_ResourceComponent "{5D247A59598D71AE}" {
+    m_aContainers {
+     SCR_ResourceContainer "{5D3CDAE74F1A6127}" {
+      m_fResourceValueCurrent 400
+      m_fResourceValueMax 400
+     }
+    }
+   }
+  }
+  coords 5893.779 55.44 8008.282
+  angleY -88.7
+ }
+ {
+  components {
+   SCR_ResourceComponent "{5D247A59598D71AE}" {
+    m_aContainers {
+     SCR_ResourceContainer "{5D3CDAE74F1A6127}" {
+      m_fResourceValueCurrent 400
+      m_fResourceValueMax 400
+     }
+    }
+   }
+  }
+  coords 5894.927 55.44 8005.802
+  angleY -88.7
+ }
+ {
+  components {
+   SCR_ResourceComponent "{5D247A59598D71AE}" {
+    m_aContainers {
+     SCR_ResourceContainer "{5D3CDAE74F1A6127}" {
+      m_fResourceValueCurrent 400
+      m_fResourceValueMax 400
+     }
+    }
+   }
+  }
+  coords 5893.779 55.44 8008.282
+  angleY -88.7
+ }
+ {
+  components {
+   SCR_ResourceComponent "{5D247A59598D71AE}" {
+    m_aContainers {
+     SCR_ResourceContainer "{5D3CDAE74F1A6127}" {
+      m_fResourceValueCurrent 400
+      m_fResourceValueMax 400
+     }
+    }
+   }
+  }
+  coords 5893.847 55.44 8004.587
+  angleY -88.7
+ }
+ {
+  components {
+   SCR_ResourceComponent "{5D247A59598D71AE}" {
+    m_aContainers {
+     SCR_ResourceContainer "{5D3CDAE74F1A6127}" {
+      m_fResourceValueCurrent 400
+      m_fResourceValueMax 400
+     }
+    }
+   }
+  }
+  coords 5893.803 55.44 8010.773
+  angleY -88.7
+ }
+}

--- a/Worlds/COALobby/Ruha/Harry_SO_PressureChange_Layers/objs.layer
+++ b/Worlds/COALobby/Ruha/Harry_SO_PressureChange_Layers/objs.layer
@@ -1,0 +1,170 @@
+$grp CRF_ManualMarker : "{7B677FB61E410D0D}PrefabsEditable/Markers/ObjectiveMarker.et" {
+ {
+  coords 5507.537 65.799 6445.299
+  m_MarkerColor 0 0 0 1
+  m_sDescription "Ammo Depot"
+  m_aVisibleForFactions {
+   "OPFOR"
+  }
+ }
+ {
+  coords 6080.425 57.121 6914.355
+  m_MarkerColor 0 0 0 1
+  m_sDescription "Urban Command Post"
+  m_aVisibleForFactions {
+   "OPFOR"
+  }
+ }
+ {
+  coords 6045.376 57.097 6864.555
+  m_MarkerColor 0 0 0 1
+  m_sQuadName "mark-question"
+  m_sDescription "Urban Command Post"
+  m_aVisibleForFactions {
+   "BLUFOR" "SPEC"
+  }
+  m_bVisibleForEmptyFaction 1
+ }
+ {
+  coords 5235.218 69.305 7781.626
+  m_MarkerColor 0 0 0 1
+  m_sQuadName "mark-question"
+  m_sDescription "Urban Command Post"
+  m_aVisibleForFactions {
+   "BLUFOR" "SPEC"
+  }
+  m_bVisibleForEmptyFaction 1
+ }
+ {
+  coords 5500.48 66.242 6482.913
+  m_MarkerColor 0 0 0 1
+  m_sQuadName "mark-question"
+  m_sDescription "Ammo Depot"
+  m_aVisibleForFactions {
+   "BLUFOR" "SPEC"
+  }
+  m_bVisibleForEmptyFaction 1
+ }
+ {
+  coords 6749.738 55.902 7078.077
+  m_MarkerColor 0 0 0 1
+  m_sQuadName "mark-question"
+  m_sDescription "Ammo Depot"
+  m_aVisibleForFactions {
+   "BLUFOR" "SPEC"
+  }
+  m_bVisibleForEmptyFaction 1
+ }
+}
+SCR_DestructibleEntity : "{80CD669232DBC261}Prefabs/Structures/Signs/Military/SignRectangle_01_140x100/SignFlag_FIA_01.et" {
+ coords 5505.677 66.329 6443.707
+ angleY -49.037
+}
+GenericEntity : "{CDFDEF05A1055D8D}Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_Large_01/cacheHuntObj.et" {
+ coords 5504.568 65.799 6441.118
+ angleY -48.4
+ {
+  $grp GenericEntity : "{3FD3F403025BBDF5}Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_Large_01/SupplyStack_Large_01_storage.et" {
+   {
+    coords -0.039 0 -1.114
+    angleY 2.226
+   }
+   {
+    coords 1.35 0 -1.077
+    angleY 1.16
+   }
+   {
+    coords 4.061 0 0.428
+    angleY 0.037
+   }
+   {
+    coords 5.614 0 -0.99
+    angleY 48.4
+   }
+   {
+    coords 6.523 0 0.627
+    angleY 5.444
+   }
+  }
+  $grp GenericEntity : "{52E67D46C7855822}Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_Large_01/SupplyStack_Large_01_storage_US_covered.et" {
+   {
+    coords 9.744 0 -1.803
+    angleY 4.039
+   }
+   {
+    coords 1.276 0 0.076
+    angleY 85.229
+   }
+   {
+    coords 2.896 0 -1.077
+    angleY 4.856
+   }
+  }
+  GenericEntity : "{7165ECD98DF55E7C}Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_Large_01/SupplyStack_Large_01_item.et" {
+   coords 4.319 0 -0.79
+   angleY -0.85
+  }
+  GenericEntity : "{7D2C0FB3B8ACF2B0}Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_Large_01/SupplyStack_Large_01_storage_FIA_covered.et" {
+   coords -1.438 0 -1.097
+   angleY 2.226
+  }
+  $grp GenericEntity : "{FE4A51A953C54DA0}Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_Large_01/SupplyStack_Large_01_Vehicle.et" {
+   {
+    coords -1.26 0 0.052
+    angleY 2.226
+   }
+   {
+    coords 2.505 0 0.182
+    angleY 1.648
+   }
+  }
+ }
+}
+GenericEntity : "{F09296B9255F6704}Prefabs/Compositions/Misc/SubCompositions/Tents/Tent_CommandPost_US_01.et" {
+ components {
+  SCR_DestructionMultiPhaseComponent "{5D9B05DCAB2C9D93}" {
+   Enabled 1
+   "Additional hit zones" {
+    HitZone Default {
+     DamageReduction 10
+     DamageThreshold 200
+    }
+   }
+   m_fBaseHealth 1000
+  }
+ }
+ coords 6079.788 56.996 6915.233
+ angleY -98.442
+ {
+  StaticModelEntity {
+   ID "5CB6B2BAE096C538"
+   {
+    StaticModelEntity {
+     ID "5D466416286F4114"
+     {
+      GenericEntity {
+       ID "5D4669A08ACACECC"
+       components {
+        SCR_DestructionMultiPhaseComponent "{5D46D21E5FD531BA}" {
+         Enabled 1
+        }
+       }
+      }
+     }
+    }
+   }
+  }
+  GenericEntity : "{B85D81962A3F85BA}Prefabs/Props/Fabric/Flags/Flag_1_2_Everon_01.et" {
+   coords 4.404 5.514 1.342
+   angleY 98.442
+  }
+  GenericEntity : "{C8A9F7FDDF3CE851}Prefabs/Compositions/Misc/SubCompositions/Decorations/Barrel_Radio_01.et" {
+   coords 0.358 0.004 14.755
+   angleY 98.442
+  }
+  GenericEntity : "{CCB14E0E5C278B73}Prefabs/MP/Campaign/Assets/CampaignHQRadioWest.et" {
+   coords -0.433 1.038 0.518
+   angleY 11.063
+  }
+ }
+}

--- a/Worlds/COALobby/Ruha/Harry_SO_PressureChange_Layers/opfor.layer
+++ b/Worlds/COALobby/Ruha/Harry_SO_PressureChange_Layers/opfor.layer
@@ -1,0 +1,131 @@
+$grp SCR_VehicleSpawn {
+ {
+  coords 5514.375 61.763 6280.217
+  angleY -48.399
+  m_rnPrefab "{A5DDB987CC8C4B92}Prefabs/Vehicles/Wheeled/M998/M1025_armed_M134_MERDC.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+ {
+  coords 5537.07 62.012 6306.005
+  angleY -48.399
+  m_rnPrefab "{00C9BBE426F7D459}Prefabs/Vehicles/Wheeled/M998/M997_maxi_ambulance.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+ {
+  coords 5533.467 61.083 6270.117
+  angleY -55.602
+  m_rnPrefab "{F1FBD0972FA5FE09}Prefabs/Vehicles/Wheeled/M923A1/M923A1_transport.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+ {
+  coords 5540.122 61.004 6279.247
+  angleY -55.602
+  m_rnPrefab "{F1FBD0972FA5FE09}Prefabs/Vehicles/Wheeled/M923A1/M923A1_transport.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+ {
+  coords 5546.959 61.029 6288.875
+  angleY -55.602
+  m_rnPrefab "{F1FBD0972FA5FE09}Prefabs/Vehicles/Wheeled/M923A1/M923A1_transport.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+ {
+  coords 5554.146 60.992 6296.875
+  angleY -55.602
+  m_rnPrefab "{F1FBD0972FA5FE09}Prefabs/Vehicles/Wheeled/M923A1/M923A1_transport.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+ {
+  coords 5549.483 60.367 6260.973
+  angleY -55.602
+  m_rnPrefab "{F1FBD0972FA5FE09}Prefabs/Vehicles/Wheeled/M923A1/M923A1_transport.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+ {
+  coords 5556.552 60.34 6270.875
+  angleY -55.602
+  m_rnPrefab "{F1FBD0972FA5FE09}Prefabs/Vehicles/Wheeled/M923A1/M923A1_transport.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+ {
+  coords 5564.001 60.341 6279.801
+  angleY -55.602
+  m_rnPrefab "{F1FBD0972FA5FE09}Prefabs/Vehicles/Wheeled/M923A1/M923A1_transport.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+ {
+  coords 5570.853 60.368 6290.404
+  angleY -55.602
+  m_rnPrefab "{F1FBD0972FA5FE09}Prefabs/Vehicles/Wheeled/M923A1/M923A1_transport.et"
+  respawnDelay 10000
+  firstSpawn 1
+ }
+}
+SCR_AIGroup : "{5BFC01F79A5A8C68}Prefabs/Groups/OPFOR/Standard/Command/CRF_OPFOR_Company_p.et" {
+ coords 5604.448 60.899 6285.246
+ {
+  SCR_AIGroup : "{24DA56B34E727840}Prefabs/Groups/OPFOR/Standard/Support/CRF_OPFOR_MedicTeam_p.et" {
+   coords 11.449 0.933 0.633
+   {
+    SCR_AIGroup : "{6524B6A6C69BD3EE}Prefabs/Groups/OPFOR/Standard/Command/CRF_OPFOR_Platoon_p.et" {
+     coords -12.258 -0.196 -6.125
+     {
+      $grp SCR_AIGroup : "{92F50F60726EB86D}Prefabs/Groups/OPFOR/Standard/Infantry/CRF_OPFOR_RifleSquad_p.et" {
+       {
+        coords 9.921 -0.09 -8.98
+       }
+       {
+        coords 10.253 -0.26 -14.546
+        {
+         SCR_AIGroup : "{A1BDE5C4CC62ACAC}Prefabs/Groups/OPFOR/Standard/Support/CRF_OPFOR_MATTeam_p.et" {
+          coords 23.024 -0.953 5.373
+          m_aUnitPrefabSlots {
+           "{9CB623C7B62F4955}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_SL_P.et" "{A7E13866EA953B26}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_MMG_P.et" "{75876A55FD810645}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AMMG_P.et" "{8F5CA160B87492A1}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_MAT_P.et" "{5D3AF353AF60AFC2}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AMAT_P.et"
+          }
+          {
+           SCR_AIGroup : "{6524B6A6C69BD3EE}Prefabs/Groups/OPFOR/Standard/Command/CRF_OPFOR_Platoon_p.et" {
+            coords -33.833 1.247 4.199
+            {
+             $grp SCR_AIGroup : "{92F50F60726EB86D}Prefabs/Groups/OPFOR/Standard/Infantry/CRF_OPFOR_RifleSquad_p.et" {
+              {
+               coords 10.859 -0.855 -19.47
+              }
+              {
+               coords 10.924 -1.139 -23.781
+               {
+                SCR_AIGroup : "{A1BDE5C4CC62ACAC}Prefabs/Groups/OPFOR/Standard/Support/CRF_OPFOR_MATTeam_p.et" {
+                 coords 22.908 -0.948 3.44
+                 m_aUnitPrefabSlots {
+                  "{9CB623C7B62F4955}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_SL_P.et" "{A7E13866EA953B26}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_MMG_P.et" "{75876A55FD810645}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AMMG_P.et" "{8F5CA160B87492A1}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_MAT_P.et" "{5D3AF353AF60AFC2}Prefabs/Characters/Factions/OPFOR/CRF_GS_OPFOR_AMAT_P.et"
+                 }
+                 {
+                  SCR_AIGroup : "{803383BB28D07BB9}Prefabs/Groups/OPFOR/Standard/Vehicle/CRF_OPFOR_2manVehicleCrew_p.et" {
+                   coords -10.845 -0.018 25.676
+                  }
+                 }
+                }
+               }
+              }
+             }
+            }
+           }
+          }
+         }
+        }
+       }
+      }
+     }
+    }
+   }
+  }
+ }
+}

--- a/Worlds/COALobby/Ruha/Harry_SO_PressureChange_Layers/polyzones.layer
+++ b/Worlds/COALobby/Ruha/Harry_SO_PressureChange_Layers/polyzones.layer
@@ -1,0 +1,59 @@
+PolylineShapeEntity : "{318DDE6633C34CF1}PrefabsEditable/PolyZone/GameBoundry.et" {
+ components {
+  CRF_PolyZone "{65862E4575B86577}" {
+   m_bLineMode 1
+  }
+ }
+ coords 6352.789 68.805 6908.303
+ Points {
+  ShapePoint "{66A8228D0FF7C5EC}" {
+   Position 429.592 -8.365 -2210.993
+  }
+  ShapePoint "{66A8228D0CC72C71}" {
+   Position 756.198 -10.972 1244.87
+  }
+  ShapePoint "{66A8228D15047FA9}" {
+   Position -1860.798 13.072 1250.771
+  }
+  ShapePoint "{66A8228D1A341371}" {
+   Position -2013.287 -6.179 -1422.059
+  }
+  ShapePoint "{66A8ECEF24E70197}" {
+   Position 427.735 -8.204 -2210.295
+  }
+ }
+}
+PolylineShapeEntity : "{8AE1D02BC25C93C5}PrefabsEditable/PolyZone/BLUFORSafestartBoundry.et" {
+ coords 5955.615 54.562 8015.256
+ Points {
+  ShapePoint "{66A8228EC9F2A2D9}" {
+   Position -177.041 1.405 -177.695
+  }
+  ShapePoint "{66A8228EC81F7508}" {
+   Position -206.72 0.882 65.435
+  }
+  ShapePoint "{66A8228ED27B783C}" {
+   Position 208.639 -2.201 110.087
+  }
+  ShapePoint "{66A8228ED1C3EC52}" {
+   Position 214.649 -0.401 -108.533
+  }
+ }
+}
+PolylineShapeEntity : "{D8E7812AC12E29EB}PrefabsEditable/PolyZone/OPFORSafestartBoundry.et" {
+ coords 5615.547 59.541 6271.912
+ Points {
+  ShapePoint "{66A8228D3FDB493C}" {
+   Position 71.844 -7.62 -150.964
+  }
+  ShapePoint "{66A8228D3ECDEFC6}" {
+   Position -196.497 5.724 11.017
+  }
+  ShapePoint "{66A8228D3C2E63A3}" {
+   Position -54.078 3.346 150.15
+  }
+  ShapePoint "{66A8228D036FCFF3}" {
+   Position 224.466 -8.259 68.935
+  }
+ }
+}


### PR DESCRIPTION
Mission Pull Request Template

This Pull Request will:

Add the mission Pressure Change made by Harry to the repository.

**Mission Creation Checklist:**
- [x] Mission File
- [x] Gearscripts Tested
- [x] Ingame Play Area Markers
- [x] Ingame Briefings to all players
- [x] Side-based briefings  
- [x] Mission .conf file


**Faction(s):**

BLUFOR - Modern Rebels Defending
BLUFOR Comp: Inf
BLUFOR Assets: Mortars, MMG, Engi trucks

OPFOR - Modern FIA Attacking
OPFOR Comp: Moto Inf
OPFOR Assets: Armed Humvee, MMG, MAT

**Objectives/Win Conditions:**

Blufor is trying to find, and destroy two objectives. They are given a couple of possible generalized locations. Opfor wants to attack the blufor base and stop the indirect threat. 

**Terrain:**

Ruha

**Short mission description:**

Competing separatist groups are vying for control in the area. Blufor has deployed recon teams to find, and destroy two targets in the area by calling in indirect fire. 

**Slotting Ratio:**

1:1

**Time limit:**

<60min>

**Mission Briefing Screenshot:**

<img width="1018" height="735" alt="image" src="https://github.com/user-attachments/assets/3ae586d7-c8b2-4ffc-a8dc-3f4f5a649e09" />

**Design concept/thoughts:**

I've been trying to think of a fun way to make an area recon, where the recon element calls in indirect fire to destroy the objective. The issue is how to not have the recon force just use the indirect to squash enemies on defense. I think I've solved this by putting the mortars on the defending side, and having small recon elements move out from them looking for the targets. Opfor starts with no knowledge of blufor location, and while they can do their own recon to find them, when the mortars start firing it'll be pretty quick to start the assault. 

**Other Notes:**

Team leads have CLS kit added again, rifleman demo doesn't have satchel and has two detonators again. 