### PR TITLE
Fixes shareable markers not saving on disconnect

### DIFF
--- a/scripts/Game/Systems/Core/Managers/CRF_RplToAuthorityManager.c
+++ b/scripts/Game/Systems/Core/Managers/CRF_RplToAuthorityManager.c
@@ -1809,4 +1809,107 @@ class CRF_RplToAuthorityManager : ScriptComponent
 		CRF_PlayableCharacter playableCharacter = CRF_PlayableCharacter.Cast(entity.FindComponent(CRF_PlayableCharacter));
 		playableCharacter.SendSpreadPos();
 	}
+	
+	void SharerMapMarkerGlobal(int markerUID, int playerId)
+	{
+		Faction playerFaction = SCR_FactionManager.SGetLocalPlayerFaction();
+		if (!playerFaction)
+			return;
+		
+		Rpc(RpcAsk_ShareMapMarkerGlobal, markerUID, playerFaction.GetFactionKey(), playerId);
+	}
+	
+	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
+	void RpcAsk_ShareMapMarkerGlobal(int markerUID, string factionKey, int playerId)
+	{
+		array<int> playerIds = {};
+		PlayerManager pm = GetGame().GetPlayerManager();
+		pm.GetPlayers(playerIds);
+		SCR_FactionManager factionManager = SCR_FactionManager.Cast(GetGame().GetFactionManager());
+		if (!factionManager)
+			return;
+		foreach (int otherPlayerId: playerIds)
+		{
+			if (playerId == otherPlayerId)
+				continue;
+			
+			Faction playerFaction = factionManager.GetPlayerFaction(otherPlayerId);
+			if (!playerFaction)
+				continue;
+			
+			if (playerFaction.GetFactionKey() != factionKey)
+				continue;
+			
+			SCR_PlayerController pc = SCR_PlayerController.Cast(pm.GetPlayerController(otherPlayerId));
+			if (!pc)
+				continue;
+			
+			pc.SharerMarkerGlobal(markerUID);
+			array<int> tempMarkerArray = {};
+			tempMarkerArray.Insert(markerUID);
+			SCR_MapMarkerManagerComponent.GetInstance().UpdateSharedMarkers(tempMarkerArray, otherPlayerId);
+		}
+	}
+	
+	void ShareMapMarkers()
+	{
+		SCR_MapMarkerManagerComponent mapMarkersMan = SCR_MapMarkerManagerComponent.GetInstance();
+		if (!mapMarkersMan)
+			return;
+		
+		array<int> markerUIDs = {};
+		foreach (SCR_MapMarkerBase marker: mapMarkersMan.GetStaticMarkers())
+		{
+			if (marker.m_bIsShared)
+				markerUIDs.Insert(marker.GetMarkerID());
+		}
+		
+		Rpc(RpcAsk_ShareMapMarkers,markerUIDs, SCR_PlayerController.GetLocalPlayerId());
+	}
+	
+	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
+	void RpcAsk_ShareMapMarkers(array<int> markerUIDs, int playerId)
+	{
+		PlayerManager pm = GetGame().GetPlayerManager();
+		IEntity playerEntity = pm.GetPlayerControlledEntity(playerId);
+		if (!playerEntity)
+			return;
+		
+		// Get the faction of the sharing player
+		SCR_FactionManager factionMan = SCR_FactionManager.Cast(GetGame().GetFactionManager());
+		if (!factionMan)
+			return;
+			
+		Faction sharingPlayerFaction = factionMan.GetPlayerFaction(playerId);
+		if (!sharingPlayerFaction)
+			return;
+		
+		array<int> playerIds = {};
+		pm.GetPlayers(playerIds);
+		foreach (int otherPlayerId: playerIds)
+		{
+			if (otherPlayerId == playerId)
+				continue;
+			
+			IEntity entity = pm.GetPlayerControlledEntity(otherPlayerId);
+			if (!entity)
+				continue;
+			
+			// Check distance - only share with nearby players
+			if (vector.Distance(playerEntity.GetOrigin(), entity.GetOrigin()) > SCR_MapMarkerManagerComponent.MARKER_SHARE_DISTANCE)
+				continue;
+			
+			// Check faction - only share with same faction players
+			Faction otherPlayerFaction = factionMan.GetPlayerFaction(otherPlayerId);
+			if (!otherPlayerFaction || otherPlayerFaction != sharingPlayerFaction)
+				continue;
+			
+			SCR_PlayerController otherController = SCR_PlayerController.Cast(pm.GetPlayerController(otherPlayerId));
+			if (!otherController)
+				continue;
+				
+			otherController.ShareMarker(markerUIDs);
+			SCR_MapMarkerManagerComponent.GetInstance().UpdateSharedMarkers(markerUIDs, otherPlayerId);
+		}
+	}
 };

