### PR TITLE
Changes from WCS PGO7 to Vanilla PGO7

### DIFF
--- a/Configs/Gearscripts/Standard/80s/CRF_GS_East_GER_80s.conf
+++ b/Configs/Gearscripts/Standard/80s/CRF_GS_East_GER_80s.conf
@@ -117,21 +117,20 @@ CRF_GearScriptConfig {
   m_Weapon "{722CE6FEC39EE896}Prefabs/Weapons/Launchers/RPG22/Launcher_RPG22.et"
  }
  m_MAT CRF_Spec_Weapon_Class "{673C05F7161940F8}" {
-  m_Weapon "{AC4C33E8AE72A9F9}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7_rhs_CRF.et"
+  m_Weapon "{E8A55396050E1762}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7.et"
   m_MagazineArray {
-   CRF_Spec_Magazine_Class "{673C05F716194045}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AF}" {
     m_Magazine "{86A7681BD1D4E4BB}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VR.et"
-    m_MagazineCount 0
     m_AssistantMagazineCount 1
    }
-   CRF_Spec_Magazine_Class "{673C05F716194044}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AC}" {
     m_Magazine "{4A3B196E4EA820E9}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_OG7V.et"
     m_MagazineCount 1
     m_AssistantMagazineCount 1
    }
-   CRF_Spec_Magazine_Class "{673C05F71619403B}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AA}" {
     m_Magazine "{FBBF84E3B447D822}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VL.et"
-    m_MagazineCount 1
+    m_MagazineCount 2
     m_AssistantMagazineCount 2
    }
   }

--- a/Configs/Gearscripts/Standard/80s/CRF_GS_FIA.conf
+++ b/Configs/Gearscripts/Standard/80s/CRF_GS_FIA.conf
@@ -136,21 +136,20 @@ CRF_GearScriptConfig {
   m_Weapon "{722CE6FEC39EE896}Prefabs/Weapons/Launchers/RPG22/Launcher_RPG22.et"
  }
  m_MAT CRF_Spec_Weapon_Class "{628CDE935E91D224}" {
-  m_Weapon "{AC4C33E8AE72A9F9}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7_rhs_CRF.et"
+  m_Weapon "{E8A55396050E1762}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7.et"
   m_MagazineArray {
-   CRF_Spec_Magazine_Class "{628CDE935E91D230}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AF}" {
     m_Magazine "{86A7681BD1D4E4BB}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VR.et"
-    m_MagazineCount 0
     m_AssistantMagazineCount 1
    }
-   CRF_Spec_Magazine_Class "{628CDE935E91D232}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AC}" {
     m_Magazine "{4A3B196E4EA820E9}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_OG7V.et"
     m_MagazineCount 1
     m_AssistantMagazineCount 1
    }
-   CRF_Spec_Magazine_Class "{628CDE935E91D234}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AA}" {
     m_Magazine "{FBBF84E3B447D822}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VL.et"
-    m_MagazineCount 1
+    m_MagazineCount 2
     m_AssistantMagazineCount 2
    }
   }

--- a/Configs/Gearscripts/Standard/80s/CRF_GS_USSR80s.conf
+++ b/Configs/Gearscripts/Standard/80s/CRF_GS_USSR80s.conf
@@ -147,7 +147,7 @@ CRF_GearScriptConfig {
   m_Weapon "{722CE6FEC39EE896}Prefabs/Weapons/Launchers/RPG22/Launcher_RPG22.et"
  }
  m_MAT CRF_Spec_Weapon_Class "{629D042DD805C5D8}" {
-  m_Weapon "{AC4C33E8AE72A9F9}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7_rhs_CRF.et"
+  m_Weapon "{E8A55396050E1762}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7.et"
   m_MagazineArray {
    CRF_Spec_Magazine_Class "{629D042DD805C5AF}" {
     m_Magazine "{86A7681BD1D4E4BB}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VR.et"
@@ -161,7 +161,7 @@ CRF_GearScriptConfig {
    }
    CRF_Spec_Magazine_Class "{629D042DD805C5AA}" {
     m_Magazine "{FBBF84E3B447D822}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VL.et"
-    m_MagazineCount 1
+    m_MagazineCount 2
     m_AssistantMagazineCount 2
    }
   }

--- a/Configs/Gearscripts/Standard/GWOT/CRF_GS_2000s_Iraq.conf
+++ b/Configs/Gearscripts/Standard/GWOT/CRF_GS_2000s_Iraq.conf
@@ -118,21 +118,20 @@ CRF_GearScriptConfig {
   m_Weapon "{722CE6FEC39EE896}Prefabs/Weapons/Launchers/RPG22/Launcher_RPG22.et"
  }
  m_MAT CRF_Spec_Weapon_Class "{673A76F52B829B04}" {
-  m_Weapon "{AC4C33E8AE72A9F9}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7_rhs_CRF.et"
+  m_Weapon "{E8A55396050E1762}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7.et"
   m_MagazineArray {
-   CRF_Spec_Magazine_Class "{673A76F52B829B07}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AF}" {
     m_Magazine "{86A7681BD1D4E4BB}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VR.et"
-    m_MagazineCount 0
     m_AssistantMagazineCount 1
    }
-   CRF_Spec_Magazine_Class "{673A76F52B829B06}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AC}" {
     m_Magazine "{4A3B196E4EA820E9}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_OG7V.et"
     m_MagazineCount 1
     m_AssistantMagazineCount 1
    }
-   CRF_Spec_Magazine_Class "{673A76F52B829B01}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AA}" {
     m_Magazine "{FBBF84E3B447D822}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VL.et"
-    m_MagazineCount 1
+    m_MagazineCount 2
     m_AssistantMagazineCount 2
    }
   }

--- a/Configs/Gearscripts/Standard/GWOT/CRF_GS_MEC.conf
+++ b/Configs/Gearscripts/Standard/GWOT/CRF_GS_MEC.conf
@@ -130,21 +130,20 @@ CRF_GearScriptConfig {
   }
  }
  m_MAT CRF_Spec_Weapon_Class "{689427E88A4454D9}" {
-  m_Weapon "{AC4C33E8AE72A9F9}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7_rhs_CRF.et"
+  m_Weapon "{E8A55396050E1762}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7.et"
   m_MagazineArray {
-   CRF_Spec_Magazine_Class "{689427E88A4454DA}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AF}" {
     m_Magazine "{86A7681BD1D4E4BB}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VR.et"
-    m_MagazineCount 0
     m_AssistantMagazineCount 1
    }
-   CRF_Spec_Magazine_Class "{689427E88A4454DB}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AC}" {
     m_Magazine "{4A3B196E4EA820E9}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_OG7V.et"
     m_MagazineCount 1
     m_AssistantMagazineCount 1
    }
-   CRF_Spec_Magazine_Class "{689427E88A4454DC}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AA}" {
     m_Magazine "{FBBF84E3B447D822}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VL.et"
-    m_MagazineCount 1
+    m_MagazineCount 2
     m_AssistantMagazineCount 2
    }
   }

--- a/Configs/Gearscripts/Standard/GWOT/CRF_GS_MEInsurgents.conf
+++ b/Configs/Gearscripts/Standard/GWOT/CRF_GS_MEInsurgents.conf
@@ -116,21 +116,20 @@ CRF_GearScriptConfig {
   }
  }
  m_MAT CRF_Spec_Weapon_Class "{65823349F66CA6C9}" {
-  m_Weapon "{AC4C33E8AE72A9F9}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7_rhs_CRF.et"
+  m_Weapon "{E8A55396050E1762}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7.et"
   m_MagazineArray {
-   CRF_Spec_Magazine_Class "{65823349F66CA6CE}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AF}" {
     m_Magazine "{86A7681BD1D4E4BB}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VR.et"
-    m_MagazineCount 0
     m_AssistantMagazineCount 1
    }
-   CRF_Spec_Magazine_Class "{65823349F66CA6CD}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AC}" {
     m_Magazine "{4A3B196E4EA820E9}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_OG7V.et"
     m_MagazineCount 1
     m_AssistantMagazineCount 1
    }
-   CRF_Spec_Magazine_Class "{65823349F66CA6B2}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AA}" {
     m_Magazine "{FBBF84E3B447D822}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VL.et"
-    m_MagazineCount 1
+    m_MagazineCount 2
     m_AssistantMagazineCount 2
    }
   }

--- a/Configs/Gearscripts/Standard/GWOT/CRF_GS_RUSMilitia.conf
+++ b/Configs/Gearscripts/Standard/GWOT/CRF_GS_RUSMilitia.conf
@@ -187,21 +187,20 @@ CRF_GearScriptConfig {
   m_Weapon "{3FEEC75992196DAC}Prefabs/Weapons/Launchers/RPG18/Launcher_RPG18.et"
  }
  m_MAT CRF_Spec_Weapon_Class "{66723B2D04CD1F0F}" {
-  m_Weapon "{AC4C33E8AE72A9F9}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7_rhs_CRF.et"
+  m_Weapon "{E8A55396050E1762}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7.et"
   m_MagazineArray {
-   CRF_Spec_Magazine_Class "{66723B2D04CD1F0E}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AF}" {
     m_Magazine "{86A7681BD1D4E4BB}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VR.et"
-    m_MagazineCount 0
     m_AssistantMagazineCount 1
    }
-   CRF_Spec_Magazine_Class "{66723B2D04CD1F0B}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AC}" {
     m_Magazine "{4A3B196E4EA820E9}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_OG7V.et"
     m_MagazineCount 1
     m_AssistantMagazineCount 1
    }
-   CRF_Spec_Magazine_Class "{66723B2D04CD1F09}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AA}" {
     m_Magazine "{FBBF84E3B447D822}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VL.et"
-    m_MagazineCount 1
+    m_MagazineCount 2
     m_AssistantMagazineCount 2
    }
   }

--- a/Configs/Gearscripts/Standard/Modern/CRF_GS_CDF.conf
+++ b/Configs/Gearscripts/Standard/Modern/CRF_GS_CDF.conf
@@ -90,21 +90,20 @@ CRF_GearScriptConfig {
   m_Weapon "{3FEEC75992196DAC}Prefabs/Weapons/Launchers/RPG18/Launcher_RPG18.et"
  }
  m_MAT CRF_Spec_Weapon_Class "{65472866F7726039}" {
-  m_Weapon "{AC4C33E8AE72A9F9}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7_rhs_CRF.et"
+  m_Weapon "{E8A55396050E1762}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7.et"
   m_MagazineArray {
-   CRF_Spec_Magazine_Class "{65472866F772603E}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AF}" {
     m_Magazine "{86A7681BD1D4E4BB}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VR.et"
-    m_MagazineCount 0
     m_AssistantMagazineCount 1
    }
-   CRF_Spec_Magazine_Class "{65472866F772603D}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AC}" {
     m_Magazine "{4A3B196E4EA820E9}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_OG7V.et"
     m_MagazineCount 1
     m_AssistantMagazineCount 1
    }
-   CRF_Spec_Magazine_Class "{65472866F7726033}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AA}" {
     m_Magazine "{FBBF84E3B447D822}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VL.et"
-    m_MagazineCount 1
+    m_MagazineCount 2
     m_AssistantMagazineCount 2
    }
   }

--- a/Configs/Gearscripts/Standard/Modern/CRF_GS_CDF_Modern_Day.conf
+++ b/Configs/Gearscripts/Standard/Modern/CRF_GS_CDF_Modern_Day.conf
@@ -175,21 +175,20 @@ CRF_GearScriptConfig {
   m_Weapon "{722CE6FEC39EE896}Prefabs/Weapons/Launchers/RPG22/Launcher_RPG22.et"
  }
  m_MAT CRF_Spec_Weapon_Class "{68E62266CC56DDA1}" {
-  m_Weapon "{AC4C33E8AE72A9F9}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7_rhs_CRF.et"
+  m_Weapon "{E8A55396050E1762}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7.et"
   m_MagazineArray {
-   CRF_Spec_Magazine_Class "{68E62266CC5750A2}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AF}" {
     m_Magazine "{86A7681BD1D4E4BB}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VR.et"
-    m_MagazineCount 0
     m_AssistantMagazineCount 1
    }
-   CRF_Spec_Magazine_Class "{68E62266CC5750A9}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AC}" {
     m_Magazine "{4A3B196E4EA820E9}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_OG7V.et"
     m_MagazineCount 1
     m_AssistantMagazineCount 1
    }
-   CRF_Spec_Magazine_Class "{68E62266CC5750AA}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AA}" {
     m_Magazine "{FBBF84E3B447D822}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VL.et"
-    m_MagazineCount 1
+    m_MagazineCount 2
     m_AssistantMagazineCount 2
    }
   }
@@ -324,7 +323,7 @@ CRF_GearScriptConfig {
    m_iItemCount 0
   }
   CRF_Inventory_Item "{68E62266CC547238}" {
-   m_sItemPrefab "{7DEDA95CC6A54555}Prefabs/Characters/Armbands/Single/Armband_Yellow.et"
+   m_sItemPrefab "{7DEDA95CC6A54555}Prefabs/Characters/Armbands/Single/Armband_Single_Yellow.et"
    m_iItemCount 1
   }
  }

--- a/Configs/Gearscripts/Standard/Modern/CRF_GS_CHDKz.conf
+++ b/Configs/Gearscripts/Standard/Modern/CRF_GS_CHDKz.conf
@@ -183,21 +183,20 @@ CRF_GearScriptConfig {
   m_Weapon "{3FEEC75992196DAC}Prefabs/Weapons/Launchers/RPG18/Launcher_RPG18.et"
  }
  m_MAT CRF_Spec_Weapon_Class "{65472860B9186CE0}" {
-  m_Weapon "{AC4C33E8AE72A9F9}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7_rhs_CRF.et"
+  m_Weapon "{E8A55396050E1762}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7.et"
   m_MagazineArray {
-   CRF_Spec_Magazine_Class "{65472860B9186CE1}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AF}" {
     m_Magazine "{86A7681BD1D4E4BB}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VR.et"
-    m_MagazineCount 0
     m_AssistantMagazineCount 1
    }
-   CRF_Spec_Magazine_Class "{65472860B9186CE4}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AC}" {
     m_Magazine "{4A3B196E4EA820E9}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_OG7V.et"
     m_MagazineCount 1
     m_AssistantMagazineCount 1
    }
-   CRF_Spec_Magazine_Class "{65472860B9186D1A}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AA}" {
     m_Magazine "{FBBF84E3B447D822}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VL.et"
-    m_MagazineCount 1
+    m_MagazineCount 2
     m_AssistantMagazineCount 2
    }
   }

--- a/Configs/Gearscripts/Standard/Modern/CRF_GS_RHSMSV.conf
+++ b/Configs/Gearscripts/Standard/Modern/CRF_GS_RHSMSV.conf
@@ -90,21 +90,20 @@ CRF_GearScriptConfig {
   m_Weapon "{722CE6FEC39EE896}Prefabs/Weapons/Launchers/RPG22/Launcher_RPG22.et"
  }
  m_MAT CRF_Spec_Weapon_Class "{629D042A59FA7CCE}" {
-  m_Weapon "{AC4C33E8AE72A9F9}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7_rhs_CRF.et"
+  m_Weapon "{E8A55396050E1762}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7.et"
   m_MagazineArray {
-   CRF_Spec_Magazine_Class "{629D042A59FA7CC1}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AF}" {
     m_Magazine "{86A7681BD1D4E4BB}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VR.et"
-    m_MagazineCount 0
     m_AssistantMagazineCount 1
    }
-   CRF_Spec_Magazine_Class "{629D042A59FA7CC3}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AC}" {
     m_Magazine "{4A3B196E4EA820E9}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_OG7V.et"
     m_MagazineCount 1
     m_AssistantMagazineCount 1
    }
-   CRF_Spec_Magazine_Class "{629D042A59FA7CC5}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AA}" {
     m_Magazine "{FBBF84E3B447D822}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VL.et"
-    m_MagazineCount 1
+    m_MagazineCount 2
     m_AssistantMagazineCount 2
    }
   }

--- a/Configs/Gearscripts/Standard/Modern/CRF_GS_RHS_AFRF_Modern_Day.conf
+++ b/Configs/Gearscripts/Standard/Modern/CRF_GS_RHS_AFRF_Modern_Day.conf
@@ -130,21 +130,20 @@ CRF_GearScriptConfig {
   m_Weapon "{722CE6FEC39EE896}Prefabs/Weapons/Launchers/RPG22/Launcher_RPG22.et"
  }
  m_MAT CRF_Spec_Weapon_Class "{68E62279AD3992DE}" {
-  m_Weapon "{AC4C33E8AE72A9F9}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7_rhs_CRF.et"
+  m_Weapon "{E8A55396050E1762}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7.et"
   m_MagazineArray {
-   CRF_Spec_Magazine_Class "{68E62279AD3992DF}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AF}" {
     m_Magazine "{86A7681BD1D4E4BB}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VR.et"
-    m_MagazineCount 0
     m_AssistantMagazineCount 1
    }
-   CRF_Spec_Magazine_Class "{68E62279AD3992DC}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AC}" {
     m_Magazine "{4A3B196E4EA820E9}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_OG7V.et"
     m_MagazineCount 1
     m_AssistantMagazineCount 1
    }
-   CRF_Spec_Magazine_Class "{68E62279AD398BBD}" {
+   CRF_Spec_Magazine_Class "{629D042DD805C5AA}" {
     m_Magazine "{FBBF84E3B447D822}Prefabs/Weapons/Ammo/RPG/RHS_AmmoRocket_PG7VL.et"
-    m_MagazineCount 1
+    m_MagazineCount 2
     m_AssistantMagazineCount 2
    }
   }
@@ -275,7 +274,7 @@ CRF_GearScriptConfig {
    m_iItemCount 0
   }
   CRF_Inventory_Item "{68E62266FAD4777C}" {
-   m_sItemPrefab "{6353534ADC6D67B4}Prefabs/Characters/Armbands/Single/Armband_White.et"
+   m_sItemPrefab "{6353534ADC6D67B4}Prefabs/Characters/Armbands/Single/Armband_Single_White.et"
    m_iItemCount 1
   }
  }

--- a/Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7_rhs_CRF.et
+++ b/Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7_pgo7_rhs_CRF.et
@@ -5,7 +5,7 @@ GenericEntity : "{7A82FE978603F137}Prefabs/Weapons/Launchers/RPG7/Launcher_RPG7.
    components {
     AttachmentSlotComponent "{B502E4DC8A9E835E}" {
      AttachmentSlot InventoryStorageSlot optics {
-      Prefab "{8F83CE66A8F44D72}Prefabs/Weapons/Attachments/Optics/pgo7v3/Optic_PGO7V3.et"
+      Prefab "{E5E9DBBF3BFB88C6}Prefabs/Weapons/Attachments/Optics/Optic_PGO7/Optic_PGO7V3.et"
      }
     }
     SCR_MuzzleInMagComponent "{50F65D04F21F7633}" {


### PR DESCRIPTION
We largely use one prefab, Launcher_RPG7_pgo7_rhs_CRF.et, for the bulk of our gear scripts. I changed the scope on it from the WCS version to the vanilla since WCS crashed yesterday, and is still crashing today for me. 