### PR TITLE
Minor Optimization - Adds early exit to FindComponent() background Loops

### DIFF
--- a/scripts/Game/GameMode/Search And Destroy/CRF_S&D_Display.c
+++ b/scripts/Game/GameMode/Search And Destroy/CRF_S&D_Display.c
@@ -6,6 +6,9 @@ class CRF_SearchAndDestroyDisplay : SCR_InfoDisplayExtended
 	protected CRF_SearchAndDestroyGamemodeManager m_SDComponent = null;
 	protected SCR_PopUpNotification m_PopUpNotification = null;
 	
+	// Trist: Track If Component Is Present (Temporary solution for minimizing perf. impact of FindComponent() loops when main component isnt used.)
+	protected bool m_bComponentPresent = false;
+	
 	//------------------------------------------------------------------------------------------------
 
 	// override/static functions
@@ -16,11 +19,16 @@ class CRF_SearchAndDestroyDisplay : SCR_InfoDisplayExtended
 	{
 		super.DisplayUpdate(owner, timeSlice);
 		
+		// Trist Bandaid: If we already searched and component doesn't exist, don't spam FindComponent() every frame
+		if (m_bComponentPresent && !m_SDComponent) // ^
+			return; // ^
+		
 		if (!m_SDComponent || !m_wTimer || !m_wBackground) {
 			m_SDComponent = CRF_SearchAndDestroyGamemodeManager.Cast(GetGame().GetGameMode().FindComponent(CRF_SearchAndDestroyGamemodeManager));
+			m_bComponentPresent = true;  // Trist: FindComponent Bandaid
 			m_wTimer      = TextWidget.Cast(m_wRoot.FindWidget("Timer"));
 			m_wBackground = ImageWidget.Cast(m_wRoot.FindWidget("Background"));
-			return;
+			if (!m_SDComponent) return; // Trist: FindComponent Bandaid
 		};
 		
 		if(!CRF_PlayerControllerManager.GetInstance().m_bHUDVisible)

--- a/scripts/Game/Systems/Components/BattleRoyale/CRF_BattleRoyaleComponent_Display.c
+++ b/scripts/Game/Systems/Components/BattleRoyale/CRF_BattleRoyaleComponent_Display.c
@@ -14,6 +14,9 @@ class CRF_BattleRoyaleComponentDisplay : SCR_InfoDisplayExtended
 	protected BlurWidget m_wBlur;
 	protected CRF_BattleRoyaleComponent m_BattleRoyaleComponent;
 	
+	// Track if Component is present (Temporary solution for minimizing perf. impact of FindComponent() loops when main component isnt used.)
+	protected bool m_bComponentPresent = false;
+	
 	// Cached toggle - read once at init, never re-checked
 	protected bool m_bPlayerTrackingEnabled = true;
 	
@@ -61,10 +64,15 @@ class CRF_BattleRoyaleComponentDisplay : SCR_InfoDisplayExtended
 		if (RplSession.Mode() == RplMode.Dedicated)
 			return;
 		
+		// Early exit: If we already searched and component doesn't exist, don't spam FindComponent() every frame
+		if (m_bComponentPresent && !m_BattleRoyaleComponent)
+			return;
+		
 		// Get components if not initialized
 		if (!m_BattleRoyaleComponent || !m_wTimer || !m_wBackground || !m_wStageText || !m_wPlayerCount || !m_wWinnerText) 
 		{
 			m_BattleRoyaleComponent = CRF_BattleRoyaleComponent.Cast(GetGame().GetGameMode().FindComponent(CRF_BattleRoyaleComponent));
+			m_bComponentPresent = true;  // Mark that we've searched
 			if (!m_BattleRoyaleComponent) 
 				return;
 			

--- a/scripts/Game/Systems/Components/Map/CRF_MapStagingComponent_Display.c
+++ b/scripts/Game/Systems/Components/Map/CRF_MapStagingComponent_Display.c
@@ -13,6 +13,9 @@ class CRF_MapStagingComponentDisplay : SCR_InfoDisplayExtended
 	protected ImageWidget m_wBackground;
 	protected CRF_MapStagingComponent m_StagingComponent;
 	
+	// Track If Component Is Present (Temporary solution for minimizing perf. impact of FindComponent() loops when main component isnt used.)
+	protected bool m_bComponentPresent = false;
+	
 	// Store original sizes of elements, For future use but not implemented
 	protected float m_fOriginalTimerWidth = -1;
 	protected float m_fOriginalTimerHeight = -1;
@@ -53,10 +56,15 @@ class CRF_MapStagingComponentDisplay : SCR_InfoDisplayExtended
 		if (RplSession.Mode() == RplMode.Dedicated)
 			return;
 		
+		// Early exit: If we already searched and component doesn't exist, don't spam FindComponent() every frame
+		if (m_bComponentPresent && !m_StagingComponent)
+			return;
+		
 		// Get components if not initialized
 		if (!m_StagingComponent || !m_wTimer || !m_wBackground || !m_wStageText) 
 		{
 			m_StagingComponent = CRF_MapStagingComponent.Cast(GetGame().GetGameMode().FindComponent(CRF_MapStagingComponent));
+			m_bComponentPresent = true;  // Mark that we've searched
 			if (!m_StagingComponent) return;
 			
 			m_wTimer = TextWidget.Cast(m_wRoot.FindWidget("Timer"));


### PR DESCRIPTION
Very minor bandaid. Any InfoDisplay classes that have  `FindComponent()` within `DisplayUpdate` in our gamemodes are constantly firing it via the CRFPlayerController when not loaded during all other mission types. Results in background component searches when the gm's arent present in world. Just added early exits. Very slight clientside perf improvement.

I dunno if this is bad practice or if there is a better way, I just noticed it when profiling.
Was in Mapstaging, BR, and S&D. Adds a boolean if not present + exits to prevent FindComponent spam.


<img width="388" height="185" alt="image" src="https://github.com/user-attachments/assets/681d6b83-909e-46ba-a40e-4f80d9edafa5" />

Picrel is during the BR mission testing. When profiling its easy to miss but multiplicative based on each unused component.

