### PR TITLE
Feature | Event spawning

### DIFF
--- a/PrefabsMissionMaking/Systems/SpawnPoints/EventZonePoles/BLUFOR_EventZone.et
+++ b/PrefabsMissionMaking/Systems/SpawnPoints/EventZonePoles/BLUFOR_EventZone.et
@@ -1,0 +1,92 @@
+GenericEntity : "{8364151EF33B3B33}Prefabs/Structures/Core/FlagPole_Base.et" {
+ ID "50C6D20663830070"
+ components {
+  CRF_EventRespawnComponent "{68A4B9F56D42F700}" {
+   m_sEventPoleFaction "BLUFOR"
+  }
+  CRF_RespawnPointComponent "{68A4B9F4875A8125}" {
+   Enabled 0
+   m_sRespawnPointFaction "BLUFOR"
+  }
+  MeshObject "{68A4B9F4875A82CA}" {
+   Object "{C41BFB78E6FFFBCB}Assets/Structures/Military/Flags/FlagPole_01/FlagPole_01.xob"
+  }
+  RigidBody "{68A4B9F4875A82CD}" {
+   SimState None
+   ResponseIndex "NoCollision"
+   ModelGeometry 1
+  }
+  SCR_DestructionMultiPhaseComponent "{51BACBF3C4A56479}" : "{76DA308CC9E2AB84}Prefabs/Props/Core/DestructionMultiPhase_Base.ct" {
+   EnableDamage 0
+   m_fBaseHealth 100000
+   m_DestroySpawnObjects {
+    SCR_DebrisSpawnable "{68A4B9F4875A82C3}" {
+     m_ModelPrefabs {
+      "{180F19ED1440D32A}Assets/Structures/Military/Flags/FlagPole_01/dst/Flagpole_01_dst.xob"
+     }
+     m_fMass 50
+     m_eMaterialSoundType METAL_POLE
+    }
+   }
+   m_eMaterialSoundType BREAK_METAL_POLE
+  }
+  SCR_EditableCommentComponent "{68A4B9F4875A82C6}" {
+   m_UIInfo SCR_EditableCommentUIInfo "{68A4B9F4875A82F8}" {
+    Name "BLUFOR EVENT AREA"
+   }
+   m_bStatic 0
+   m_bGME_IsVisible 0
+   m_sColor 0.071 0.192 0.561 1
+   m_fSizeCoef 0.8
+  }
+  SCR_EditableSystemComponent "{68A4B9F4875A82FA}" {
+   m_EntityType SYSTEM
+   m_UIInfo SCR_EditableEntityUIInfo "{68A4B9F4875A82FC}" {
+    Name "Blufor Spawn Point"
+    Icon "{302979C3EAF01D2E}UI/Textures/Editor/ContentBrowser/ContentBrowser_Trait_SpawnPoint.edds"
+    m_Image "{2F23E25348144FAE}UI/Textures/FieldManual/MPModes/Conflict/Tiles/respawn_UI.edds"
+    m_sFaction "BLUFOR"
+    m_aAuthoredLabels {
+     ENTITYTYPE_SYSTEM FACTION_CRF_BLUFOR
+    }
+    m_aAutoLabels {
+     ENTITYTYPE_SYSTEM
+    }
+    m_EntityBudgetCost {
+     SCR_EntityBudgetValue "{68A4B9F4875A82FE}" {
+      m_BudgetType SYSTEMS
+      m_Value 1
+     }
+    }
+   }
+   m_bAutoRegister ALWAYS
+   m_vIconPos 0 0 0
+   m_AccessKey 769
+   m_Flags 69
+  }
+  SCR_FactionAffiliationComponent "{68A4B9F4875A82F1}" {
+   "faction affiliation" "BLUFOR"
+  }
+  SCR_HorizontalAlignComponent "{68A4B9F4875A82F2}" {
+  }
+  SlotManagerComponent "{68A4B9F4875A82F4}" {
+   Slots {
+    EntitySlotInfo Flag {
+     Offset 0.0181 5.2653 0.0122
+     Angles 0 180 0
+     Prefab "{AB72A0D9CB73483B}Prefabs/Props/Fabric/Flags/Gearscript Factions/BLUFOR_FLAG.et"
+    }
+   }
+  }
+  RplComponent "{649042617FEE1ECC}" : "{B193E926C1935A4C}Prefabs/Editor/Components/Default_RplComponent.ct" {
+   Streamable Disabled
+  }
+ }
+ coords 0 0 0
+ {
+  CRF_ManualMarker : "{E256B56F799AEB41}PrefabsMissionMaking/Markers/SpawnMarkers/BLUFOR_SpawnMarker.et" {
+   ID "68A4B9F4875A810C"
+   coords 0 0 0
+  }
+ }
+}

