### PR TITLE
Temp Disable Airdrop For Br Testing

### DIFF
--- a/Worlds/Arland/CRF_SPCL_FightClub_Layers/airdrop.layer
+++ b/Worlds/Arland/CRF_SPCL_FightClub_Layers/airdrop.layer
@@ -1,4 +1,5 @@
 BaseGameTriggerEntity airdrop {
+ Flags 0x200000 0
  coords 1836.74 53.18 2252.188
  userScript "	"\
  "	bool m_bSafeStartInit = false;"\

--- a/Worlds/Arland/CRF_SPCL_FightClub_Layers/default.layer
+++ b/Worlds/Arland/CRF_SPCL_FightClub_Layers/default.layer
@@ -4,6 +4,7 @@ SCR_AIWorld : "{01DC74137CFDDB6A}Prefabs/AI/SCR_AIWorld_Arland.et" {
 CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et" {
  components {
   CRF_AirdropManager "{685355B93E7507C0}" {
+   Enabled 0
   }
   CRF_BattleRoyaleComponent "{686F1BAC9584AE29}" {
    m_iInitialDelay 150


### PR DESCRIPTION
Just temp update for the BR to test under player load. More peers results in more eonframe spam.
Zeus will have to manually place people for this go around. NOT for next friday