### PR TITLE
Swap To OnPlayerKilled

### DIFF
--- a/Prefabs/Characters/!Spectator/CRF_Spectator.et
+++ b/Prefabs/Characters/!Spectator/CRF_Spectator.et
@@ -154,6 +154,9 @@ CRF_SpectatorCharacter : "{D7EB93B0550FD158}Prefabs/Characters/!Core/CRF_Player.
     SoundIdentity SoundIdentity "{56E6D945D8F79290}" {
      VoiceID 0
     }
+    Name ""
+    Alias ""
+    Surname ""
    }
   }
   BaseLoadoutManagerComponent "{520EA1D2DB11821E}" {

--- a/Prefabs/Characters/!Spectator/CRF_Spectator.et
+++ b/Prefabs/Characters/!Spectator/CRF_Spectator.et
@@ -15,6 +15,7 @@ CRF_SpectatorCharacter : "{D7EB93B0550FD158}Prefabs/Characters/!Core/CRF_Player.
    StaminaThresholdMinimum 0.0001
   }
   SCR_CharacterControllerComponent "{520EA1D2F659CEA5}" {
+   DeathTimer 0
    AllowLightImpactAnim 0
    AllowRagdollEffectorsFromDamage 0
    m_fDrowningDuration 1000000000

--- a/Scripts/Game/Systems/Core/Entities/CRF_Gamemode.c
+++ b/Scripts/Game/Systems/Core/Entities/CRF_Gamemode.c
@@ -438,31 +438,50 @@ class CRF_Gamemode : SCR_BaseGameMode
 //=============================================================================================================================================================================================================================================================================================================================================================
 	
 	//------------------------------------------------------------------------------------------------
-	//! Process entity spawning for players
-	//! \param[in] entity The spawned entity
-	protected override void OnControllableSpawned(IEntity entity)
+	//! Default player kill behaviour. Called when a player is killed (and HandlePlayerKilled returns true).
+	protected override void OnPlayerKilled(int playerId, IEntity playerEntity, IEntity killerEntity, notnull Instigator killer)
 	{
-		super.OnControllableSpawned(entity);
+		super.OnPlayerKilled(playerId, playerEntity, killerEntity, killer);
 		
-		SCR_ChimeraCharacter character = SCR_ChimeraCharacter.Cast(entity);
-		
-		if (!character)
+		// Skip processing on client
+		if (RplSession.Mode() == RplMode.Client)
 			return;
-			
-		// Handle initial entity race condition fix
-		if (character.GetPrefabData().GetPrefabName() == CRF_EntityHelper.GetSpectatorResource())
+
+		// Get player faction
+		Faction faction = CRF_SlottingManager.GetInstance().GetPlayerSlotFaction(playerId);
+		FactionKey factionKey;
+		
+		if (faction)
+			factionKey = faction.GetFactionKey();
+
+		// Handle respawn if enabled, tickets available, and within time window
+		if (m_RespawnManager.m_bCurrentRespawnEnabled && 
+			!CRF_EntityHelper.IsSpectator(playerEntity) && 
+			m_GamemodeState != CRF_EGamemodeState.AAR && 
+			m_RespawnManager.TicketsRemaining(factionKey) &&
+			m_RespawnManager.IsRespawnTimeAllowed() &&
+			!m_RespawnManager.GetFactionSpawnpoints(factionKey).IsEmpty() &&
+			!factionKey.IsEmpty())
 		{
-			int playerId = GetGame().GetPlayerManager().GetPlayerIdFromControlledEntity(character);
-			if (playerId > 0 && m_GamemodeState == CRF_EGamemodeState.GAME)
-			{
-				// Check if player should have a proper character instead of initial entity
-				if (m_SlottingManager.IsPlayerInASlot(playerId) && !m_SlottingManager.IsPlayerConsideredDead(playerId))
-				{
-					// Schedule re-initialization to fix race condition
-					GetGame().GetCallqueue().CallLater(OnControllableInitilizePlayerDelayed, 500, false, playerId);
-				}
-			}
+			// Deduct ticket
+			m_RespawnManager.SubtractTicket(factionKey, 1);
+
+			// Display respawn screen
+			GetGame().GetCallqueue().CallLater(
+				m_RplBroadcastManager.SendRespawnScreen,
+				(CRF_GamemodeManager.PLAYER_INITILIZATION_TIME + 75),
+				false,
+				playerId
+			);
 		}
+		
+		// Update slot death state so player gets put into spec
+		int slotID = m_SlottingManager.GetCharacterSlotID(playerEntity);
+		if (slotID != -1)
+			m_SlottingManager.UpdateSlotDeathState(slotID, true);
+		
+		// Move player to spectator
+		m_GamemodeManager.InitilizePlayer(playerId);
 	}
 
 	//------------------------------------------------------------------------------------------------
@@ -479,67 +498,8 @@ class CRF_Gamemode : SCR_BaseGameMode
 		if (RplSession.Mode() == RplMode.Client)
 			return;
 		
-		m_GarbageManager.m_aDeadBodies.Insert(entity);
-		
-		// Note: The base game's data collector is automatically triggered by super.OnControllableDestroyed()
-		// Our modded CRF_SCR_DataCollectorComponent.OnPlayerKilled() hooks into this and calls the logging manager
-		
-		// Create instigator context for tracking kill details
-		SCR_InstigatorContextData instigatorContextData = new SCR_InstigatorContextData(-1, entity, killerEntity, instigator);
-		int playerId = instigatorContextData.GetVictimPlayerID();
-		
-		// Return if not a player character
-		if (playerId <= 0 || instigatorContextData.GetVictimCharacterControlType() == SCR_ECharacterControlType.POSSESSED_AI)
-			return;
-
-		// Determine delay time for respawn/spectator
-		int delay = 2000;
-		if (CRF_EntityHelper.IsSpectator(entity))
-			delay = 0;
-		
-		// Get player faction
-		Faction faction = CRF_SlottingManager.GetInstance().GetPlayerSlotFaction(playerId);
-		FactionKey factionKey;
-		
-		if (faction)
-			factionKey = faction.GetFactionKey();
-
-		// Handle respawn if enabled, tickets available, and within time window
-		if (m_RespawnManager.m_bCurrentRespawnEnabled && 
-			!CRF_EntityHelper.IsSpectator(entity) && 
-			m_GamemodeState != CRF_EGamemodeState.AAR && 
-			m_RespawnManager.TicketsRemaining(factionKey) &&
-			m_RespawnManager.IsRespawnTimeAllowed() &&
-			!m_RespawnManager.GetFactionSpawnpoints(factionKey).IsEmpty() &&
-			!factionKey.IsEmpty())
-		{
-			// Deduct ticket
-			m_RespawnManager.SubtractTicket(factionKey, 1);
-
-			// Display respawn screen
-			GetGame().GetCallqueue().CallLater(
-				m_RplBroadcastManager.SendRespawnScreen,
-				(delay + 150),
-				false,
-				playerId
-			);
-		}
-		
-		// Update slot death state so player gets put into spec
-		int slotID = m_SlottingManager.GetCharacterSlotID(entity);
-		
-		if(slotID != -1)
-			m_SlottingManager.UpdateSlotDeathState(slotID, true);
-		
-		// Move player to spectator
-		GetGame().GetCallqueue().CallLater(OnControllableInitilizePlayerDelayed, delay, false, playerId);
-	}
-	
-	//------------------------------------------------------------------------------------------------
-	//! For some godforsaken reason, removing this and directly calling "m_GamemodeManager.InitilizePlayer" in the call later doesnt work.
-	protected void OnControllableInitilizePlayerDelayed(int playerId)
-	{
-		m_GamemodeManager.InitilizePlayer(playerId);
+		if (CRF_GearscriptCharacter.Cast(entity))
+			m_GarbageManager.m_aDeadBodies.Insert(entity);
 	}
 	
 //=============================================================================================================================================================================================================================================================================================================================================================