--- a/PrefabsMissionMaking/Systems/SpawnPoints/EventZonePoles/BLUFOR_EventZone.et.meta
+++ b/PrefabsMissionMaking/Systems/SpawnPoints/EventZonePoles/BLUFOR_EventZone.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{E483D3A190D51541}PrefabsMissionMaking/Systems/SpawnPoints/BLUFOR_EventZone.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/PrefabsMissionMaking/Systems/SpawnPoints/EventZonePoles/CIVILIAN_EventZone.et
+++ b/PrefabsMissionMaking/Systems/SpawnPoints/EventZonePoles/CIVILIAN_EventZone.et
@@ -1,0 +1,92 @@
+GenericEntity : "{8364151EF33B3B33}Prefabs/Structures/Core/FlagPole_Base.et" {
+ ID "50C6D20663830070"
+ components {
+  CRF_EventRespawnComponent "{68A470C278AD5A7A}" {
+   m_sEventPoleFaction "CIV"
+  }
+  CRF_RespawnPointComponent "{68A470C263EEAD12}" {
+   Enabled 0
+   m_sRespawnPointFaction "CIV"
+  }
+  MeshObject "{68A470C263EEAD06}" {
+   Object "{C41BFB78E6FFFBCB}Assets/Structures/Military/Flags/FlagPole_01/FlagPole_01.xob"
+  }
+  RigidBody "{68A470C263EEAD3A}" {
+   SimState None
+   ResponseIndex "NoCollision"
+   ModelGeometry 1
+  }
+  SCR_DestructionMultiPhaseComponent "{51BACBF3C4A56479}" : "{76DA308CC9E2AB84}Prefabs/Props/Core/DestructionMultiPhase_Base.ct" {
+   EnableDamage 0
+   m_fBaseHealth 100000
+   m_DestroySpawnObjects {
+    SCR_DebrisSpawnable "{68A470C263EEAD3F}" {
+     m_ModelPrefabs {
+      "{180F19ED1440D32A}Assets/Structures/Military/Flags/FlagPole_01/dst/Flagpole_01_dst.xob"
+     }
+     m_fMass 50
+     m_eMaterialSoundType METAL_POLE
+    }
+   }
+   m_eMaterialSoundType BREAK_METAL_POLE
+  }
+  SCR_EditableCommentComponent "{68A470C263EEAD33}" {
+   m_UIInfo SCR_EditableCommentUIInfo "{68A470C263EEAD35}" {
+    Name "CIVILIAN SPAWN"
+   }
+   m_bStatic 0
+   m_bGME_IsVisible 0
+   m_sColor 0.318 0.071 0.561 1
+   m_fSizeCoef 0.8
+  }
+  SCR_EditableSystemComponent "{68A470C263EEAD37}" {
+   m_EntityType SYSTEM
+   m_UIInfo SCR_EditableEntityUIInfo "{68A470C263EEAD29}" {
+    Name "Civ Spawn Point"
+    Icon "{302979C3EAF01D2E}UI/Textures/Editor/ContentBrowser/ContentBrowser_Trait_SpawnPoint.edds"
+    m_Image "{2F23E25348144FAE}UI/Textures/FieldManual/MPModes/Conflict/Tiles/respawn_UI.edds"
+    m_sFaction "CIV"
+    m_aAuthoredLabels {
+     ENTITYTYPE_SYSTEM FACTION_CRF_CIV
+    }
+    m_aAutoLabels {
+     ENTITYTYPE_SYSTEM
+    }
+    m_EntityBudgetCost {
+     SCR_EntityBudgetValue "{68A470C263EEAD2C}" {
+      m_BudgetType SYSTEMS
+      m_Value 1
+     }
+    }
+   }
+   m_bAutoRegister ALWAYS
+   m_vIconPos 0 0 0
+   m_AccessKey 769
+   m_Flags 69
+  }
+  SCR_FactionAffiliationComponent "{68A470C263EEAD2F}" {
+   "faction affiliation" "CIV"
+  }
+  SCR_HorizontalAlignComponent "{68A470C263EEAD20}" {
+  }
+  SlotManagerComponent "{68A470C263EEAD21}" {
+   Slots {
+    EntitySlotInfo Flag {
+     Offset 0.0181 5.2653 0.0122
+     Angles 0 180 0
+     Prefab "{103104DE0FD580AA}Prefabs/Props/Fabric/Flags/Gearscript Factions/CIV_FLAG.et"
+    }
+   }
+  }
+  RplComponent "{649042617FD38925}" : "{B193E926C1935A4C}Prefabs/Editor/Components/Default_RplComponent.ct" {
+   Streamable Disabled
+  }
+ }
+ coords 0 0 0
+ {
+  CRF_ManualMarker : "{CC041EDE06E4A0C3}PrefabsMissionMaking/Markers/SpawnMarkers/CIVILIAN_SpawnMarker.et" {
+   ID "68A470C263EEAD66"
+   coords 0 0 0
+  }
+ }
+}

--- a/PrefabsMissionMaking/Systems/SpawnPoints/EventZonePoles/CIVILIAN_EventZone.et.meta
+++ b/PrefabsMissionMaking/Systems/SpawnPoints/EventZonePoles/CIVILIAN_EventZone.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{F830D7B59FB65895}PrefabsMissionMaking/Systems/SpawnPoints/CIVILIAN_EventZone.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/PrefabsMissionMaking/Systems/SpawnPoints/EventZonePoles/INDFOR_EventZone.et
+++ b/PrefabsMissionMaking/Systems/SpawnPoints/EventZonePoles/INDFOR_EventZone.et
@@ -1,0 +1,92 @@
+GenericEntity : "{8364151EF33B3B33}Prefabs/Structures/Core/FlagPole_Base.et" {
+ ID "50C6D20663830070"
+ components {
+  CRF_EventRespawnComponent "{68A470C2737E0FD2}" {
+   m_sEventPoleFaction "INDFOR"
+  }
+  CRF_RespawnPointComponent "{68A470C2682661B7}" {
+   Enabled 0
+   m_sRespawnPointFaction "INDFOR"
+  }
+  MeshObject "{68A470C2682661A6}" {
+   Object "{C41BFB78E6FFFBCB}Assets/Structures/Military/Flags/FlagPole_01/FlagPole_01.xob"
+  }
+  RigidBody "{68A470C268266159}" {
+   SimState None
+   ResponseIndex "NoCollision"
+   ModelGeometry 1
+  }
+  SCR_DestructionMultiPhaseComponent "{51BACBF3C4A56479}" : "{76DA308CC9E2AB84}Prefabs/Props/Core/DestructionMultiPhase_Base.ct" {
+   EnableDamage 0
+   m_fBaseHealth 100000
+   m_DestroySpawnObjects {
+    SCR_DebrisSpawnable "{68A470C26826615E}" {
+     m_ModelPrefabs {
+      "{180F19ED1440D32A}Assets/Structures/Military/Flags/FlagPole_01/dst/Flagpole_01_dst.xob"
+     }
+     m_fMass 50
+     m_eMaterialSoundType METAL_POLE
+    }
+   }
+   m_eMaterialSoundType BREAK_METAL_POLE
+  }
+  SCR_EditableCommentComponent "{68A470C268266150}" {
+   m_UIInfo SCR_EditableCommentUIInfo "{68A470C268266152}" {
+    Name "INDFOR SPAWN"
+   }
+   m_bStatic 0
+   m_bGME_IsVisible 0
+   m_sColor 0.071 0.561 0.192 1
+   m_fSizeCoef 0.8
+  }
+  SCR_EditableSystemComponent "{68A470C268266155}" {
+   m_EntityType SYSTEM
+   m_UIInfo SCR_EditableEntityUIInfo "{68A470C268266148}" {
+    Name "Indfor Spawn Point"
+    Icon "{302979C3EAF01D2E}UI/Textures/Editor/ContentBrowser/ContentBrowser_Trait_SpawnPoint.edds"
+    m_Image "{2F23E25348144FAE}UI/Textures/FieldManual/MPModes/Conflict/Tiles/respawn_UI.edds"
+    m_sFaction "INDFOR"
+    m_aAuthoredLabels {
+     ENTITYTYPE_SYSTEM FACTION_CRF_INDFOR
+    }
+    m_aAutoLabels {
+     ENTITYTYPE_SYSTEM
+    }
+    m_EntityBudgetCost {
+     SCR_EntityBudgetValue "{68A470C26826614B}" {
+      m_BudgetType SYSTEMS
+      m_Value 1
+     }
+    }
+   }
+   m_bAutoRegister ALWAYS
+   m_vIconPos 0 0 0
+   m_AccessKey 769
+   m_Flags 69
+  }
+  SCR_FactionAffiliationComponent "{68A470C26826614E}" {
+   "faction affiliation" "INDFOR"
+  }
+  SCR_HorizontalAlignComponent "{68A470C26826614F}" {
+  }
+  SlotManagerComponent "{68A470C268266141}" {
+   Slots {
+    EntitySlotInfo Flag {
+     Offset 0.0181 5.2653 0.0122
+     Angles 0 180 0
+     Prefab "{8C743CB2D8E074D5}Prefabs/Props/Fabric/Flags/Gearscript Factions/INDFOR_FLAG.et"
+    }
+   }
+  }
+  RplComponent "{649042617FD97F99}" : "{B193E926C1935A4C}Prefabs/Editor/Components/Default_RplComponent.ct" {
+   Streamable Disabled
+  }
+ }
+ coords 0 0 0
+ {
+  CRF_ManualMarker : "{C113055E29F43DAA}PrefabsMissionMaking/Markers/SpawnMarkers/INDFOR_SpawnMarker.et" {
+   ID "68A470C2682661BC"
+   coords 0 0 0
+  }
+ }
+}