--- a/scripts/Game/Systems/VanillaOverrides/CRF_SCR_PlayerController.c
+++ b/scripts/Game/Systems/VanillaOverrides/CRF_SCR_PlayerController.c
@@ -157,6 +157,74 @@ modded class SCR_PlayerController
 		SCR_Global.TeleportPlayer(GetPlayerId(), location);
 	}
 	
+	void SharerMapMarkerGlobal(int markerUID, int playerId)
+	{
+		Faction playerFaction = SCR_FactionManager.SGetLocalPlayerFaction();
+		if (!playerFaction)
+			return;
+		
+		Rpc(RpcAsk_ShareMapMarkerGlobal, markerUID, playerFaction.GetFactionKey(), playerId);
+	}
+	
+	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
+	void RpcAsk_ShareMapMarkerGlobal(int markerUID, string factionKey, int playerId)
+	{
+		array<int> playerIds = {};
+		PlayerManager pm = GetGame().GetPlayerManager();
+		pm.GetPlayers(playerIds);
+		SCR_FactionManager factionManager = SCR_FactionManager.Cast(GetGame().GetFactionManager());
+		if (!factionManager)
+			return;
+		foreach (int otherPlayerId: playerIds)
+		{
+			if (playerId == otherPlayerId)
+				continue;
+			
+			Faction playerFaction = factionManager.GetPlayerFaction(otherPlayerId);
+			if (!playerFaction)
+				continue;
+			
+			if (playerFaction.GetFactionKey() != factionKey)
+				continue;
+			
+			SCR_PlayerController pc = SCR_PlayerController.Cast(pm.GetPlayerController(otherPlayerId));
+			if (!pc)
+				continue;
+			
+			pc.SharerMarkerGlobal(markerUID);
+			array<int> tempMarkerArray = {};
+			tempMarkerArray.Insert(markerUID);
+			SCR_MapMarkerManagerComponent.GetInstance().UpdateSharedMarkers(tempMarkerArray, otherPlayerId);
+		}
+	}
+	
+	void SharerMarkerGlobal(int markerUID)
+	{
+		Rpc(RpcDo_SharerMarkerGlobal, markerUID);
+	}
+	
+	[RplRpc(RplChannel.Reliable, RplRcver.Owner)]
+	void RpcDo_SharerMarkerGlobal(int markerUID)
+	{
+		SCR_MapMarkerManagerComponent mapMarkersMan = SCR_MapMarkerManagerComponent.GetInstance();
+		if (!mapMarkersMan)
+			return;
+		
+		bool markersUpdated = false;
+		foreach (SCR_MapMarkerBase marker: mapMarkersMan.GetStaticMarkers())
+		{
+			if (marker.GetMarkerID() == markerUID && !marker.m_bIsShared)
+			{
+				marker.m_bIsShared = true;
+				markersUpdated = true;
+			}
+		}
+		
+		// Only update visibility if any markers were actually changed
+		if (markersUpdated)
+			mapMarkersMan.UpdateAllMarkerVisibilities();
+	}
+	
 	void ShareMapMarkers()
 	{
 		SCR_MapMarkerManagerComponent mapMarkersMan = SCR_MapMarkerManagerComponent.GetInstance();
@@ -166,7 +234,8 @@ modded class SCR_PlayerController
 		array<int> markerUIDs = {};
 		foreach (SCR_MapMarkerBase marker: mapMarkersMan.GetStaticMarkers())
 		{
-			markerUIDs.Insert(marker.GetMarkerID());
+			if (marker.m_bIsShared)
+				markerUIDs.Insert(marker.GetMarkerID());
 		}
 		
 		Rpc(RpcAsk_ShareMapMarkers,markerUIDs, GetPlayerId());
@@ -214,6 +283,7 @@ modded class SCR_PlayerController
 				continue;
 				
 			otherController.ShareMarker(markerUIDs);
+			SCR_MapMarkerManagerComponent.GetInstance().UpdateSharedMarkers(markerUIDs, otherPlayerId);
 		}
 	}
 	