--- a/Scripts/Game/Systems/Core/Entities/Characters/CRF_SpectatorCharacter.c
+++ b/Scripts/Game/Systems/Core/Entities/Characters/CRF_SpectatorCharacter.c
@@ -14,9 +14,6 @@ class CRF_SpectatorCharacter : CRF_PlayerCharacter
 		super.EOnInit(owner);
 		
 		GetGame().GetCallqueue().Call(DisablePhysicsAndDamage);
-		
-		if (RplSession.Mode() != RplMode.Client)
-			owner.SetOrigin("0 500 0")
 	}
 	
 	//------------------------------------------------------------------------------------------------

--- a/Scripts/Game/Systems/Core/Helpers/CRF_MissionHelper.c
+++ b/Scripts/Game/Systems/Core/Helpers/CRF_MissionHelper.c
@@ -52,7 +52,10 @@ class CRF_MissionHelper {
 		if (count == 0)
 			return "0 0 0";   // no data
 
-		return sum / count;
+		vector center = sum/count;
+		center[1] = center[1] + 225;
+		
+		return center;
 	}
 
 	//------------------------------------------------------------------------------------------------

--- a/Scripts/Game/Systems/Core/Managers/Gamemode/CRF_GamemodeManager.c
+++ b/Scripts/Game/Systems/Core/Managers/Gamemode/CRF_GamemodeManager.c
@@ -104,7 +104,7 @@ class CRF_GamemodeManager : SCR_BaseGameModeComponent
 		{
 			playerCharacter.DisableAI();
 			CRF_PlayerHelper.AssignFactionToPlayer(playerController, faction);
-			GetGame().GetCallqueue().CallLater(InitilizePlayerCharacter, CRF_GamemodeManager.PLAYER_INITILIZATION_TIME, false, playerId, playerController, playerCharacter);
+			GetGame().GetCallqueue().CallLater(InitilizePlayerCharacter, PLAYER_INITILIZATION_TIME, false, playerId, playerController, playerCharacter);
 		};
 	}
 	
@@ -191,7 +191,8 @@ class CRF_GamemodeManager : SCR_BaseGameModeComponent
 		Print(string.Format("[CRF_GamemodeManager] Creating new spectator entity for player %1", playerId), LogLevel.NORMAL);
 		
 		Resource spectatorRes = Resource.Load(CRF_EntityHelper.GetSpectatorResource());
-		spec = CRF_PlayerCharacter.Cast(GetGame().SpawnEntityPrefab(spectatorRes, GetGame().GetWorld(), CRF_EntityHelper.CreateSpawnParams(CRF_EntityHelper.ZERO_SPAWN_VECTOR)));
+		EntitySpawnParams spawnParams = CRF_EntityHelper.CreateSpawnParams(CRF_Gamemode.GetInstance().GetGenericSpawn());
+		spec = CRF_PlayerCharacter.Cast(GetGame().SpawnEntityPrefab(spectatorRes, GetGame().GetWorld(), spawnParams));
 		
 		if (!spec)
 		{


### PR DESCRIPTION
Swaps our OnControllableDestroyed to OnPlayer killed for all player death handling.

Also re-enabled spectators to spawn at the center of the AO, which should help replication load times on large maps.