--- a/PrefabsMissionMaking/Systems/SpawnPoints/EventZonePoles/INDFOR_EventZone.et.meta
+++ b/PrefabsMissionMaking/Systems/SpawnPoints/EventZonePoles/INDFOR_EventZone.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{25B8306C97ADCF22}PrefabsMissionMaking/Systems/SpawnPoints/INDFOR_EventZone.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/PrefabsMissionMaking/Systems/SpawnPoints/EventZonePoles/OPFOR_EventZone.et
+++ b/PrefabsMissionMaking/Systems/SpawnPoints/EventZonePoles/OPFOR_EventZone.et
@@ -1,0 +1,92 @@
+GenericEntity : "{8364151EF33B3B33}Prefabs/Structures/Core/FlagPole_Base.et" {
+ ID "50C6D20663830070"
+ components {
+  CRF_EventRespawnComponent "{68A470C20D10F40F}" {
+   m_sEventPoleFaction "OPFOR"
+  }
+  CRF_RespawnPointComponent "{68A470C26DE48948}" {
+   Enabled 0
+   m_sRespawnPointFaction "OPFOR"
+  }
+  MeshObject "{68A470C26DE48AFB}" {
+   Object "{C41BFB78E6FFFBCB}Assets/Structures/Military/Flags/FlagPole_01/FlagPole_01.xob"
+  }
+  RigidBody "{68A470C26DE48AF0}" {
+   SimState None
+   ResponseIndex "NoCollision"
+   ModelGeometry 1
+  }
+  SCR_DestructionMultiPhaseComponent "{51BACBF3C4A56479}" : "{76DA308CC9E2AB84}Prefabs/Props/Core/DestructionMultiPhase_Base.ct" {
+   EnableDamage 0
+   m_fBaseHealth 100000
+   m_DestroySpawnObjects {
+    SCR_DebrisSpawnable "{68A470C26DE48AF7}" {
+     m_ModelPrefabs {
+      "{180F19ED1440D32A}Assets/Structures/Military/Flags/FlagPole_01/dst/Flagpole_01_dst.xob"
+     }
+     m_fMass 50
+     m_eMaterialSoundType METAL_POLE
+    }
+   }
+   m_eMaterialSoundType BREAK_METAL_POLE
+  }
+  SCR_EditableCommentComponent "{68A470C26DE48AEB}" {
+   m_UIInfo SCR_EditableCommentUIInfo "{68A470C26DE48AEC}" {
+    Name "OPFOR SPAWN"
+   }
+   m_bStatic 0
+   m_bGME_IsVisible 0
+   m_sColor 0.561 0.071 0.071 1
+   m_fSizeCoef 0.8
+  }
+  SCR_EditableSystemComponent "{68A470C26DE48AEE}" {
+   m_EntityType SYSTEM
+   m_UIInfo SCR_EditableEntityUIInfo "{68A470C26DE48AE0}" {
+    Name "Opfor Spawn Point"
+    Icon "{302979C3EAF01D2E}UI/Textures/Editor/ContentBrowser/ContentBrowser_Trait_SpawnPoint.edds"
+    m_Image "{2F23E25348144FAE}UI/Textures/FieldManual/MPModes/Conflict/Tiles/respawn_UI.edds"
+    m_sFaction "OPFOR"
+    m_aAuthoredLabels {
+     ENTITYTYPE_SYSTEM FACTION_CRF_OPFOR
+    }
+    m_aAutoLabels {
+     ENTITYTYPE_SYSTEM
+    }
+    m_EntityBudgetCost {
+     SCR_EntityBudgetValue "{68A470C26DE48AE4}" {
+      m_BudgetType SYSTEMS
+      m_Value 1
+     }
+    }
+   }
+   m_bAutoRegister ALWAYS
+   m_vIconPos 0 0 0
+   m_AccessKey 769
+   m_Flags 69
+  }
+  SCR_FactionAffiliationComponent "{68A470C26DE48AE6}" {
+   "faction affiliation" "OPFOR"
+  }
+  SCR_HorizontalAlignComponent "{68A470C26DE48AE7}" {
+  }
+  SlotManagerComponent "{68A470C26DE48A99}" {
+   Slots {
+    EntitySlotInfo Flag {
+     Offset 0.0181 5.2653 0.0122
+     Angles 0 180 0
+     Prefab "{6B9C2405427CACEC}Prefabs/Props/Fabric/Flags/Gearscript Factions/OPFOR_FLAG.et"
+    }
+   }
+  }
+  RplComponent "{649042617FCFD793}" : "{B193E926C1935A4C}Prefabs/Editor/Components/Default_RplComponent.ct" {
+   Streamable Disabled
+  }
+ }
+ coords 0 0 0
+ {
+  CRF_ManualMarker : "{10F92A3FD09DA1C5}PrefabsMissionMaking/Markers/SpawnMarkers/OPFOR_SpawnMarker.et" {
+   ID "68A470C26DE48981"
+   coords 0 0 0
+  }
+ }
+}

