### PR TITLE
Bug Fix - Fixes callsign error

### DIFF
--- a/scripts/Game/Systems/VanillaOverrides/CRF_SCR_Faction.c
+++ b/scripts/Game/Systems/VanillaOverrides/CRF_SCR_Faction.c
@@ -48,7 +48,10 @@ modded class SCR_Faction
 		if (GetFactionKey() == "CIV")
 			return;
 		ref array<ref SCR_CallsignInfo> squadCallsigns = {};
-		GetCallsignInfo().GetSquadArray(squadCallsigns);
+		SCR_FactionCallsignInfo callsignInfo = GetCallsignInfo();
+		if (!callsignInfo)
+			return;
+		callsignInfo.GetSquadArray(squadCallsigns);
 		CVON_VONGameModeComponent gamemodeComp = CVON_VONGameModeComponent.GetInstance();
 		if (!gamemodeComp.m_FreqConfig)
 			return;


### PR DESCRIPTION
Fixes
------------------------------------
02.11 2025 14:54:24
Virtual Machine Exception

Reason: NULL pointer to instance

Class:      'SCR_Faction'
Function: 'InitializeFactionChannels'
Stack trace:
scripts/Game/Systems/VanillaOverrides/CRF_SCR_Faction.c:51 Function InitializeFactionChannels
scripts/Game/game.c:914 Function OnUpdate
scripts/Game/tmp.c:8 Function OnUpdate