--- a/scripts/Game/Systems/VanillaOverrides/CRF_SCR_PlayerController.c
+++ b/scripts/Game/Systems/VanillaOverrides/CRF_SCR_PlayerController.c
@@ -6,9 +6,6 @@ class CRF_BulletTracerContainer
 
 modded class SCR_PlayerController
 {
-	// Maximum distance (in meters) to share markers with nearby players
-	protected const float MARKER_SHARE_DISTANCE = 8.0;
-	
 	bool m_bIsBulletTrackingEnabled = false;
 	ref array<ref CRF_BulletTracerContainer> m_aActiveTraces = {};
 	bool m_bIsListeningToSpec = false;
@@ -157,47 +154,6 @@ modded class SCR_PlayerController
 		SCR_Global.TeleportPlayer(GetPlayerId(), location);
 	}
 	
-	void SharerMapMarkerGlobal(int markerUID, int playerId)
-	{
-		Faction playerFaction = SCR_FactionManager.SGetLocalPlayerFaction();
-		if (!playerFaction)
-			return;
-		
-		Rpc(RpcAsk_ShareMapMarkerGlobal, markerUID, playerFaction.GetFactionKey(), playerId);
-	}
-	
-	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
-	void RpcAsk_ShareMapMarkerGlobal(int markerUID, string factionKey, int playerId)
-	{
-		array<int> playerIds = {};
-		PlayerManager pm = GetGame().GetPlayerManager();
-		pm.GetPlayers(playerIds);
-		SCR_FactionManager factionManager = SCR_FactionManager.Cast(GetGame().GetFactionManager());
-		if (!factionManager)
-			return;
-		foreach (int otherPlayerId: playerIds)
-		{
-			if (playerId == otherPlayerId)
-				continue;
-			
-			Faction playerFaction = factionManager.GetPlayerFaction(otherPlayerId);
-			if (!playerFaction)
-				continue;
-			
-			if (playerFaction.GetFactionKey() != factionKey)
-				continue;
-			
-			SCR_PlayerController pc = SCR_PlayerController.Cast(pm.GetPlayerController(otherPlayerId));
-			if (!pc)
-				continue;
-			
-			pc.SharerMarkerGlobal(markerUID);
-			array<int> tempMarkerArray = {};
-			tempMarkerArray.Insert(markerUID);
-			SCR_MapMarkerManagerComponent.GetInstance().UpdateSharedMarkers(tempMarkerArray, otherPlayerId);
-		}
-	}
-	
 	void SharerMarkerGlobal(int markerUID)
 	{
 		Rpc(RpcDo_SharerMarkerGlobal, markerUID);
@@ -223,68 +179,6 @@ modded class SCR_PlayerController
 		// Only update visibility if any markers were actually changed
 		if (markersUpdated)
 			mapMarkersMan.UpdateAllMarkerVisibilities();
-	}
-	
-	void ShareMapMarkers()
-	{
-		SCR_MapMarkerManagerComponent mapMarkersMan = SCR_MapMarkerManagerComponent.GetInstance();
-		if (!mapMarkersMan)
-			return;
-		
-		array<int> markerUIDs = {};
-		foreach (SCR_MapMarkerBase marker: mapMarkersMan.GetStaticMarkers())
-		{
-			if (marker.m_bIsShared)
-				markerUIDs.Insert(marker.GetMarkerID());
-		}
-		
-		Rpc(RpcAsk_ShareMapMarkers,markerUIDs, GetPlayerId());
-	}
-	
-	[RplRpc(RplChannel.Reliable, RplRcver.Server)]
-	void RpcAsk_ShareMapMarkers(array<int> markerUIDs, int playerId)
-	{
-		PlayerManager pm = GetGame().GetPlayerManager();
-		IEntity playerEntity = pm.GetPlayerControlledEntity(playerId);
-		if (!playerEntity)
-			return;
-		
-		// Get the faction of the sharing player
-		SCR_FactionManager factionMan = SCR_FactionManager.Cast(GetGame().GetFactionManager());
-		if (!factionMan)
-			return;
-			
-		Faction sharingPlayerFaction = factionMan.GetPlayerFaction(playerId);
-		if (!sharingPlayerFaction)
-			return;
-		
-		array<int> playerIds = {};
-		pm.GetPlayers(playerIds);
-		foreach (int otherPlayerId: playerIds)
-		{
-			if (otherPlayerId == playerId)
-				continue;
-			
-			IEntity entity = pm.GetPlayerControlledEntity(otherPlayerId);
-			if (!entity)
-				continue;
-			
-			// Check distance - only share with nearby players
-			if (vector.Distance(playerEntity.GetOrigin(), entity.GetOrigin()) > MARKER_SHARE_DISTANCE)
-				continue;
-			
-			// Check faction - only share with same faction players
-			Faction otherPlayerFaction = factionMan.GetPlayerFaction(otherPlayerId);
-			if (!otherPlayerFaction || otherPlayerFaction != sharingPlayerFaction)
-				continue;
-			
-			SCR_PlayerController otherController = SCR_PlayerController.Cast(pm.GetPlayerController(otherPlayerId));
-			if (!otherController)
-				continue;
-				
-			otherController.ShareMarker(markerUIDs);
-			SCR_MapMarkerManagerComponent.GetInstance().UpdateSharedMarkers(markerUIDs, otherPlayerId);
-		}
 	}
 	
 	void ShareMarker(array<int> markerUIDs)