--- a/PrefabsMissionMaking/Systems/SpawnPoints/EventZonePoles/OPFOR_EventZone.et.meta
+++ b/PrefabsMissionMaking/Systems/SpawnPoints/EventZonePoles/OPFOR_EventZone.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{72975061FD830076}PrefabsMissionMaking/Systems/SpawnPoints/OPFOR_EventZone.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/UI/layouts/HUD/EventRespawns/CRF_EventRespawnTimer.layout
+++ b/UI/layouts/HUD/EventRespawns/CRF_EventRespawnTimer.layout
@@ -1,0 +1,40 @@
+FrameWidgetClass {
+ Name "rootFrame"
+ {
+  TextWidgetClass "{68A470C52AC925D1}" {
+   Name "TimerText"
+   Slot FrameWidgetSlot "{68A470C52AC925FD}" {
+    Anchor 0.5 0 0.5 0
+    PositionX -150
+    OffsetLeft -150
+    PositionY 20
+    OffsetTop 20
+    SizeX 300
+    OffsetRight -150
+    SizeY 80
+    OffsetBottom -100
+   }
+   Text "1199.85"
+   "Font Size" 100
+   "Horizontal Alignment" Center
+   FontProperties FontProperties "{68A470C53032A6B3}" {
+    Font "{EABA4FE9D014CCEF}UI/Fonts/RobotoCondensed/RobotoCondensed_Bold.fnt"
+   }
+  }
+  PanelWidgetClass "{68A470C5D78E33B0}" {
+   Name "Panel0"
+   Slot FrameWidgetSlot "{68A470C5D78E335C}" {
+    Anchor 0.5 0 0.5 0
+    PositionX -150
+    OffsetLeft -150
+    PositionY 20
+    OffsetTop 20
+    SizeX 300
+    OffsetRight -150
+    SizeY 80
+    OffsetBottom -100
+   }
+   Color 0 0 0 1
+  }
+ }
+}

--- a/UI/layouts/HUD/EventRespawns/CRF_EventRespawnTimer.layout.meta
+++ b/UI/layouts/HUD/EventRespawns/CRF_EventRespawnTimer.layout.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{2BC691AB45F165D7}UI/layouts/HUD/EventRespawns/CRF_EventRespawnTimer.layout"
+ Configurations {
+  LayoutResourceClass PC {
+  }
+  LayoutResourceClass XBOX_ONE : PC {
+  }
+  LayoutResourceClass XBOX_SERIES : PC {
+  }
+  LayoutResourceClass PS4 : PC {
+  }
+  LayoutResourceClass PS5 : PC {
+  }
+  LayoutResourceClass HEADLESS : PC {
+  }
+  LayoutResourceClass Xbox : PC {
+  }
+ }
+}

--- a/scripts/Game/Systems/Components/Respawns/CRF_EventRespawnComponent.c
+++ b/scripts/Game/Systems/Components/Respawns/CRF_EventRespawnComponent.c
@@ -1,0 +1,83 @@
+class CRF_EventRespawnComponentClass: ScriptComponentClass {}
+class CRF_EventRespawnComponent: ScriptComponent
+{
+	[Attribute("", uiwidget: UIWidgets.ComboBox, enums: {ParamEnum("", ""), ParamEnum("BLUFOR", "BLUFOR"), ParamEnum("OPFOR", "OPFOR"), ParamEnum("INDFOR", "INDFOR"), ParamEnum("CIV", "CIV")})]
+	string m_sEventPoleFaction;
+	
+	override void OnPostInit(IEntity owner)
+	{
+		super.OnPostInit(owner);
+		SetEventMask(owner, EntityEvent.INIT);
+	}
+	
+	override void EOnInit(IEntity owner)
+	{
+		super.EOnInit(owner);
+		#ifdef WORKBENCH
+		//Only do error checking in the workbench itself
+		//For the love of god BI please TRY CATCH
+		//For in game in the WB
+		if (GetGame().GetWorld())
+		{
+			CRF_RespawnManager respawnMan = CRF_RespawnManager.GetInstance();
+			if (!respawnMan)
+				return;
+			
+			RegisterEventPole(respawnMan);
+			return;
+		}
+		WorldEditor worldEditor = Workbench.GetModule(WorldEditor);
+		if (!worldEditor)
+			return;
+		WorldEditorAPI api = worldEditor.GetApi();		
+		if (!api)
+			return;
+		IEntitySource entitySource = api.FindEntityByName("CRF_Lobby");
+		if (!entitySource)
+			return;
+		
+		CRF_Gamemode gamemode = CRF_Gamemode.Cast(api.SourceToEntity(entitySource));
+		if (!gamemode)
+			return;
+		
+		CRF_RespawnManager respawnMan = CRF_RespawnManager.Cast(gamemode.FindComponent(CRF_RespawnManager));
+		if (!respawnMan)
+			return;
+		
+		//Setting it for checking in the gamemode
+		RegisterEventPole(respawnMan);
+		#else
+		//Code that actually runs in the dedicated enviroment
+		if (!Replication.IsServer())
+			return;
+		
+		CRF_RespawnManager respawnMan = CRF_RespawnManager.GetInstance();
+		if (!respawnMan)
+			return;
+		
+		RegisterEventPole(respawnMan);
+		#endif
+	}
+	
+	void RegisterEventPole(CRF_RespawnManager respawnMan)
+	{
+		switch (m_sEventPoleFaction)
+		{
+			case "BLUFOR": 
+			respawnMan.m_BLUFOREventPole = GetOwner();
+			break;
+			
+			case "OPFOR": 
+			respawnMan.m_OPFOREventPole = GetOwner();
+			break;
+			
+			case "INDFOR": 
+			respawnMan.m_INDFOREventPole = GetOwner();
+			break;
+			
+			case "CIV": 
+			respawnMan.m_CIVEventPole = GetOwner();
+			break;
+		}
+	}
+}

