### PR TITLE
Added Coop Mission 'Storming Out'

### DIFF
--- a/Missions/CRF_CO52_StormingOut.conf
+++ b/Missions/CRF_CO52_StormingOut.conf
@@ -1,0 +1,13 @@
+SCR_MissionHeader {
+ World "{46B69853F6DE308B}Worlds/COALobby/Eden/FanServ_CoOp_StormingOut.ent"
+ m_sName "CRF CO52 Storming Out"
+ m_sAuthor "FanServ"
+ m_sDescription "US forces must hold Montignac in a storm"
+ m_sIcon "{B7385DA4504BD4D5}CRF Images/crflogo.edds"
+ m_sLoadingScreen "{B7385DA4504BD4D5}CRF Images/crflogo.edds"
+ m_sPreviewImage "{B7385DA4504BD4D5}CRF Images/crflogo.edds"
+ m_sGameMode "COOP"
+ m_iPlayerCount 128
+ m_iStartingHours 18
+ m_iMapMarkerLimitPerPlayer 120
+}

--- a/Missions/CRF_CO52_StormingOut.conf.meta
+++ b/Missions/CRF_CO52_StormingOut.conf.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{B8F9EB4258D5C469}Missions/CRF_CO52_StormingOut.conf"
+ Configurations {
+  CONFResourceClass PC {
+  }
+  CONFResourceClass XBOX_ONE : PC {
+  }
+  CONFResourceClass XBOX_SERIES : PC {
+  }
+  CONFResourceClass PS4 : PC {
+  }
+  CONFResourceClass PS5 : PC {
+  }
+  CONFResourceClass HEADLESS : PC {
+  }
+  CONFResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Worlds/COALobby/Eden/FanServ_CoOp_StormingOut.ent
+++ b/Worlds/COALobby/Eden/FanServ_CoOp_StormingOut.ent
@@ -1,0 +1,3 @@
+SubScene {
+ Parent "{853E92315D1D9EFE}worlds/Eden/Eden.ent"
+}

--- a/Worlds/COALobby/Eden/FanServ_CoOp_StormingOut.ent.meta
+++ b/Worlds/COALobby/Eden/FanServ_CoOp_StormingOut.ent.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{46B69853F6DE308B}Worlds/COALobby/Eden/FanServ_CoOp_StormingOut.ent"
+ Configurations {
+  ENTResourceClass PC {
+  }
+  ENTResourceClass XBOX_ONE : PC {
+  }
+  ENTResourceClass XBOX_SERIES : PC {
+  }
+  ENTResourceClass PS4 : PC {
+  }
+  ENTResourceClass PS5 : PC {
+  }
+  ENTResourceClass HEADLESS : PC {
+  }
+  ENTResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Worlds/COALobby/Eden/FanServ_CoOp_StormingOut_Layers/AAINIT.layer
+++ b/Worlds/COALobby/Eden/FanServ_CoOp_StormingOut_Layers/AAINIT.layer
@@ -1,0 +1,93 @@
+SCR_AIWorld : "{70CCCF16487C927F}Prefabs/AI/SCR_AIWorld_Eden.et" {
+ coords 4739.167 163.307 6983.162
+}
+CRF_Gamemode CRF_Lobby1 : "{6A996BBFCEB37E78}Prefabs/MP/Modes/Lobby/CRF_Lobby.et" {
+ components {
+  SCR_InitWeatherComponent "{64427EEC0AFF43EE}" {
+   m_sInitialStartingWeatherId "Heavy Thunderstorm"
+   m_initialWeatherDurationMin 1
+   m_initialWeatherDurationMax 2
+  }
+  SCR_TimeAndWeatherHandlerComponent "{64427EEC304DD9A0}" {
+   m_iStartingHours 18
+   m_aStartingWeatherAndTime {
+    SCR_TimeAndWeatherState "{66EE8AEC3605B974}" {
+     m_sWeatherPresetName "Heavy Thunderstorm"
+     m_iStartingHour 16
+    }
+   }
+  }
+ }
+ coords 4736.844 162.927 6983.029
+ m_iTimeLimitMinutes 90
+ EnableAIInGameState 1
+ m_aMissionDescriptors {
+  CRF_MissionDescriptor "{644250503DF684C0}" {
+   m_sTextData "A US Green Beret platoon has been able to hold a disproportionate amount of territory with the aid of CAS. However, a heavy storm has rendered CAS unavailable. The platoon has occupied Montignac to hold out until the storm ends. Numerically superior Russian forces have converged in the surrounding towns to eliminate the platoon before the storm breaks. The RUAF reinforcements are coordinated by MCOM stations."\
+   ""\
+   "BLUFOR Composition: Armored/Infantry/Mechanized/Etc.."\
+   "BLUFOR Assets: 1x Platoon, 1x MMG, 1x Indirect Team, 2x Vehicle Crew"\
+   ""\
+   "OPFOR Composition: Armored/Infantry/Mechanized/Etc.."\
+   "OPFOR Assets: IFVs, gun cars, mortars"\
+   ""\
+   "Time: 1800"\
+   ""\
+   "Weather: Heavy Thunderstorm"
+  }
+  CRF_MissionDescriptor "{64425051F2E00216}" {
+   m_sTextData "- Primary Objective: Survive in the town of Montignac until the storm clears"\
+   ""\
+   "- Secondary Objectives:"\
+   "1. Destroy the MCOM coordinating the enemy mortars"\
+   "2. Destroy the MCOM coordinating heavy vehicle support"\
+   "3. Destroy the MCOM coordinating light vehicle support"\
+   "4. Destroy the MCOM coordinating logistics support"
+  }
+  CRF_MissionDescriptor "{6442505149CF6C93}" {
+   m_sTextData "Light vehicles should come from Provins (Site A)"\
+   "Mortars should be in Entre Deux (Site B)"\
+   "Heavy vehicles should come from Tyrone (Site C)"\
+   "Troop transport trucks should come from Villeneuf (Site D)"\
+   ""\
+   "BLUFOR should receive M2 Humvees when destroying the Site A MCOM."\
+   "BLUFOR should receive a Mortar Pit when destroying the Site B MCOM."\
+   "BLUFOR should receive a Bradley IFV when destroying the Site C MCOM."\
+   "BLUFOR should receive a Logi Truck and a Construction Truck when destroying the Site D MCOM."
+  }
+ }
+ m_BLUFORGearScriptSettings CRF_GearScriptContainer "{64570ACB9B419A7B}" {
+  m_rGearScript "{2D94AD67BEABCC05}Configs/Gearscripts/Custom/Salami/CRF_GS_Modern_GreenBeretCOOP.conf"
+ }
+ m_OPFORGearScriptSettings CRF_GearScriptContainer "{64570ACB9B11EAAD}" {
+  m_rGearScript "{55E059EFC4E71234}Configs/Gearscripts/Custom/Salami/CRF_GS_ModernRussian.conf"
+ }
+ {
+  SCR_FactionManager "6729503624D00B81" {
+   ID "632A77473B3CC3A8"
+   Factions {
+    SCR_Faction "{628B22E9B4056C88}" {
+     m_CallsignInfo SCR_FactionCallsignInfo "{5DA0F2A6677ADA9E}" {
+      m_aSquadNames {
+       SCR_CallsignInfo "{672B24EF3F55D8BF}" {
+        m_sCallsign "1-4"
+       }
+       SCR_CallsignInfo "{6729503586CCBA09}" {
+        m_sCallsign "MMG"
+       }
+       SCR_CallsignInfo "{67295035875D3A2C}" {
+        m_sCallsign "MORTAR"
+       }
+       SCR_CallsignInfo "{672950358C10B511}" {
+        m_sCallsign "IFV"
+       }
+       SCR_CallsignInfo "{672B24EAE70B1E63}" {
+        m_sCallsign "ZEUS"
+       }
+      }
+     }
+    }
+   }
+  }
+ }
+}

--- a/Worlds/COALobby/Eden/FanServ_CoOp_StormingOut_Layers/BLUFOR.layer
+++ b/Worlds/COALobby/Eden/FanServ_CoOp_StormingOut_Layers/BLUFOR.layer
@@ -1,0 +1,46 @@
+SCR_AIGroup : "{3D4D53B053964445}Prefabs/Groups/BLUFOR/Standard/Command/CRF_BLUFOR_Platoon_p.et" {
+ coords 5009.778 174.688 7019.758
+ m_aUnitPrefabSlots +{
+  "{A49CC762AEE2A230}Prefabs/Characters/Factions/BLUFOR/CRF_GS_BLUFOR_DroneOp_P.et"
+ }
+ {
+  SCR_AIGroup : "{9C45BAF40F909576}Prefabs/Groups/BLUFOR/Standard/Infantry/CRF_BLUFOR_RifleSquad_p.et" {
+   coords 4.527 0 17.738
+   {
+    SCR_AIGroup : "{9C45BAF40F909576}Prefabs/Groups/BLUFOR/Standard/Infantry/CRF_BLUFOR_RifleSquad_p.et" {
+     coords -24.625 0 12.807
+     {
+      SCR_AIGroup : "{9C45BAF40F909576}Prefabs/Groups/BLUFOR/Standard/Infantry/CRF_BLUFOR_RifleSquad_p.et" {
+       coords -16.562 0 14.333
+       {
+        SCR_AIGroup : "{9C45BAF40F909576}Prefabs/Groups/BLUFOR/Standard/Infantry/CRF_BLUFOR_RifleSquad_p.et" {
+         coords -8.91 0 12.464
+         {
+          SCR_AIGroup : "{2F07AC5EE3DE3921}Prefabs/Groups/BLUFOR/Standard/Support/CRF_BLUFOR_MMGTeam_p.et" {
+           coords 26.185 0 -51.19
+           {
+            SCR_AIGroup : "{3CF105AFDCEA45A3}Prefabs/Groups/BLUFOR/Standard/Support/CRF_BLUFOR_IndirectTeam_p.et" {
+             coords -32.241 -0.001 25.109
+             {
+              SCR_AIGroup : "{5804AD2759E17E13}Prefabs/Groups/BLUFOR/Standard/Vehicle/CRF_BLUFOR_3manCrew_p.et" {
+               coords 14.572 0.001 -15.279
+               {
+                SCR_AIGroup : "{5F4B68E250ACF256}Prefabs/Groups/BLUFOR/Zeus/CRF_BLUFOR_Zeus.et" {
+                 coords 0 0 0
+                }
+               }
+              }
+             }
+            }
+           }
+          }
+         }
+        }
+       }
+      }
+     }
+    }
+   }
+  }
+ }
+}

--- a/Worlds/COALobby/Eden/FanServ_CoOp_StormingOut_Layers/BLUFORVICS.layer
+++ b/Worlds/COALobby/Eden/FanServ_CoOp_StormingOut_Layers/BLUFORVICS.layer
@@ -1,0 +1,86 @@
+$grp CRF_VehicleSpawner {
+ {
+  coords 5536.658 95.531 6049.953
+  angles 0 30 0
+  m_rVehicle "{CD1B5570AF3D50B6}Prefabs/Vehicles/Wheeled/M998/M1025_ION.et"
+  m_sFactionKey "BLUFOR"
+  m_bShouldRespawnOnSideRespawn 0
+ }
+ {
+  coords 5531.658 95.5 6040.375
+  angles 0 30 0
+  m_rVehicle "{053040D358C1DC44}Prefabs/Vehicles/Wheeled/M998/M1025_ION_armed_m2hb.et"
+  m_sFactionKey "BLUFOR"
+  m_bShouldRespawnOnSideRespawn 0
+ }
+ {
+  coords 5031.955 176.055 6983.572
+  angles 0 220 0
+  m_rVehicle "{81FDAD5EB644CC3D}Prefabs/Vehicles/Wheeled/M923A1/M923A1_transport_covered.et"
+  m_sFactionKey "BLUFOR"
+  m_bShouldRespawnOnSideRespawn 0
+ }
+ {
+  coords 5039.166 176.502 6994.487
+  angles 0 210 0
+  m_rVehicle "{81FDAD5EB644CC3D}Prefabs/Vehicles/Wheeled/M923A1/M923A1_transport_covered.et"
+  m_sFactionKey "BLUFOR"
+  m_bShouldRespawnOnSideRespawn 0
+ }
+ {
+  coords 5047.721 176.959 7007.621
+  angles 0 215 0
+  m_rVehicle "{4E3A86638BFF9FC6}Prefabs/Vehicles/Wheeled/M998/M997_maxi_ambulance_USAF.et"
+  m_sFactionKey "BLUFOR"
+  m_bShouldRespawnOnSideRespawn 0
+ }
+ {
+  coords 5055.564 177.348 7019.586
+  angles 0 215 0
+  m_rVehicle "{4E3A86638BFF9FC6}Prefabs/Vehicles/Wheeled/M998/M997_maxi_ambulance_USAF.et"
+  m_sFactionKey "BLUFOR"
+  m_bShouldRespawnOnSideRespawn 0
+ }
+ {
+  coords 5528.392 95.528 6032.679
+  angles 0 30 0
+  m_rVehicle "{053040D358C1DC44}Prefabs/Vehicles/Wheeled/M998/M1025_ION_armed_m2hb.et"
+  m_sFactionKey "BLUFOR"
+  m_bShouldRespawnOnSideRespawn 0
+ }
+ {
+  coords 4900.627 35.813 9107.836
+  angles 0 120 0
+  m_rVehicle "{B15B8D3E31D43639}Prefabs/Vehicles/Tracked/BFV/M2A3_BUSK_OD.et"
+  m_sFactionKey "BLUFOR"
+  m_bShouldRespawnOnSideRespawn 0
+ }
+ {
+  coords 2829.827 86.457 6341.85
+  angles 0 330 0
+  m_rVehicle "{1FF144F8A209239D}Prefabs/Vehicles/Wheeled/M923A1/M923A1_arsenal.et"
+  m_sFactionKey "BLUFOR"
+  m_bShouldRespawnOnSideRespawn 0
+ }
+ {
+  coords 2846.858 86.561 6335.071
+  angles 0 270 0
+  m_rVehicle "{2D74C39A650A3030}Prefabs/Vehicles/Wheeled/M923A1/M923A1_engineer.et"
+  m_sFactionKey "BLUFOR"
+  m_bShouldRespawnOnSideRespawn 0
+ }
+ {
+  coords 2860.33 86.786 6337.005
+  angles 0 260 0
+  m_rVehicle "{A042ACE5C2B13206}Prefabs/Vehicles/Wheeled/M923A1/M923A1_repair.et"
+  m_sFactionKey "BLUFOR"
+  m_bShouldRespawnOnSideRespawn 0
+ }
+ {
+  coords 2877.7 87.164 6339.507
+  angles 0 260 0
+  m_rVehicle "{2BE1F8B9299B67C1}Prefabs/Vehicles/Wheeled/M923A1/M923A1_tanker.et"
+  m_sFactionKey "BLUFOR"
+  m_bShouldRespawnOnSideRespawn 0
+ }
+}

--- a/Worlds/COALobby/Eden/FanServ_CoOp_StormingOut_Layers/Markers.layer
+++ b/Worlds/COALobby/Eden/FanServ_CoOp_StormingOut_Layers/Markers.layer
@@ -1,0 +1,59 @@
+PolylineShapeEntity : "{8AE1D02BC25C93C5}PrefabsEditable/PolyZone/BLUFORSafestartBoundry.et" {
+ coords 4538.563 146.616 7062.91
+ Points {
+  ShapePoint "{672B1AEC2C02ECE9}" {
+   Position -62.623 10.238 -86.255
+  }
+  ShapePoint "{672B1AEC2D4ABDD4}" {
+   Position -75.302 0 60.287
+  }
+  ShapePoint "{672B1AEC2DD3650C}" {
+   Position 48.197 0 145.585
+  }
+  ShapePoint "{672B1AEC2FF667B4}" {
+   Position 131.013 0 193.218
+  }
+  ShapePoint "{672B1AEC30AF0335}" {
+   Position 132.695 0 336.681
+  }
+  ShapePoint "{672B1AEC312B3E33}" {
+   Position 281.669 0 337.336
+  }
+  ShapePoint "{672B1AEC358B140C}" {
+   Position 600.484 36.103 95.168
+  }
+  ShapePoint "{672B1AEDDF855C46}" {
+   Position 748.145 28.465 -13.124
+  }
+  ShapePoint "{672B1AEDE798B058}" {
+   Position 618.432 0 -137.287
+  }
+  ShapePoint "{672B1AEDEC634802}" {
+   Position 352.35 0.331 -180.53
+  }
+  ShapePoint "{672B1AED84B58532}" {
+   Position 257.342 7.267 -318.768
+  }
+  ShapePoint "{672B1AEDEF63B3BF}" {
+   Position -53.328 2.702 -300.799
+  }
+ }
+}
+$grp CRF_MissionMarker : "{AAE0E36B0BB5FEC4}PrefabsEditable/Markers/ObjectiveMarkers/BLUFORObjectiveMarker.et" {
+ {
+  coords 5544.509 95.383 6062.95
+  m_sMissionMarkerDescription "MCOM A"
+ }
+ {
+  coords 5817.29 214.797 7050.15
+  m_sMissionMarkerDescription "MCOM B"
+ }
+ {
+  coords 4910.511 37.185 9071.759
+  m_sMissionMarkerDescription "MCOM C"
+ }
+ {
+  coords 2830.285 82.09 6419.696
+  m_sMissionMarkerDescription "MCOM D"
+ }
+}

--- a/Worlds/COALobby/Eden/FanServ_CoOp_StormingOut_Layers/Objectives.layer
+++ b/Worlds/COALobby/Eden/FanServ_CoOp_StormingOut_Layers/Objectives.layer
@@ -1,0 +1,14 @@
+$grp SCR_BaseTriggerEntity {
+ aSiteTrigger {
+  coords 5598.525 96.41 6025.915
+ }
+ bSiteTrigger {
+  coords 5860.532 214.502 7066.216
+ }
+ cSiteTrigger {
+  coords 4959.35 36.648 9148.062
+ }
+ dSiteTrigger {
+  coords 2839.073 85.271 6384.815
+ }
+}


### PR DESCRIPTION
Mission Pull Request Template

This Pull Request will:

Add the mission <mission name!> made by <author name!> to the repository.

**Mission Creation Checklist:**
- [x] Mission File
- [x] Gearscripts Tested
- [x] Ingame Play Area Markers
- [x] Ingame Briefings to all players
- [x] Side-based briefings  
- [x] Mission .conf file


**Faction(s):**

BLUFOR Composition: Green Beret platoon
BLUFOR Assets: 1x Platoon, 1x MMG, 1x Indirect Team, 2x Vehicle Crew

OPFOR Composition: Modern Russian Armed Forces
OPFOR Assets: IFVs, gun cars, mortars

**Objectives/Win Conditions:**

- Primary Objective: Survive in the town of Montignac until the storm clears

- Secondary Objectives:
1. Destroy the MCOM coordinating the enemy mortars
2. Destroy the MCOM coordinating heavy vehicle support
3. Destroy the MCOM coordinating light vehicle support
4. Destroy the MCOM coordinating logistics support

**Terrain:**

Eden

**Short mission description:**

A US Green Beret platoon has been able to hold a disproportionate amount of territory with the aid of CAS. However, a heavy storm has rendered CAS unavailable. The platoon has occupied Montignac to hold out until the storm ends. Numerically superior RUAF forces have converged in the surrounding towns to eliminate the platoon before the storm breaks. The RUAF reinforcements are coordinated by MCOM stations.

**Slotting Ratio:**

N/A

**Time limit:**

90 minutes

**Mission Briefing Screenshot:**

**Design concept/thoughts:**

<enter text here>

**Other Notes:**

<Assets? Admin notes? Anything else?>