--- a/scripts/Game/Systems/VanillaOverrides/Managers/CRF_SCR_MapMarkerManagerComponent.c
+++ b/scripts/Game/Systems/VanillaOverrides/Managers/CRF_SCR_MapMarkerManagerComponent.c
@@ -1,23 +1,60 @@
 // Prevents map markers from being deleted when a player disconnects
 modded class SCR_MapMarkerManagerComponent
 {
+	ref map<int, ref array<int>> m_MarkersSharedReference = new map<int, ref array<int>>; 
 	SCR_PlayerController m_PlayerController;
 	protected int m_iCachedLocalPlayerId = -1;
+	
+	void UpdateSharedMarkers(array<int> markers, int playerId)
+	{
+		array<int> currentMarkers = m_MarkersSharedReference.Get(playerId);
+		foreach (int markerUID: markers)
+		{
+			if (currentMarkers.Contains(markerUID))
+				continue;
+			
+			currentMarkers.Insert(markerUID);
+		}
+	}
+	
+	override void OnPlayerConnected(int playerId)
+	{
+		super.OnPlayerConnected(playerId);
+		SCR_PlayerController pc = SCR_PlayerController.Cast(GetGame().GetPlayerManager().GetPlayerController(playerId));
+		if (!pc)
+			return;
+		
+		array<int> markers = m_MarkersSharedReference.Get(playerId);
+		if (!markers)
+		{
+			m_MarkersSharedReference.Set(playerId, new array<int>);
+			return;
+		}
+		
+		if (markers.Count() == 0)
+			return;
+
+		pc.ShareMarker(markers);
+	}
 	
 	override void OnAddSynchedMarker(SCR_MapMarkerBase marker)
 	{								
 		CRF_SafestartManager safestartMan = CRF_SafestartManager.GetInstance();	
 		SCR_FactionManager factionMan = SCR_FactionManager.Cast(GetGame().GetFactionManager());
-		Faction playerFaction;
-		if (factionMan)
-			playerFaction = factionMan.GetPlayerFaction(SCR_PlayerController.GetLocalPlayerId());
-		CRF_Gamemode gamemode = CRF_Gamemode.GetInstance();
-		if (safestartMan && gamemode && playerFaction)
-			if (safestartMan.GetSafestartStatus())
-				marker.m_bIsShared = true;
-			else if (!gamemode.DoesFactionShareMarker(playerFaction.GetFactionKey()))
-				marker.m_bIsShared = true;
-		
+		SCR_PlayerController pc = SCR_PlayerController.Cast(GetGame().GetPlayerController());
+		if (pc)
+		{
+			int playerId = pc.GetPlayerId();
+			Faction playerFaction;
+			if (factionMan)
+				playerFaction = factionMan.GetPlayerFaction(playerId);
+			CRF_Gamemode gamemode = CRF_Gamemode.GetInstance();
+			if (safestartMan && gamemode && playerFaction)
+				if (safestartMan.GetSafestartStatus() && marker.GetMarkerOwnerID() == playerId)
+					pc.SharerMapMarkerGlobal(marker.GetMarkerID(), playerId);
+				else if (!gamemode.DoesFactionShareMarker(playerFaction.GetFactionKey()) && marker.GetMarkerOwnerID() == playerId)
+					pc.SharerMapMarkerGlobal(marker.GetMarkerID(), playerId);
+		}
 		
 		super.OnAddSynchedMarker(marker);
 		

--- a/scripts/Game/Systems/VanillaOverrides/Managers/CRF_SCR_MapMarkerManagerComponent.c
+++ b/scripts/Game/Systems/VanillaOverrides/Managers/CRF_SCR_MapMarkerManagerComponent.c
@@ -1,6 +1,8 @@
 // Prevents map markers from being deleted when a player disconnects
 modded class SCR_MapMarkerManagerComponent
 {
+	// Maximum distance (in meters) to share markers with nearby players
+	static const float MARKER_SHARE_DISTANCE = 8.0;
 	ref map<int, ref array<int>> m_MarkersSharedReference = new map<int, ref array<int>>; 
 	SCR_PlayerController m_PlayerController;
 	protected int m_iCachedLocalPlayerId = -1;
@@ -51,9 +53,9 @@ modded class SCR_MapMarkerManagerComponent
 			CRF_Gamemode gamemode = CRF_Gamemode.GetInstance();
 			if (safestartMan && gamemode && playerFaction)
 				if (safestartMan.GetSafestartStatus() && marker.GetMarkerOwnerID() == playerId)
-					pc.SharerMapMarkerGlobal(marker.GetMarkerID(), playerId);
+					CRF_RplToAuthorityManager.GetInstance().SharerMapMarkerGlobal(marker.GetMarkerID(), playerId);
 				else if (!gamemode.DoesFactionShareMarker(playerFaction.GetFactionKey()) && marker.GetMarkerOwnerID() == playerId)
-					pc.SharerMapMarkerGlobal(marker.GetMarkerID(), playerId);
+					CRF_RplToAuthorityManager.GetInstance().SharerMapMarkerGlobal(marker.GetMarkerID(), playerId);
 		}
 		
 		super.OnAddSynchedMarker(marker);

--- a/scripts/Game/Systems/VanillaOverrides/UI/CRF_SCR_MapMarkersUI.c
+++ b/scripts/Game/Systems/VanillaOverrides/UI/CRF_SCR_MapMarkersUI.c
@@ -31,7 +31,7 @@ modded class SCR_PlayerControllerCommandingComponent
 	
 	void ShareMapMarkers()
 	{
-		SCR_PlayerController.Cast(GetGame().GetPlayerController()).ShareMapMarkers();
+		CRF_RplToAuthorityManager.GetInstance().ShareMapMarkers();
 	}
 	
 	void CheckIfValidSpawn()


### PR DESCRIPTION
Fixes https://github.com/CoalitionArma/Coalition-Reforger-Framework/issues/1095

Or atleast should, I can't fully test because reconnecting with the same dedi client in the tools still doesn't retain the player ID, despite BI saying it should :))))))))))))))))))))))))))))))))))))))))))))))))))))))))))