--- a/scripts/Game/Systems/Core/CRF_Gamemode.c
+++ b/scripts/Game/Systems/Core/CRF_Gamemode.c
@@ -44,6 +44,9 @@ class CRF_Gamemode : SCR_BaseGameMode
 	//------------------------------------------------------------------------------------
 	[Attribute("0", UIWidgets.Hidden)]
 	bool m_bRespawnEnabled;
+	
+	[Attribute("0", UIWidgets.Hidden)]
+	bool m_bEventBasedRespawns;
 
 	[Attribute("0", UIWidgets.Hidden)]
 	bool m_bWaveRespawn;
@@ -202,6 +205,12 @@ class CRF_Gamemode : SCR_BaseGameMode
 	{
 		super.EOnInit(owner);
 		
+		//Checks for errors in Workbench
+		#ifdef WORKBENCH
+		//Checks to see if event based respawn poles are down for the active sides
+		GetGame().GetCallqueue().CallLater(EventPoleWarning, 1000, false);
+		#endif
+		
 		// Load configs on dedicated server
 		if (RplSession.Mode() == RplMode.Dedicated) {
 			CRF_ModeratorConfig.LoadConfig();	
@@ -222,6 +231,29 @@ class CRF_Gamemode : SCR_BaseGameMode
 		
 		// Enable frame events for batch processing
 		SetEventMask(EntityEvent.FRAME);
+	}
+	
+	/**
+	 * Delayed to allow time for entities to register themselves
+	 */
+	void EventPoleWarning()
+	{
+		if (m_bEventBasedRespawns)
+		{
+			CRF_RespawnManager respawnMan = CRF_RespawnManager.GetInstance();
+			if (m_BluforSlots.Count() > 0 && !respawnMan.m_BLUFOREventPole)
+				Print(string.Format("No Event pole for BLUFOR"), LogLevel.ERROR);
+			
+			if (m_OpforSlots.Count() > 0 && !respawnMan.m_OPFOREventPole)
+				Print(string.Format("No Event pole for OPFOR"), LogLevel.ERROR);
+			
+			if (m_IndforSlots.Count() > 0 && !respawnMan.m_INDFOREventPole)
+				Print(string.Format("No Event pole for INDFOR"), LogLevel.ERROR);
+			
+			if (m_CivSlots.Count() > 0 && !respawnMan.m_CIVEventPole)
+				Print(string.Format("No Event pole for CIV"), LogLevel.ERROR);
+			
+		}
 	}
 	
 	//===================================================================================

--- a/scripts/Game/Systems/Core/Managers/Gamemode/CRF_GamemodeManager.c
+++ b/scripts/Game/Systems/Core/Managers/Gamemode/CRF_GamemodeManager.c
@@ -27,6 +27,7 @@ class CRF_GamemodeManager : SCR_BaseGameModeComponent
 	protected CRF_SafestartManager m_SafestartManager;
 	protected SCR_GroupsManagerComponent m_GroupsManagerComponent;
 	protected CRF_AdminMenuManager m_AdminMenuManager;
+	protected CRF_RespawnManager m_RespawnManager;
 	
 	protected static CRF_GamemodeManager m_sInstance;
 	
@@ -199,6 +200,7 @@ class CRF_GamemodeManager : SCR_BaseGameModeComponent
 	{
 		m_Gamemode = CRF_Gamemode.GetInstance();
 		m_SlottingManager = CRF_SlottingManager.GetInstance();
+		m_RespawnManager = CRF_RespawnManager.GetInstance();
 		m_SafestartManager = CRF_SafestartManager.GetInstance();
 		m_GroupsManagerComponent = SCR_GroupsManagerComponent.GetInstance();
 		m_AdminMenuManager = CRF_AdminMenuManager.GetInstance();
@@ -271,14 +273,37 @@ class CRF_GamemodeManager : SCR_BaseGameModeComponent
 		// Determine if player should be spectator or playable character
 		if (!m_SlottingManager.IsPlayerInASlot(playerId) || m_SlottingManager.IsPlayerConsideredDead(playerId))
 		{
-			// SPECTATOR PATH: Create initial entity for spectators
-			playerCharacter = CreateSpectatorEntity(CRF_GamemodeManager.ZERO_SPAWN_VECTOR);
-	
-			
-			faction = GetGame().GetFactionManager().GetFactionByKey("SPEC");
-			
-			RemovePlayerFromCurrentGroup(playerId);
-			DisableDamageForSpectator(playerCharacter);
+			//Handled for event based respawns so characters are spawned at the flag poles unarmed
+			faction = m_SlottingManager.GetPlayerSlotFaction(playerId);
+			if (!faction)
+				return;
+			if (m_Gamemode.m_bEventBasedRespawns && m_Gamemode.m_bRespawnEnabled && m_RespawnManager.TicketsRemaining(faction.GetFactionKey()))
+			{			
+				GetEventPoleRespawn(playerId, spawnLocation);
+				
+				playerCharacter = GetOrCreatePlayableCharacter(playerId, spawnLocation, alreadyCreated);
+				if (playerCharacter)
+					SCR_ChimeraCharacter.Cast(playerCharacter).m_bEventPoleCharacter = true;
+				// If character already existed (respawn case), clean up any old initial/spectator entity
+				if (alreadyCreated)
+				{
+					DeleteOldInitialEntity(playerController, playerCharacter);
+				}
+				CRF_MenuManager.GetInstance().RemovePlayerFromAnyChannel(playerId, false);
+				// Schedule gear setup so when they respawn they get set to unarmed characters
+				// So much more simple than rooting up 3 entire systems		
+			}
+			else
+			{
+				// SPECTATOR PATH: Create initial entity for spectators
+				playerCharacter = CreateSpectatorEntity(CRF_GamemodeManager.ZERO_SPAWN_VECTOR);
+		
+				
+				faction = GetGame().GetFactionManager().GetFactionByKey("SPEC");
+				
+				RemovePlayerFromCurrentGroup(playerId);
+				DisableDamageForSpectator(playerCharacter);
+			}
 		} 
 		else 
 		{
@@ -301,6 +326,54 @@ class CRF_GamemodeManager : SCR_BaseGameModeComponent
 			AssignFactionToPlayer(playerController, faction);
 			GetGame().GetCallqueue().CallLater(InitilizePlayerCharacter, CRF_GamemodeManager.PLAYER_INITILIZATION_TIME, false, playerId, playerController, playerCharacter);
 		};
+	}
+	
+	//------------------------------------------------------------------------------------------------
+	/**
+	* Fetches the event respawn area of a player
+	* @param playerId ID of the player
+	* @out param spawnLocation The spawn location for the sides event respawn area
+	*/
+	void GetEventPoleRespawn(int playerId, out vector spawnLocation[4])
+	{
+		Faction faction = m_SlottingManager.GetPlayerSlotFaction(playerId);
+		//WTFFFFFFFFFFFFFFFFFFF
+		if (!faction)
+			return;
+		
+		CRF_RespawnManager respawnMan = CRF_RespawnManager.GetInstance();
+		if (!respawnMan)
+			return;
+		switch (faction.GetFactionKey())
+		{
+			case "BLUFOR":
+			if (!respawnMan.m_BLUFOREventPole)
+				return;
+			
+			respawnMan.m_BLUFOREventPole.GetTransform(spawnLocation);
+			break;
+								
+			case "OPFOR":
+			if (!respawnMan.m_OPFOREventPole)
+				return;
+			
+			respawnMan.m_OPFOREventPole.GetTransform(spawnLocation);
+			break;
+			
+			case "INDFOR":
+			if (!respawnMan.m_INDFOREventPole)
+				return;
+			
+			respawnMan.m_INDFOREventPole.GetTransform(spawnLocation);
+			break;
+			
+			case "CIV":
+			if (!respawnMan.m_CIVEventPole)
+				return;
+			
+			respawnMan.m_CIVEventPole.GetTransform(spawnLocation);
+			break;
+		}
 	}
 	
 	//------------------------------------------------------------------------------------------------
@@ -416,6 +489,9 @@ class CRF_GamemodeManager : SCR_BaseGameModeComponent
 	{
 		alreadyCreated = true;
 		SCR_ChimeraCharacter playerCharacter = m_SlottingManager.GetPlayerSlotCharacter(playerId);
+		
+		if (playerCharacter && playerCharacter.m_bEventPoleCharacter)
+			SCR_EntityHelper.DeleteEntityAndChildren(playerCharacter);
 		
 		if (!playerCharacter || playerCharacter.GetCharacterController().IsDead())
 		{

--- a/scripts/Game/Systems/Core/Managers/Gamemode/CRF_GamemodeManager.c
+++ b/scripts/Game/Systems/Core/Managers/Gamemode/CRF_GamemodeManager.c
@@ -277,7 +277,7 @@ class CRF_GamemodeManager : SCR_BaseGameModeComponent
 			faction = m_SlottingManager.GetPlayerSlotFaction(playerId);
 			if (!faction)
 				return;
-			if (m_Gamemode.m_bEventBasedRespawns && m_Gamemode.m_bRespawnEnabled && m_RespawnManager.TicketsRemaining(faction.GetFactionKey()))
+			if (m_Gamemode.m_bEventBasedRespawns && m_RespawnManager.m_bCurrentRespawnEnabled && m_RespawnManager.TicketsRemaining(faction.GetFactionKey()))
 			{			
 				GetEventPoleRespawn(playerId, spawnLocation);
 				
@@ -290,8 +290,6 @@ class CRF_GamemodeManager : SCR_BaseGameModeComponent
 					DeleteOldInitialEntity(playerController, playerCharacter);
 				}
 				CRF_MenuManager.GetInstance().RemovePlayerFromAnyChannel(playerId, false);
-				// Schedule gear setup so when they respawn they get set to unarmed characters
-				// So much more simple than rooting up 3 entire systems		
 			}
 			else
 			{

--- a/scripts/Game/Systems/Core/Managers/Gamemode/CRF_GearscriptManager.c
+++ b/scripts/Game/Systems/Core/Managers/Gamemode/CRF_GearscriptManager.c
@@ -134,8 +134,12 @@ class CRF_GearscriptManager : ScriptComponent
 		CRF_EGearRole role = CRF_RoleHelper.ResourceToRole(resourceNameToScan);
 		ClearEntityGear(inventory, inventoryManager);
 
+		//If it's an event pole character spawn them unarmed
 		//Delay so when we clear gear, the client has enough time to actually clear it before getting new gear. This prevents animation bugs.
-		GetGame().GetCallqueue().CallLater(SetEntityGearDelay, 500, false, gearScriptResourceName, entity, role, inventory, inventoryManager, gearScriptSettings);
+		if (SCR_ChimeraCharacter.Cast(entity).m_bEventPoleCharacter)
+			GetGame().GetCallqueue().CallLater(SetEntityGearDelay, 500, false, gearScriptResourceName, entity, CRF_EGearRole.UNARMED, inventory, inventoryManager, gearScriptSettings);
+		else
+			GetGame().GetCallqueue().CallLater(SetEntityGearDelay, 500, false, gearScriptResourceName, entity, role, inventory, inventoryManager, gearScriptSettings);
 	}
 	
 	void SetEntityGearDelay(string gearScriptResourceName, IEntity entity, CRF_EGearRole role, SCR_CharacterInventoryStorageComponent inventory,

--- a/scripts/Game/Systems/Core/Managers/Gamemode/CRF_RespawnManager.c
+++ b/scripts/Game/Systems/Core/Managers/Gamemode/CRF_RespawnManager.c
@@ -57,6 +57,8 @@ class CRF_RespawnManager : ScriptComponent
 	
 	protected bool m_bNeedsRespawn = false;
 	protected bool m_bRespawnInit = false;
+	
+	Widget m_wEventRespawnUI;
 
 	void CRF_RespawnManager(IEntityComponentSource src, IEntity ent, IEntity parent)
 	{
@@ -422,10 +424,19 @@ class CRF_RespawnManager : ScriptComponent
 		bool isTimerExpired = m_fRespawnTimer <= 0;
 		bool isGameInAARState = (m_Gamemode.m_GamemodeState == CRF_EGamemodeState.AAR);
 		
+		MenuBase topMenu = GetGame().GetMenuManager().GetTopMenu();
+		//Removes timer whenever respawn menu is open
+		if (topMenu && topMenu.IsInherited(CRF_RespawnMenu))
+		{
+			if (m_wEventRespawnUI)
+				m_wEventRespawnUI.RemoveFromHierarchy();
+		}
+			
+				
+		
 		if (isTimerExpired || isGameInAARState)
 		{
 			// Check if Respawn Screen is open
-			MenuBase topMenu = GetGame().GetMenuManager().GetTopMenu();
 			if (topMenu)
 			{
 				if (topMenu.IsInherited(CRF_RespawnMenu))
@@ -454,6 +465,9 @@ class CRF_RespawnManager : ScriptComponent
 				}
 			}
 		}
+		
+		if (m_wEventRespawnUI)
+			TextWidget.Cast(m_wEventRespawnUI.FindAnyWidget("TimerText")).SetText(SCR_FormatHelper.FormatTime((int)CRF_RespawnManager.GetInstance().m_fRespawnTimer));
 
 		// Handle respawn menu
 		if (!m_Gamemode.m_bEventBasedRespawns)
@@ -461,9 +475,7 @@ class CRF_RespawnManager : ScriptComponent
 		else
 		{
 			if (isTimerExpired || isGameInAARState)
-			{
-				MenuBase topMenu = GetGame().GetMenuManager().GetTopMenu();
-				
+			{	
 				if (topMenu)
 					if (topMenu.IsInherited(CRF_RespawnMenu))
 						return;
@@ -965,5 +977,11 @@ class CRF_RespawnManager : ScriptComponent
 	{
 		m_bCurrentRespawnEnabled = !m_bCurrentRespawnEnabled;
 		Replication.BumpMe();
+	}
+	
+	void ~CRF_RespawnManager()
+	{
+		if (m_wEventRespawnUI)
+			delete m_wEventRespawnUI;
 	}
 }

--- a/scripts/Game/Systems/Core/Managers/Gamemode/CRF_RespawnManager.c
+++ b/scripts/Game/Systems/Core/Managers/Gamemode/CRF_RespawnManager.c
@@ -19,6 +19,12 @@ class CRF_RespawnManager : ScriptComponent
 	[RplProp()]
 	int m_iCIVTickets;
 	
+	//Server logs location of event poles(Where players huddle when they die during our longer events)
+	IEntity m_BLUFOREventPole;
+	IEntity m_OPFOREventPole;
+	IEntity m_INDFOREventPole;
+	IEntity m_CIVEventPole;
+	
 	
 	//Respawn variables
 	[RplProp()] bool m_bCurrentRespawnEnabled;
@@ -420,36 +426,53 @@ class CRF_RespawnManager : ScriptComponent
 		{
 			// Check if Respawn Screen is open
 			MenuBase topMenu = GetGame().GetMenuManager().GetTopMenu();
-			if (!topMenu)
-				return;
-			if (topMenu.IsInherited(CRF_RespawnMenu))
+			if (topMenu)
 			{
-				// Check if respawn selection was confirmed in the UI
-				CRF_RespawnMenu respawnMenuUI = CRF_RespawnMenu.Cast(topMenu);
-				if (m_SelectedSpawnRplID != -1 && m_RespawnConfirmed)
+				if (topMenu.IsInherited(CRF_RespawnMenu))
 				{
-					// Reset the timer
-					m_fRespawnTimer = (float)m_iRespawnWaveCurrentTime;
-					m_iLocalTimeToRespawn = m_iCurrentTimeToRespawn;
-					m_bNeedsRespawn = false;
-					// Only perform respawn if not in AAR state
-					if (!isGameInAARState)
+					// Check if respawn selection was confirmed in the UI
+					CRF_RespawnMenu respawnMenuUI = CRF_RespawnMenu.Cast(topMenu);
+					if (m_SelectedSpawnRplID != -1 && m_RespawnConfirmed)
 					{
-						GetGame().GetMenuManager().CloseAllMenus();
-						CRF_RplToAuthorityManager.GetInstance().RespawnPlayer(SCR_PlayerController.GetLocalPlayerId(), m_SelectedSpawnRplID);
-						
-						// Set menu state back to default
-						m_SelectedSpawnRplID = -1;
-						m_RespawnConfirmed = false; 
+						// Reset the timer
+						m_fRespawnTimer = (float)m_iRespawnWaveCurrentTime;
+						m_iLocalTimeToRespawn = m_iCurrentTimeToRespawn;
+						m_bNeedsRespawn = false;
+						// Only perform respawn if not in AAR state
+						if (!isGameInAARState)
+						{
+							GetGame().GetMenuManager().CloseAllMenus();
+							CRF_RplToAuthorityManager.GetInstance().RespawnPlayer(SCR_PlayerController.GetLocalPlayerId(), m_SelectedSpawnRplID);
+							
+							// Set menu state back to default
+							m_SelectedSpawnRplID = -1;
+							m_RespawnConfirmed = false; 
+						}
+		
+						return;
 					}
-	
-					return;
 				}
 			}
 		}
 
 		// Handle respawn menu
-		ShowRespawnMenuIfNeeded();
+		if (!m_Gamemode.m_bEventBasedRespawns)
+			ShowRespawnMenuIfNeeded();
+		else
+		{
+			if (isTimerExpired || isGameInAARState)
+			{
+				MenuBase topMenu = GetGame().GetMenuManager().GetTopMenu();
+				
+				if (topMenu)
+					if (topMenu.IsInherited(CRF_RespawnMenu))
+						return;
+				
+				GetGame().GetMenuManager().CloseAllMenus();
+				
+				GetGame().GetMenuManager().OpenMenu(ChimeraMenuPreset.CRF_RespawnMenu);
+			}
+		}
 	}
 	
 	//------------------------------------------------------------------------------------------------

--- a/scripts/Game/Systems/Core/Managers/Gamemode/CRF_RplBroadcastManager.c
+++ b/scripts/Game/Systems/Core/Managers/Gamemode/CRF_RplBroadcastManager.c
@@ -488,7 +488,6 @@ class CRF_RplBroadcastManager : ScriptComponent
 	{
 		// Telemetry: int
 		LogTelemetry("SendRespawnScreen", CRF_BandwidthTelemetryManager.EstimateSize_Int());
-		
 		#ifdef WORKBENCH
 		RpcDo_SendRespawnScreen(playerId);
 		#else
@@ -1384,20 +1383,26 @@ class CRF_RplBroadcastManager : ScriptComponent
 	{
 		if (!IsLocalPlayer(playerId))
 			return;
-
-		// Close any open menus
-		MenuBase topMenu = GetGame().GetMenuManager().GetTopMenu();
-		if (topMenu)
+		
+		CRF_Gamemode gamemode = CRF_Gamemode.GetInstance();
+		if (!gamemode)
+			return;
+		
+		if (!gamemode.m_bEventBasedRespawns)
 		{
-			topMenu.Close();
+			// Close any open menus
+			MenuBase topMenu = GetGame().GetMenuManager().GetTopMenu();
+			if (topMenu)
+			{
+				topMenu.Close();
+			}
+	
+			GetGame().GetMenuManager().CloseAllMenus();
+			
+			// Open respawn menu
+			GetGame().GetMenuManager().OpenMenu(ChimeraMenuPreset.CRF_RespawnMenu);
 		}
 
-		GetGame().GetMenuManager().CloseAllMenus();
-		
-		// Open respawn menu
-		GetGame().GetMenuManager().OpenMenu(ChimeraMenuPreset.CRF_RespawnMenu);
-
-		
 		// Set up respawn timers
 		m_RespawnManager.m_iLocalTimeToRespawn = m_RespawnManager.m_iCurrentTimeToRespawn;
 		m_RespawnManager.m_fRespawnTimer = (float)m_RespawnManager.GetCurrentWaveTimer();

--- a/scripts/Game/Systems/Core/Managers/Gamemode/CRF_RplBroadcastManager.c
+++ b/scripts/Game/Systems/Core/Managers/Gamemode/CRF_RplBroadcastManager.c
@@ -1404,6 +1404,9 @@ class CRF_RplBroadcastManager : ScriptComponent
 		}
 
 		// Set up respawn timers
+		if (!m_RespawnManager.m_wEventRespawnUI)
+			m_RespawnManager.m_wEventRespawnUI = GetGame().GetWorkspace().CreateWidgets("{2BC691AB45F165D7}UI/layouts/HUD/EventRespawns/CRF_EventRespawnTimer.layout");
+		
 		m_RespawnManager.m_iLocalTimeToRespawn = m_RespawnManager.m_iCurrentTimeToRespawn;
 		m_RespawnManager.m_fRespawnTimer = (float)m_RespawnManager.GetCurrentWaveTimer();
 	}

--- a/scripts/Game/Systems/VanillaOverrides/Character/CRF_SCR_ChimeraCharacter.c
+++ b/scripts/Game/Systems/VanillaOverrides/Character/CRF_SCR_ChimeraCharacter.c
@@ -1,5 +1,8 @@
 modded class SCR_ChimeraCharacter
 {
+	// Used in the event pole process to know if we should delete this character if a respawn is requested.
+	// Only tracked on the auth
+	bool m_bEventPoleCharacter = false;
 	void SelectPrimaryWeapon()
 	{
 		Rpc(RpcDo_SelectPrimaryWeapon);

--- a/scripts/WorkbenchGame/MissionPlugins/CRF_MissionGamemodePlugin.c
+++ b/scripts/WorkbenchGame/MissionPlugins/CRF_MissionGamemodePlugin.c
@@ -32,6 +32,9 @@ class CRF_MissionGamemodePlugin : WorkbenchPlugin
 	
 	[Attribute("0", "auto", "", category: "CRF Mission Settings - Respawn")]
 	protected bool m_bRespawnEnabled;
+	
+	[Attribute("0", "auto", "", category: "CRF Mission Settings - Respawn")]
+	protected bool m_bEventBasedRespawns;
 
 	[Attribute("0", "auto", "", category: "CRF Mission Settings - Respawn")]
 	protected bool m_bWaveRespawn;
@@ -73,7 +76,7 @@ class CRF_MissionGamemodePlugin : WorkbenchPlugin
 		m_iMissionTimeLimit = gamemode.m_iTimeLimitMinutes;
 		m_bMissionAllowsEspionage = gamemode.m_bAllowEspionage;
 		m_bLockUnusedSlots = gamemode.m_bLockUnusedSlots;
-		m_bRespawnEnabled = gamemode.m_bRespawnEnabled;
+		m_bEventBasedRespawns = gamemode.m_bEventBasedRespawns;
 		m_bWaveRespawn = gamemode.m_bWaveRespawn;
 		m_iTimeToRespawn = gamemode.m_iTimeToRespawn;
 		m_iRespawnCutoffMinutes = gamemode.m_iRespawnCutoffMinutes;
@@ -134,6 +137,7 @@ class CRF_MissionGamemodePlugin : WorkbenchPlugin
 		api.SetVariableValue(entitySource, null, "m_bAllowEspionage", m_bMissionAllowsEspionage.ToString());
 		api.SetVariableValue(entitySource, null, "m_bLockUnusedSlots", m_bLockUnusedSlots.ToString());
 		api.SetVariableValue(entitySource, null, "m_bRespawnEnabled", m_bRespawnEnabled.ToString());
+		api.SetVariableValue(entitySource, null, "m_bEventBasedRespawns", m_bEventBasedRespawns.ToString());
 		api.SetVariableValue(entitySource, null, "m_bWaveRespawn", m_bWaveRespawn.ToString());
 		api.SetVariableValue(entitySource, null, "m_iTimeToRespawn", m_iTimeToRespawn.ToString());
 		api.SetVariableValue(entitySource, null, "m_iRespawnCutoffMinutes", m_iRespawnCutoffMinutes.ToString());


### PR DESCRIPTION
Adds the old event spawning from A3 where players would spawn around a pole and be able to talk before being thrown into the mission again.

To use:
- Enable event based respawns in the plugin settings
- Place the event respawn pole for all the sides active in your mission
- Have respawns enabled

It'll bark errors at you if you have a side slotted but don't have an event pole set up for them.