### PR TITLE
New Mission | Harry Raid93 Counters

### DIFF
--- a/Configs/Gearscripts/Custom/Harry/50s/CRF_GS_US50s.conf
+++ b/Configs/Gearscripts/Custom/Harry/50s/CRF_GS_US50s.conf
@@ -82,7 +82,7 @@ CRF_GearScriptConfig {
    CRF_Spec_Magazine_Class "{691AD02AE258B75F}" {
     m_Magazine "{34A82AA1E0CBFE4B}Prefabs/Weapons/Magazines/BC_Magazine_30-06_BAR_20rnd_M2_4Ball_1Tracer.et"
     m_MagazineCount 21
-    m_AssistantMagazineCount 42
+    m_AssistantMagazineCount 21
    }
   }
  }

--- a/Configs/Gearscripts/Custom/Harry/50s/CRF_GS_US50s.conf
+++ b/Configs/Gearscripts/Custom/Harry/50s/CRF_GS_US50s.conf
@@ -1,0 +1,579 @@
+CRF_GearScriptConfig {
+ m_FactionName "US Army"
+ m_FactionIcon "{EB7F65DBC9392557}UI/Textures/Editor/EditableEntities/Factions/EditableEntity_Faction_USA.edds"
+ m_FactionIdentity "{93C4AAA0496F0B42}Configs/Identities/North America/CRF_CharacterIdentity_American.conf"
+ m_Rifles {
+  CRF_Weapon_Class "{691AD02AE25736B6}" {
+   m_Weapon "{8F5A4A44DD1D84D6}Prefabs/Weapons/Rifles/M1 Garand/BC_Rifle_M1_Garand.et"
+   m_MagazineArray {
+    CRF_Magazine_Class "{691AD02AE257366C}" {
+     m_Magazine "{6224DDAB578E96C0}Prefabs/Weapons/Magazines/M1 Garand/BC_Clip_8rnd_M1_Garand.et"
+     m_MagazineCount 30
+    }
+   }
+  }
+  CRF_Weapon_Class "{691AD02F142A8AD6}" {
+   m_Weapon "{B31929F65F0D0279}Prefabs/Weapons/Rifles/M14/Rifle_M21.et"
+   m_MagazineArray {
+    CRF_Magazine_Class "{691AD02F4F904F9B}" {
+     m_Magazine "{D963A7DB30D19B4E}Prefabs/Weapons/Magazines/762x51_M14_20rnd/Magazine_762x51_M14_20rnd_4Ball_1Tracer_M80_M62.et"
+     m_MagazineCount 20
+    }
+   }
+  }
+ }
+ m_RifleUGLs {
+  CRF_Weapon_Class "{691AD02AE2573669}" {
+   m_Weapon "{B31929F65F0D0279}Prefabs/Weapons/Rifles/M14/Rifle_M21.et"
+   m_MagazineArray {
+    CRF_Magazine_Class "{691AD02F4F904F9B}" {
+     m_Magazine "{D963A7DB30D19B4E}Prefabs/Weapons/Magazines/762x51_M14_20rnd/Magazine_762x51_M14_20rnd_4Ball_1Tracer_M80_M62.et"
+     m_MagazineCount 20
+    }
+   }
+  }
+  CRF_Weapon_Class "{691AD02FB00B0776}" {
+   m_Weapon "{B6673927CF21BE87}Prefabs/Weapons/Rifles/Thompson M1A1/BC_Rifle_Thompson_M1A1.et"
+   m_MagazineArray {
+    CRF_Magazine_Class "{691AD02F8322B529}" {
+     m_Magazine "{5C43D5083942A22B}Prefabs/Weapons/Magazines/Thompson/BC_Magazine_M1A1_45acp_Thompson_30rnd_Stick.et"
+     m_MagazineCount 12
+    }
+   }
+  }
+  CRF_Weapon_Class "{691AD02F9B1302F6}" {
+   m_Weapon "{9E8405BDD24BCF69}Prefabs/Weapons/Shotguns/Ithaca 37/BC_Shotgun_Ithaca_37_V2.et"
+   m_Attachments {
+    "{5E6EE617A4C5469D}Prefabs/Weapons/Attachments/Bayonets/BC_Bayonet_M1917.et"
+   }
+   m_MagazineArray {
+    CRF_Magazine_Class "{691AD02FF34C15F3}" {
+     m_Magazine "{B0DFDF7AAA9C5D39}Prefabs/Weapons/Magazines/BC_Shell_12ga_Buckshot.et"
+     m_MagazineCount 40
+    }
+   }
+  }
+ }
+ m_Carbines {
+  CRF_Weapon_Class "{691AD02AE257366A}" {
+   m_Weapon "{8F5A4A44DD1D84D6}Prefabs/Weapons/Rifles/M1 Garand/BC_Rifle_M1_Garand.et"
+   m_MagazineArray {
+    CRF_Magazine_Class "{691AD02AE258B746}" {
+     m_Magazine "{6224DDAB578E96C0}Prefabs/Weapons/Magazines/M1 Garand/BC_Clip_8rnd_M1_Garand.et"
+     m_MagazineCount 30
+    }
+   }
+  }
+ }
+ m_Pistols {
+  CRF_Weapon_Class "{691AD02AE258B75B}" {
+   m_Weapon "{A21FB863A8066E58}Prefabs/Weapons/Handguns/ARY_1911/ARY_Handgun_1911.et"
+   m_MagazineArray {
+    CRF_Magazine_Class "{691AD02AE258B75D}" {
+     m_Magazine "{81563D558B5BCF69}Prefabs/Weapons/Magazines/ARY_Magazine_45acp_1911_7rnd.et"
+     m_MagazineCount 4
+    }
+   }
+  }
+ }
+ m_AR CRF_Spec_Weapon_Class "{691AD02AE258B75C}" {
+  m_Weapon "{05D871A0CEE5026F}Prefabs/Weapons/MachineGuns/BAR/BC_BAR_M1918A2.et"
+  m_MagazineArray {
+   CRF_Spec_Magazine_Class "{691AD02AE258B75F}" {
+    m_Magazine "{34A82AA1E0CBFE4B}Prefabs/Weapons/Magazines/BC_Magazine_30-06_BAR_20rnd_M2_4Ball_1Tracer.et"
+    m_MagazineCount 21
+    m_AssistantMagazineCount 42
+   }
+  }
+ }
+ m_MMG CRF_Spec_Weapon_Class "{691AD02AE258B751}" {
+  m_Weapon "{05D871A0CEE5026F}Prefabs/Weapons/MachineGuns/BAR/BC_BAR_M1918A2.et"
+  m_MagazineArray {
+   CRF_Spec_Magazine_Class "{691AD02AE258B750}" {
+    m_Magazine "{34A82AA1E0CBFE4B}Prefabs/Weapons/Magazines/BC_Magazine_30-06_BAR_20rnd_M2_4Ball_1Tracer.et"
+    m_MagazineCount 21
+    m_AssistantMagazineCount 42
+   }
+  }
+ }
+ m_SNIPER CRF_Weapon_Class "{691AD02AE258B753}" {
+  m_Weapon "{898B4433EED614A4}Prefabs/Weapons/Rifles/M1 Garand/BC_Rifle_M1D.et"
+  m_MagazineArray {
+   CRF_Magazine_Class "{691AD02AE258B752}" {
+    m_Magazine "{6224DDAB578E96C0}Prefabs/Weapons/Magazines/M1 Garand/BC_Clip_8rnd_M1_Garand.et"
+    m_MagazineCount 30
+   }
+  }
+ }
+ m_DefaultClothing {
+  CRF_Clothing "{691AD02AE258B755}" {
+   m_iClothingType BACKPACK
+   m_ClothingPrefabs {
+    "{CE832B86D234AD62}Prefabs/Items/Equipment/Backpacks/CRF_Backpack_Invisable.et"
+   }
+  }
+  CRF_Clothing "{691AD02AE258B754}" {
+   m_iClothingType HEADGEAR
+   m_ClothingPrefabs {
+    "{6E14F80C250F85FC}Prefabs/Characters/HeadGear/Helmet_M1_01/Helmet_M1_01.et"
+   }
+  }
+  CRF_Clothing "{691AD02AE258B73E}" {
+   m_iClothingType SHIRT
+   m_ClothingPrefabs {
+    "{293F577C298061E3}Prefabs/Characters/Uniforms/Jacket_US_BDU_02.et"
+    "{A080C1AEBF921DC4}Prefabs/Characters/Uniforms/Jacket_US_BDU_rolledup_02.et"
+   }
+  }
+  CRF_Clothing "{691AD02AE258059E}" {
+   m_iClothingType PANTS
+   m_ClothingPrefabs {
+    "{86BB79B9A2233780}Prefabs/Characters/Uniforms/Pants_US_M65.et"
+   }
+  }
+  CRF_Clothing "{691AD02AE2580591}" {
+   m_iClothingType BOOTS
+   m_ClothingPrefabs {
+    "{DAAFD15478BDE1C3}Prefabs/Characters/Footwear/CombatBoots_US_01.et"
+   }
+  }
+  CRF_Clothing "{691AD02AE2580590}" {
+   m_iClothingType VEST
+   m_ClothingPrefabs {
+    "{1033EBAF2CD0FD52}Prefabs/Characters/Vests/Vest_58Pattern/Variants/Vest_P58_rifleman_2.et"
+   }
+  }
+ }
+ m_sLeadershipBinocularsPrefab "{E4E4CA52CCB2D22C}Prefabs/Items/Equipment/Binoculars/Binoculars_M22/Binoculars_M22_base.et"
+ m_sAssistantBinocularsPrefab "{0CF54B9A85D8E0D4}Prefabs/Items/Equipment/Binoculars/Binoculars_M22/Binoculars_M22.et"
+ m_DefaultInventoryItems {
+  CRF_Inventory_Item "{691AD02AE2580592}" {
+   m_sItemPrefab "{3A421547BC29F679}Prefabs/Items/Equipment/Flashlights/Flashlight_MX991/Flashlight_MX991.et"
+   m_iItemCount 1
+  }
+  CRF_Inventory_Item "{691AD02AE2598C95}" {
+   m_sItemPrefab "{E8F00BF730225B00}Prefabs/Weapons/Grenades/Grenade_M67.et"
+   m_iItemCount 2
+  }
+  CRF_Inventory_Item "{691AD02AE2598C92}" {
+   m_sItemPrefab "{9DB69176CEF0EE97}Prefabs/Weapons/Grenades/Smoke_ANM8HC.et"
+   m_iItemCount 2
+  }
+  CRF_Inventory_Item "{691AD02AE2598C93}" {
+   m_sItemPrefab "{61D4F80E49BF9B12}Prefabs/Items/Equipment/Compass/Compass_SY183.et"
+   m_iItemCount 1
+  }
+  CRF_Inventory_Item "{691AD02AE2598C90}" {
+   m_sItemPrefab "{13772C903CB5E4F7}Prefabs/Items/Equipment/Maps/Map_Paper_01/PaperMap_01_folded.et"
+   m_iItemCount 1
+  }
+  CRF_Inventory_Item "{691AD02AE2598C91}" {
+   m_sItemPrefab "{78ED4FEF62BBA728}Prefabs/Items/Equipment/Watches/Watch_SandY184A.et"
+   m_iItemCount 1
+  }
+  CRF_Inventory_Item "{691AD02AE2598CAE}" {
+   m_sItemPrefab "{6E35D94130954509}Prefabs/Items/Equipment/Accessories/ETool_ALICE/ETool_ALICE_FreeRoamBuilding_Gadget.et"
+   m_iItemCount 1
+  }
+  CRF_Inventory_Item "{691AD02AE2598CA5}" {
+   m_sItemPrefab "{CBF9B9942E07B6B8}Prefabs/Items/Equipment/Accessories/ZipCuffs/ACE_Captives_ZipCuffs.et"
+   m_iItemCount 2
+  }
+  CRF_Inventory_Item "{691AD02AE2598CA2}" {
+   m_sItemPrefab "{6676FF9B716402CC}Prefabs/Items/PersonalBelongings/PersonalBelongings_US.et"
+   m_iItemCount 0
+  }
+ }
+ m_InfantryMedicalItems {
+  CRF_Inventory_Item "{691AD02AE2598CA3}" {
+   m_sItemPrefab "{A81F501D3EF6F38E}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_US_01.et"
+   m_iItemCount 2
+  }
+  CRF_Inventory_Item "{691AD02AE2598CA0}" {
+   m_sItemPrefab "{D70216B1B2889129}Prefabs/Items/Medicine/Tourniquet_01/Tourniquet_US_01.et"
+   m_iItemCount 1
+  }
+ }
+ m_MedicMedicalItems {
+  CRF_Inventory_Item "{691AD02AE2598CA1}" {
+   m_sItemPrefab "{A81F501D3EF6F38E}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_US_01.et"
+   m_iItemCount 10
+  }
+  CRF_Inventory_Item "{691AD02AE2598CBE}" {
+   m_sItemPrefab "{D70216B1B2889129}Prefabs/Items/Medicine/Tourniquet_01/Tourniquet_US_01.et"
+   m_iItemCount 3
+  }
+  CRF_Inventory_Item "{691AD02AE2598CBF}" {
+   m_sItemPrefab "{0D9A5DCF89AE7AA9}Prefabs/Items/Medicine/MorphineInjection_01/MorphineInjection_01.et"
+   m_iItemCount 6
+  }
+  CRF_Inventory_Item "{691AD02AE2599974}" {
+   m_sItemPrefab "{5B2FD067D70C1E8F}Prefabs/Items/Medicine/EpinephrineInjection/ACE_Medical_EpinephrineInjection.et"
+   m_iItemCount 6
+  }
+  CRF_Inventory_Item "{691AD02AE2599977}" {
+   m_sItemPrefab "{00E36F41CA310E2A}Prefabs/Items/Medicine/SalineBag_01/SalineBag_US_01.et"
+   m_iItemCount 5
+  }
+  CRF_Inventory_Item "{691AD02AE2599976}" {
+   m_sItemPrefab "{AE578EEA4244D41F}Prefabs/Items/Equipment/Kits/MedicalKit_01/MedicalKit_01_US.et"
+   m_iItemCount 1
+  }
+  CRF_Inventory_Item "{691AD02AE2599971}" {
+   m_sItemPrefab "{14C1A0F061D9DDEE}Prefabs/Weapons/Grenades/M18/Smoke_M18_Violet.et"
+   m_iItemCount 1
+  }
+  CRF_Inventory_Item "{691AD02AE259ACC0}" {
+   m_sItemPrefab "{D41D22DD1B8E921E}Prefabs/Weapons/Grenades/M18/Smoke_M18_Green.et"
+   m_iItemCount 1
+  }
+  CRF_Inventory_Item "{691AD02AE259ACC2}" {
+   m_sItemPrefab "{58CF3AB87C441295}Prefabs/Items/Medicine/AmmoniumCarbonatePackage/ACE_Medical_AmmoniumCarbonatePackage.et"
+   m_iItemCount 10
+  }
+  CRF_Inventory_Item "{691AD02AE25946F2}" {
+   m_sItemPrefab "{02DD34077F51F65E}Prefabs/Items/Medicine/NaloxoneInjection/ACE_Medical_NaloxoneInjection.et"
+   m_iItemCount 6
+  }
+  CRF_Inventory_Item "{691AD02AE25946FC}" {
+   m_sItemPrefab "{9BBA766CD869002C}Prefabs/Items/Medicine/PhenylephrineInjection/ACE_Medical_PhenylephrineInjection.et"
+   m_iItemCount 6
+  }
+  CRF_Inventory_Item "{691AD02AE259163C}" {
+   m_sItemPrefab "{D0434D5215B54181}Prefabs/Items/Medicine/MetoprololInjection/ACE_Medical_MetoprololInjection.et"
+   m_iItemCount 6
+  }
+  CRF_Inventory_Item "{691AD02AE259163D}" {
+   m_sItemPrefab "{9DB69176CEF0EE97}Prefabs/Weapons/Grenades/Smoke_ANM8HC.et"
+   m_iItemCount 2
+  }
+ }
+ m_RolesToSetCustomSettings {
+  CRF_Role_Custom_Gear "{691AD02AE259163E}" {
+   m_Role VEHICLE_LEAD
+   m_Clothing {
+    CRF_Clothing "{691AD02AE259163F}" {
+     m_iClothingType PANTS
+     m_ClothingPrefabs {
+      ""
+     }
+    }
+    CRF_Clothing "{691AD02AE2591638}" {
+     m_iClothingType SHIRT
+     m_ClothingPrefabs {
+      "{1D99585CF8E34D91}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01.et"
+      "{A4145024AE7084F6}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01_tucked.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE2591639}" {
+   m_Role INDIRECT_LEAD
+   m_AdditionalInventoryItems {
+    CRF_Inventory_Item "{691AD02AE259163A}" {
+     m_sItemPrefab "{6113990D163E5249}Prefabs/Items/Equipment/BalisticTable/BalisticTable_US.et"
+     m_iItemCount 1
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE25915C9}" {
+   m_Role LOGI_LEAD
+   m_Clothing {
+    CRF_Clothing "{691AD02AE25915CB}" {
+     m_iClothingType BACKPACK
+     m_ClothingPrefabs {
+      "{06B68C58B72EAAC6}Prefabs/Items/Equipment/Backpacks/Backpack_ALICE_Medium.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE25AE5E3}" {
+   m_Role MEDICAL_OFFICER
+   m_Clothing {
+    CRF_Clothing "{691AD02AE25AE5FC}" {
+     m_iClothingType BACKPACK
+     m_ClothingPrefabs {
+      "{4805E67E2AE30F8D}Prefabs/Items/Equipment/Backpacks/Backpack_Medical_M5.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE25AE5FD}" {
+   m_Role MEDIC
+   m_Clothing {
+    CRF_Clothing "{691AD02AE25AE5FE}" {
+     m_iClothingType BACKPACK
+     m_ClothingPrefabs {
+      "{4805E67E2AE30F8D}Prefabs/Items/Equipment/Backpacks/Backpack_Medical_M5.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE25AE5FF}" {
+   m_Role ASSISTANT_AUTOMATIC_RIFLEMAN
+   m_Clothing {
+    CRF_Clothing "{691AD02AE25AE5F8}" {
+     m_iClothingType BACKPACK
+     m_ClothingPrefabs {
+      "{06B68C58B72EAAC6}Prefabs/Items/Equipment/Backpacks/Backpack_ALICE_Medium.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE25AE5F9}" {
+   m_Role ASSISTANT_RIFLEMAN_ANTITANK
+   m_Clothing {
+    CRF_Clothing "{691AD02AE25AE5FA}" {
+     m_iClothingType BACKPACK
+     m_ClothingPrefabs {
+      "{06B68C58B72EAAC6}Prefabs/Items/Equipment/Backpacks/Backpack_ALICE_Medium.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE25A5D89}" {
+   m_Role ASSISTANT_HEAVY_ANTITANK
+   m_Clothing {
+    CRF_Clothing "{691AD02AE25A5D87}" {
+     m_iClothingType BACKPACK
+     m_ClothingPrefabs {
+      "{06B68C58B72EAAC6}Prefabs/Items/Equipment/Backpacks/Backpack_ALICE_Medium.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE25A1202}" {
+   m_Role ASSISTANT_MEDIUM_ANTITANK
+   m_Clothing {
+    CRF_Clothing "{691AD02AE25A1200}" {
+     m_iClothingType BACKPACK
+     m_ClothingPrefabs {
+      "{06B68C58B72EAAC6}Prefabs/Items/Equipment/Backpacks/Backpack_ALICE_Medium.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE25A1201}" {
+   m_Role ASSISTANT_HEAVY_MACHINEGUN
+   m_Clothing {
+    CRF_Clothing "{691AD02AE25A1206}" {
+     m_iClothingType BACKPACK
+     m_ClothingPrefabs {
+      "{06B68C58B72EAAC6}Prefabs/Items/Equipment/Backpacks/Backpack_ALICE_Medium.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE25A1207}" {
+   m_Role ASSISTANT_MEDIUM_MACHINEGUN
+   m_Clothing {
+    CRF_Clothing "{691AD02AE25A1204}" {
+     m_iClothingType BACKPACK
+     m_ClothingPrefabs {
+      "{06B68C58B72EAAC6}Prefabs/Items/Equipment/Backpacks/Backpack_ALICE_Medium.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE25A1205}" {
+   m_Role ASSISTANT_ANTI_AIR
+   m_Clothing {
+    CRF_Clothing "{691AD02AE25A123A}" {
+     m_iClothingType BACKPACK
+     m_ClothingPrefabs {
+      "{06B68C58B72EAAC6}Prefabs/Items/Equipment/Backpacks/Backpack_ALICE_Medium.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE25A123B}" {
+   m_Role VEHICLE_DRIVER
+   m_Clothing {
+    CRF_Clothing "{691AD02AE25A1238}" {
+     m_iClothingType PANTS
+     m_ClothingPrefabs {
+      ""
+     }
+    }
+    CRF_Clothing "{691AD02AE25BDFD1}" {
+     m_iClothingType SHIRT
+     m_ClothingPrefabs {
+      "{1D99585CF8E34D91}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01.et"
+      "{A4145024AE7084F6}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01_tucked.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE25BDFD0}" {
+   m_Role VEHICLE_GUNNER
+   m_Clothing {
+    CRF_Clothing "{691AD02AE25BDFD7}" {
+     m_iClothingType PANTS
+     m_ClothingPrefabs {
+      ""
+     }
+    }
+    CRF_Clothing "{691AD02AE25BB0E5}" {
+     m_iClothingType SHIRT
+     m_ClothingPrefabs {
+      "{1D99585CF8E34D91}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01.et"
+      "{A4145024AE7084F6}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01_tucked.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE25BB0E4}" {
+   m_Role VEHICLE_LOADER
+   m_Clothing {
+    CRF_Clothing "{691AD02AE25BB0E7}" {
+     m_iClothingType PANTS
+     m_ClothingPrefabs {
+      ""
+     }
+    }
+    CRF_Clothing "{691AD02AE25BB0E6}" {
+     m_iClothingType SHIRT
+     m_ClothingPrefabs {
+      "{1D99585CF8E34D91}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01.et"
+      "{A4145024AE7084F6}Prefabs/Characters/Uniforms/Suit_Tanker_US_01/Suit_Tanker_US_01_tucked.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE25BB0E9}" {
+   m_Role PILOT
+   m_Clothing {
+    CRF_Clothing "{691AD02AE25BB0E8}" {
+     m_iClothingType PANTS
+     m_ClothingPrefabs {
+      ""
+     }
+    }
+    CRF_Clothing "{691AD02AE25BB0DD}" {
+     m_iClothingType SHIRT
+     m_ClothingPrefabs {
+      "{B137B7CE988557D2}Prefabs/Characters/Uniforms/Suit_Pilot_US_01/Suit_Pilot_US_01.et"
+     }
+    }
+    CRF_Clothing "{691AD02AE25BB0DE}" {
+     m_iClothingType HEADGEAR
+     m_ClothingPrefabs {
+      "{483A80042765275F}Prefabs/Characters/HeadGear/Helmet_SPH4_01/Helmet_SPH4_01.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE25BB0DF}" {
+   m_Role CREW_CHIEF
+   m_Clothing {
+    CRF_Clothing "{691AD02AE25BB0D8}" {
+     m_iClothingType PANTS
+     m_ClothingPrefabs {
+      ""
+     }
+    }
+    CRF_Clothing "{691AD02AE25BB0D9}" {
+     m_iClothingType SHIRT
+     m_ClothingPrefabs {
+      "{B137B7CE988557D2}Prefabs/Characters/Uniforms/Suit_Pilot_US_01/Suit_Pilot_US_01.et"
+     }
+    }
+    CRF_Clothing "{691AD02AE25BB0DA}" {
+     m_iClothingType HEADGEAR
+     m_ClothingPrefabs {
+      "{483A80042765275F}Prefabs/Characters/HeadGear/Helmet_SPH4_01/Helmet_SPH4_01.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE25BB0DB}" {
+   m_Role LOGI_RUNNER
+   m_Clothing {
+    CRF_Clothing "{691AD02AE25BB0C4}" {
+     m_iClothingType BACKPACK
+     m_ClothingPrefabs {
+      "{06B68C58B72EAAC6}Prefabs/Items/Equipment/Backpacks/Backpack_ALICE_Medium.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE25BB0C5}" {
+   m_Role RIFLEMAN_DEMO
+   m_AdditionalInventoryItems {
+    CRF_Inventory_Item "{691AD02AE25BB0C6}" {
+     m_sItemPrefab "{D9B1F65D20081DEF}PrefabsEditable/Explosives/E_DemoBlock_M112.et"
+     m_iItemCount 2
+    }
+    CRF_Inventory_Item "{691AD02AE25BB0C0}" {
+     m_sItemPrefab "{CE0AF733722B3978}Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_M34.et"
+     m_iItemCount 1
+    }
+    CRF_Inventory_Item "{691AD02AE25B75EF}" {
+     m_sItemPrefab "{55641F140F92FDCD}Prefabs/Weapons/Explosives/Explosive_Satchels/BLUFOR_Satchel.et"
+     m_iItemCount 1
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE25B75EE}" {
+   m_Role COMBAT_ENGINEER
+   m_AdditionalInventoryItems {
+    CRF_Inventory_Item "{691AD02AE25B75ED}" {
+     m_sItemPrefab "{D9B1F65D20081DEF}PrefabsEditable/Explosives/E_DemoBlock_M112.et"
+     m_iItemCount 1
+    }
+    CRF_Inventory_Item "{691AD02AE25B7596}" {
+     m_sItemPrefab "{CE0AF733722B3978}Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_M34.et"
+     m_iItemCount 1
+    }
+    CRF_Inventory_Item "{691AD02AE25B7595}" {
+     m_sItemPrefab "{55641F140F92FDCD}Prefabs/Weapons/Explosives/Explosive_Satchels/BLUFOR_Satchel.et"
+     m_iItemCount 3
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE25B7594}" {
+   m_Role JTAC
+   m_sRoleName "Ammo Bearer"
+   m_AdditionalInventoryItems {
+    CRF_Inventory_Item "{691C06E0259D7ACD}" {
+     m_sItemPrefab "{C820846B0521423B}Prefabs/Weapons/Magazines/Box_127x99_M2_100rnd_4AP_1APIT.et"
+     m_iItemCount 2
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE25B758B}" {
+   m_Role TEAM_LEAD
+   m_sRoleName "Team Lead"
+  }
+  CRF_Role_Custom_Gear "{691AD02AF888830D}" {
+   m_Role DRONE_OPERATOR
+   m_sRoleName "Runner"
+  }
+  CRF_Role_Custom_Gear "{691C06E1F2EF2F27}" {
+   m_Role HEAVY_MACHINEGUN
+   m_AdditionalInventoryItems {
+    CRF_Inventory_Item "{691C06E1FA933F78}" {
+     m_sItemPrefab "{9B625CAE6DEE1DAB}Prefabs/Items/Equipment/Tripods/M2/Part_M2_Gun.et"
+     m_iItemCount 1
+    }
+    CRF_Inventory_Item "{691C06E044BBB80E}" {
+     m_sItemPrefab "{C820846B0521423B}Prefabs/Weapons/Magazines/Box_127x99_M2_100rnd_4AP_1APIT.et"
+     m_iItemCount 1
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691C06E1F61BDBFB}" {
+   m_Role ASSISTANT_HEAVY_MACHINEGUN
+   m_AdditionalInventoryItems {
+    CRF_Inventory_Item "{691C06E1C429C274}" {
+     m_sItemPrefab "{6A3EF260029FE220}Prefabs/Items/Equipment/Tripods/M2/Part_M3_Tripod.et"
+     m_iItemCount 1
+    }
+    CRF_Inventory_Item "{691C06E01AF7D354}" {
+     m_sItemPrefab "{C820846B0521423B}Prefabs/Weapons/Magazines/Box_127x99_M2_100rnd_4AP_1APIT.et"
+     m_iItemCount 1
+    }
+   }
+  }
+ }
+}

--- a/Configs/Gearscripts/Custom/Harry/50s/CRF_GS_US50s.conf.meta
+++ b/Configs/Gearscripts/Custom/Harry/50s/CRF_GS_US50s.conf.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{3E938198ACC1942D}Configs/Gearscripts/Custom/Salami/Iron Sickle/CRF_GS_US50s.conf"
+ Configurations {
+  CONFResourceClass PC {
+  }
+  CONFResourceClass XBOX_ONE : PC {
+  }
+  CONFResourceClass XBOX_SERIES : PC {
+  }
+  CONFResourceClass PS4 : PC {
+  }
+  CONFResourceClass PS5 : PC {
+  }
+  CONFResourceClass HEADLESS : PC {
+  }
+  CONFResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Configs/Gearscripts/Custom/Harry/50s/CRF_GS_USSR50s.conf
+++ b/Configs/Gearscripts/Custom/Harry/50s/CRF_GS_USSR50s.conf
@@ -294,14 +294,7 @@ CRF_GearScriptConfig {
   }
   CRF_Role_Custom_Gear "{691AD02AE8470830}" {
    m_Role ASSISTANT_RIFLEMAN_ANTITANK
-   m_Clothing {
-    CRF_Clothing "{691AD02AE8470831}" {
-     m_iClothingType BACKPACK
-     m_ClothingPrefabs {
-      "{41A9C55B61F375F0}Prefabs/Items/Equipment/Backpacks/Backpack_Kolobok.et"
-     }
-    }
-   }
+   m_sRoleName "Scout"
   }
   CRF_Role_Custom_Gear "{691AD02AE847083E}" {
    m_Role RIFLEMAN_ANTITANK

--- a/Configs/Gearscripts/Custom/Harry/50s/CRF_GS_USSR50s.conf
+++ b/Configs/Gearscripts/Custom/Harry/50s/CRF_GS_USSR50s.conf
@@ -1,0 +1,576 @@
+CRF_GearScriptConfig {
+ m_FactionName "USSR"
+ m_FactionIcon "{40B12B0DF911B856}UI/Textures/Editor/EditableEntities/Factions/EditableEntity_Faction_USSR.edds"
+ m_FactionIdentity "{B96582A978CDF7AD}Configs/Identities/Europe/CRF_CharacterIdentity_Russian.conf"
+ m_Rifles {
+  CRF_Weapon_Class "{691AD02AE8410716}" {
+   m_Weapon "{C1B4F7B87B720EE8}Prefabs/Weapons/Rifles/Mosin/BC_Rifle_Mosin_Nagant_9130.et"
+   m_Attachments {
+    "{4788E8C5C04D2A49}Prefabs/Weapons/Attachments/Bayonets/BC_Bayonet_Mosin.et"
+   }
+   m_MagazineArray {
+    CRF_Magazine_Class "{691AD02AE841070E}" {
+     m_Magazine "{08DB30914359361E}Prefabs/Weapons/Magazines/BC_Magazine_762x54_Stripper_5rnd_Mosin_Nagant.et"
+     m_MagazineCount 50
+    }
+   }
+  }
+  CRF_Weapon_Class "{691CE0ACE58F13FF}" {
+   m_Weapon "{6AA1C567A2F7F8CE}Prefabs/Weapons/Rifles/PPSH41/BC_PPSh41.et"
+   m_MagazineArray {
+    CRF_Magazine_Class "{691AD02AE8410702}" {
+     m_Magazine "{4198718E0E2A3A83}Prefabs/Weapons/Magazines/PPSH41/BC_Magazine_71rd_PPSH41.et"
+     m_MagazineCount 6
+    }
+   }
+  }
+ }
+ m_RifleUGLs {
+  CRF_Weapon_Class "{691AD02AE841070C}" {
+   m_Weapon "{6AA1C567A2F7F8CE}Prefabs/Weapons/Rifles/PPSH41/BC_PPSh41.et"
+   m_MagazineArray {
+    CRF_Magazine_Class "{691AD02AE8410702}" {
+     m_Magazine "{4198718E0E2A3A83}Prefabs/Weapons/Magazines/PPSH41/BC_Magazine_71rd_PPSH41.et"
+     m_MagazineCount 6
+    }
+   }
+  }
+  CRF_Weapon_Class "{691AD02E88D519A8}" {
+   m_Weapon "{41AD4E19A9BDBDCE}Prefabs/Weapons/Rifles/AK47/BC_Rifle_AK47.et"
+   m_MagazineArray {
+    CRF_Magazine_Class "{691AD02CA43ED060}" {
+     m_Magazine "{D66B57C62D7D503C}Prefabs/Weapons/Magazines/AK/BC_Magazine_762x39_AK_30rnd_Last_5Tracer.et"
+     m_MagazineCount 12
+    }
+   }
+  }
+ }
+ m_Carbines {
+  CRF_Weapon_Class "{691AD02AE8410701}" {
+   m_Weapon "{27605E676E55417D}Prefabs/Weapons/Rifles/PPSH41/BC_PPSh41_35rnd.et"
+   m_MagazineArray {
+    CRF_Magazine_Class "{691AD02AE846A80B}" {
+     m_Magazine "{5587A9FD1C78FE17}Prefabs/Weapons/Magazines/PPSH41/BC_Magazine_Ppsh41_35rnd_Stick.et"
+     m_MagazineCount 7
+    }
+   }
+  }
+ }
+ m_Pistols {
+  CRF_Weapon_Class "{691AD02AE846A80D}" {
+   m_Weapon "{C0F7DD85A86B2900}Prefabs/Weapons/Handguns/PM/Handgun_PM.et"
+   m_MagazineArray {
+    CRF_Magazine_Class "{691AD02AE846A80C}" {
+     m_Magazine "{8B853CDD11BA916E}Prefabs/Weapons/Magazines/Magazine_9x18_PM_8rnd_Ball.et"
+     m_MagazineCount 4
+    }
+   }
+  }
+ }
+ m_AR CRF_Spec_Weapon_Class "{691AD02AE846A80F}" {
+  m_Weapon "{102AC2A328B1229E}Prefabs/Weapons/MachineGuns/RPD/BC_RPD.et"
+  m_MagazineArray {
+   CRF_Spec_Magazine_Class "{691AD02AE846A80E}" {
+    m_Magazine "{EB27EF7E8CD118D2}Prefabs/Weapons/Magazines/BC_Drum_762x39_RPD_MACVSOG_125rnd_Mixed.et"
+    m_MagazineCount 12
+    m_AssistantMagazineCount 12
+   }
+  }
+ }
+ m_SNIPER CRF_Weapon_Class "{691AD02AE846E782}" {
+  m_Weapon "{6545DEABED4759E5}Prefabs/Weapons/Rifles/Mosin/BC_Rifle_Mosin_Nagant_9130_PU.et"
+  m_MagazineArray {
+   CRF_Magazine_Class "{691AD02AE8462D32}" {
+    m_Magazine "{08DB30914359361E}Prefabs/Weapons/Magazines/BC_Magazine_762x54_Stripper_5rnd_Mosin_Nagant.et"
+    m_MagazineCount 50
+   }
+  }
+ }
+ m_DefaultClothing {
+  CRF_Clothing "{691AD02AE8462D20}" {
+   m_iClothingType BACKPACK
+   m_ClothingPrefabs {
+    "{CE832B86D234AD62}Prefabs/Items/Equipment/Backpacks/CRF_Backpack_Invisable.et"
+   }
+  }
+  CRF_Clothing "{691AD02AE8462D2F}" {
+   m_iClothingType HEADGEAR
+   m_ClothingPrefabs {
+    "{A7E6D7ECD5F684D7}Prefabs/Characters/HeadGear/Helmet_SSh68_01/Helmet_SSh68_01.et"
+   }
+  }
+  CRF_Clothing "{691AD02AE8464682}" {
+   m_iClothingType SHIRT
+   m_ClothingPrefabs {
+    "{DF51FBE916A0A9FF}Prefabs/Characters/Uniforms/ARY_M69/ARY_Jacket_M69_base.et"
+   }
+  }
+  CRF_Clothing "{691AD02AE8464683}" {
+   m_iClothingType PANTS
+   m_ClothingPrefabs {
+    "{79E1BCA6AD2D7828}Prefabs/Characters/Uniforms/ARY_M69/ARY_Pants_M69_base.et"
+   }
+  }
+  CRF_Clothing "{691AD02AE8464680}" {
+   m_iClothingType BOOTS
+   m_ClothingPrefabs {
+    "{574C12EE0F37DDFF}Prefabs/Characters/Footwear/ARY_CombatBoots_Soviet_Kirza_01.et"
+   }
+  }
+  CRF_Clothing "{691AD02AE8464681}" {
+   m_iClothingType VEST
+   m_ClothingPrefabs {
+    "{08155E701A949620}Prefabs/Characters/Vests/Vest_SovietHarness/Variants/Vest_SovietHarness_rifleman.et"
+   }
+  }
+ }
+ m_sLeadershipBinocularsPrefab "{F2539FA5706E51E4}Prefabs/Items/Equipment/Binoculars/Binoculars_B12/Binoculars_B12.et"
+ m_sAssistantBinocularsPrefab "{F2539FA5706E51E4}Prefabs/Items/Equipment/Binoculars/Binoculars_B12/Binoculars_B12.et"
+ m_DefaultInventoryItems {
+  CRF_Inventory_Item "{691AD02AE8464686}" {
+   m_sItemPrefab "{575EA58E67448C2A}Prefabs/Items/Equipment/Flashlights/Flashlight_Soviet_01/Flashlight_Soviet_01.et"
+   m_iItemCount 1
+  }
+  CRF_Inventory_Item "{691AD02AE8464687}" {
+   m_sItemPrefab "{645C73791ECA1698}Prefabs/Weapons/Grenades/Grenade_RGD5.et"
+   m_iItemCount 2
+  }
+  CRF_Inventory_Item "{691AD02AE8464684}" {
+   m_sItemPrefab "{77EAE5E07DC4678A}Prefabs/Weapons/Grenades/Smoke_RDG2.et"
+   m_iItemCount 2
+  }
+  CRF_Inventory_Item "{691AD02AE8464685}" {
+   m_sItemPrefab "{7CEF68E2BC68CE71}Prefabs/Items/Equipment/Compass/Compass_Adrianov.et"
+   m_iItemCount 1
+  }
+  CRF_Inventory_Item "{691AD02AE846477A}" {
+   m_sItemPrefab "{13772C903CB5E4F7}Prefabs/Items/Equipment/Maps/Map_Paper_01/PaperMap_01_folded.et"
+   m_iItemCount 1
+  }
+  CRF_Inventory_Item "{691AD02AE8464771}" {
+   m_sItemPrefab "{6E35D94130954509}Prefabs/Items/Equipment/Accessories/ETool_ALICE/ETool_ALICE_FreeRoamBuilding_Gadget.et"
+   m_iItemCount 1
+  }
+  CRF_Inventory_Item "{691AD02AE847BE7B}" {
+   m_sItemPrefab "{CBF9B9942E07B6B8}Prefabs/Items/Equipment/Accessories/ZipCuffs/ACE_Captives_ZipCuffs.et"
+   m_iItemCount 2
+  }
+  CRF_Inventory_Item "{691AD02AE847BE7D}" {
+   m_sItemPrefab "{E096C6BD45C87B63}Prefabs/Items/PersonalBelongings/PersonalBelongings_USSR.et"
+   m_iItemCount 0
+  }
+  CRF_Inventory_Item "{691AD02AE847AF17}" {
+   m_sItemPrefab "{07BC23F8D9223863}Prefabs/Items/Misc/Sandbags/Part_Sandbag_Burlap.et"
+   m_iItemCount 10
+  }
+ }
+ m_InfantryMedicalItems {
+  CRF_Inventory_Item "{691AD02AE847AF14}" {
+   m_sItemPrefab "{C3F1FA1E2EC2B345}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_USSR_01.et"
+   m_iItemCount 2
+  }
+  CRF_Inventory_Item "{691AD02AE847AF15}" {
+   m_sItemPrefab "{80E75A71C29190DB}Prefabs/Items/Medicine/Tourniquet_01/Tourniquet_USSR_01.et"
+   m_iItemCount 1
+  }
+ }
+ m_MedicMedicalItems {
+  CRF_Inventory_Item "{691AD02AE847AF0A}" {
+   m_sItemPrefab "{C3F1FA1E2EC2B345}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_USSR_01.et"
+   m_iItemCount 10
+  }
+  CRF_Inventory_Item "{691AD02AE847AF0B}" {
+   m_sItemPrefab "{80E75A71C29190DB}Prefabs/Items/Medicine/Tourniquet_01/Tourniquet_USSR_01.et"
+   m_iItemCount 3
+  }
+  CRF_Inventory_Item "{691AD02AE847AF08}" {
+   m_sItemPrefab "{0D9A5DCF89AE7AA9}Prefabs/Items/Medicine/MorphineInjection_01/MorphineInjection_01.et"
+   m_iItemCount 6
+  }
+  CRF_Inventory_Item "{691AD02AE847AF09}" {
+   m_sItemPrefab "{5B2FD067D70C1E8F}Prefabs/Items/Medicine/EpinephrineInjection/ACE_Medical_EpinephrineInjection.et"
+   m_iItemCount 6
+  }
+  CRF_Inventory_Item "{691AD02AE847AF0E}" {
+   m_sItemPrefab "{527D7C5D2E476BDC}Prefabs/Items/Medicine/SalineBag_01/SalineBag_USSR_01.et"
+   m_iItemCount 5
+  }
+  CRF_Inventory_Item "{691AD02AE847AF0F}" {
+   m_sItemPrefab "{21EF98BFC1EB3793}Prefabs/Items/Equipment/Kits/MedicalKit_01/MedicalKit_01_USSR.et"
+   m_iItemCount 1
+  }
+  CRF_Inventory_Item "{691AD02AE847C441}" {
+   m_sItemPrefab "{58CF3AB87C441295}Prefabs/Items/Medicine/AmmoniumCarbonatePackage/ACE_Medical_AmmoniumCarbonatePackage.et"
+   m_iItemCount 10
+  }
+  CRF_Inventory_Item "{691AD02AE847C442}" {
+   m_sItemPrefab "{02DD34077F51F65E}Prefabs/Items/Medicine/NaloxoneInjection/ACE_Medical_NaloxoneInjection.et"
+   m_iItemCount 6
+  }
+  CRF_Inventory_Item "{691AD02AE847C443}" {
+   m_sItemPrefab "{9BBA766CD869002C}Prefabs/Items/Medicine/PhenylephrineInjection/ACE_Medical_PhenylephrineInjection.et"
+   m_iItemCount 6
+  }
+  CRF_Inventory_Item "{691AD02AE8473DD1}" {
+   m_sItemPrefab "{D0434D5215B54181}Prefabs/Items/Medicine/MetoprololInjection/ACE_Medical_MetoprololInjection.et"
+   m_iItemCount 6
+  }
+  CRF_Inventory_Item "{691AD02AE8473DDE}" {
+   m_sItemPrefab "{77EAE5E07DC4678A}Prefabs/Weapons/Grenades/Smoke_RDG2.et"
+   m_iItemCount 2
+  }
+ }
+ m_RolesToSetCustomSettings {
+  CRF_Role_Custom_Gear "{691AD02AE8473DDF}" {
+   m_Role VEHICLE_LEAD
+   m_Clothing {
+    CRF_Clothing "{691AD02AE8473DDC}" {
+     m_iClothingType SHIRT
+     m_ClothingPrefabs {
+      "{78C9B02C0CBD594C}Prefabs/Characters/Uniforms/Jacket_Tanker_USSR_01/Jacket_Tanker_USSR_01.et"
+     }
+    }
+    CRF_Clothing "{691AD02AE8473DDD}" {
+     m_iClothingType PANTS
+     m_ClothingPrefabs {
+      "{27494A16F172A97B}Prefabs/Characters/Uniforms/Pants_Tanker_USSR_01/Pants_Tanker_USSR_01.et"
+      "{DC91A67E1074AAC0}Prefabs/Characters/Uniforms/Pants_Tanker_USSR_01/Pants_Tanker_USSR_01_tucked.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE8473DDA}" {
+   m_Role INDIRECT_LEAD
+   m_AdditionalInventoryItems {
+    CRF_Inventory_Item "{691AD02AE8473DD8}" {
+     m_sItemPrefab "{B41607EAB58A4252}Prefabs/Items/Equipment/BalisticTable/BalisticTable_USSR.et"
+     m_iItemCount 1
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE8473DE9}" {
+   m_Role LOGI_LEAD
+   m_Clothing {
+    CRF_Clothing "{691AD02AE8473DF6}" {
+     m_iClothingType BACKPACK
+     m_ClothingPrefabs {
+      "{41A9C55B61F375F0}Prefabs/Items/Equipment/Backpacks/Backpack_Kolobok.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE8473DF7}" {
+   m_Role MEDICAL_OFFICER
+   m_Clothing {
+    CRF_Clothing "{691AD02AE8473DF4}" {
+     m_iClothingType BACKPACK
+     m_ClothingPrefabs {
+      "{7AC107CA7AFC9B59}Prefabs/Items/Equipment/Backpacks/Backpack_Medical_Soviet.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE8470834}" {
+   m_Role MEDIC
+   m_Clothing {
+    CRF_Clothing "{691AD02AE8470835}" {
+     m_iClothingType BACKPACK
+     m_ClothingPrefabs {
+      "{7AC107CA7AFC9B59}Prefabs/Items/Equipment/Backpacks/Backpack_Medical_Soviet.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE8470832}" {
+   m_Role ASSISTANT_AUTOMATIC_RIFLEMAN
+   m_Clothing {
+    CRF_Clothing "{691AD02AE8470833}" {
+     m_iClothingType BACKPACK
+     m_ClothingPrefabs {
+      "{41A9C55B61F375F0}Prefabs/Items/Equipment/Backpacks/Backpack_Kolobok.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE8470830}" {
+   m_Role ASSISTANT_RIFLEMAN_ANTITANK
+   m_Clothing {
+    CRF_Clothing "{691AD02AE8470831}" {
+     m_iClothingType BACKPACK
+     m_ClothingPrefabs {
+      "{41A9C55B61F375F0}Prefabs/Items/Equipment/Backpacks/Backpack_Kolobok.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE847083E}" {
+   m_Role RIFLEMAN_ANTITANK
+   m_Clothing {
+    CRF_Clothing "{691AD02AE84765D6}" {
+     m_iClothingType BACKPACK
+     m_ClothingPrefabs {
+      "{0D39750E5695B9D8}Prefabs/Items/Equipment/Backpacks/Backpack_RPG_Gunner.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE84765D3}" {
+   m_Role HEAVY_ANTITANK
+   m_Clothing {
+    CRF_Clothing "{691AD02AE8448D65}" {
+     m_iClothingType BACKPACK
+     m_ClothingPrefabs {
+      "{41A9C55B61F375F0}Prefabs/Items/Equipment/Backpacks/Backpack_Kolobok.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE8448D66}" {
+   m_Role MEDIUM_ANTITANK
+   m_Clothing {
+    CRF_Clothing "{691AD02AE8448D67}" {
+     m_iClothingType BACKPACK
+     m_ClothingPrefabs {
+      "{0D39750E5695B9D8}Prefabs/Items/Equipment/Backpacks/Backpack_RPG_Gunner.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE8448D18}" {
+   m_Role ASSISTANT_HEAVY_ANTITANK
+   m_Clothing {
+    CRF_Clothing "{691AD02AE844CAF9}" {
+     m_iClothingType BACKPACK
+     m_ClothingPrefabs {
+      "{6A39B5843B3F36DA}Prefabs/Items/Equipment/Backpacks/Backpack_RPG_Assistant.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE844CAF8}" {
+   m_Role ASSISTANT_MEDIUM_ANTITANK
+   m_Clothing {
+    CRF_Clothing "{691AD02AE844CAFA}" {
+     m_iClothingType BACKPACK
+     m_ClothingPrefabs {
+      "{6A39B5843B3F36DA}Prefabs/Items/Equipment/Backpacks/Backpack_RPG_Assistant.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE844CAFD}" {
+   m_Role ASSISTANT_MEDIUM_MACHINEGUN
+   m_Clothing {
+    CRF_Clothing "{691AD02AE844CAFC}" {
+     m_iClothingType BACKPACK
+     m_ClothingPrefabs {
+      "{41A9C55B61F375F0}Prefabs/Items/Equipment/Backpacks/Backpack_Kolobok.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE844CAFE}" {
+   m_Role ASSISTANT_ANTI_AIR
+   m_Clothing {
+    CRF_Clothing "{691AD02AE84464A8}" {
+     m_iClothingType BACKPACK
+     m_ClothingPrefabs {
+      "{6A39B5843B3F36DA}Prefabs/Items/Equipment/Backpacks/Backpack_RPG_Assistant.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE84464A7}" {
+   m_Role VEHICLE_DRIVER
+   m_Clothing {
+    CRF_Clothing "{691AD02AE84464A6}" {
+     m_iClothingType SHIRT
+     m_ClothingPrefabs {
+      "{78C9B02C0CBD594C}Prefabs/Characters/Uniforms/Jacket_Tanker_USSR_01/Jacket_Tanker_USSR_01.et"
+     }
+    }
+    CRF_Clothing "{691AD02AE84464A5}" {
+     m_iClothingType PANTS
+     m_ClothingPrefabs {
+      "{27494A16F172A97B}Prefabs/Characters/Uniforms/Pants_Tanker_USSR_01/Pants_Tanker_USSR_01.et"
+      "{DC91A67E1074AAC0}Prefabs/Characters/Uniforms/Pants_Tanker_USSR_01/Pants_Tanker_USSR_01_tucked.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE84464A3}" {
+   m_Role VEHICLE_GUNNER
+   m_Clothing {
+    CRF_Clothing "{691AD02AE84464A2}" {
+     m_iClothingType SHIRT
+     m_ClothingPrefabs {
+      "{78C9B02C0CBD594C}Prefabs/Characters/Uniforms/Jacket_Tanker_USSR_01/Jacket_Tanker_USSR_01.et"
+     }
+    }
+    CRF_Clothing "{691AD02AE84464A0}" {
+     m_iClothingType PANTS
+     m_ClothingPrefabs {
+      "{27494A16F172A97B}Prefabs/Characters/Uniforms/Pants_Tanker_USSR_01/Pants_Tanker_USSR_01.et"
+      "{DC91A67E1074AAC0}Prefabs/Characters/Uniforms/Pants_Tanker_USSR_01/Pants_Tanker_USSR_01_tucked.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE84464BF}" {
+   m_Role VEHICLE_LOADER
+   m_Clothing {
+    CRF_Clothing "{691AD02AE84464BD}" {
+     m_iClothingType SHIRT
+     m_ClothingPrefabs {
+      "{78C9B02C0CBD594C}Prefabs/Characters/Uniforms/Jacket_Tanker_USSR_01/Jacket_Tanker_USSR_01.et"
+     }
+    }
+    CRF_Clothing "{691AD02AE84464BC}" {
+     m_iClothingType PANTS
+     m_ClothingPrefabs {
+      "{27494A16F172A97B}Prefabs/Characters/Uniforms/Pants_Tanker_USSR_01/Pants_Tanker_USSR_01.et"
+      "{DC91A67E1074AAC0}Prefabs/Characters/Uniforms/Pants_Tanker_USSR_01/Pants_Tanker_USSR_01_tucked.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE84464BB}" {
+   m_Role PILOT
+   m_Clothing {
+    CRF_Clothing "{691AD02AE845F1BD}" {
+     m_iClothingType SHIRT
+     m_ClothingPrefabs {
+      "{6835DAF42A09E23C}Prefabs/Characters/Uniforms/Jacket_Pilot_USSR_01/Jacket_Pilot_USSR_01.et"
+     }
+    }
+    CRF_Clothing "{691AD02AE845F1BC}" {
+     m_iClothingType PANTS
+     m_ClothingPrefabs {
+      "{83DFA8F68CA40B10}Prefabs/Characters/Uniforms/Pants_Pilot_USSR_01/Pants_Pilot_USSR_01.et"
+      "{6B7F32F1F8A191B0}Prefabs/Characters/Uniforms/Pants_Pilot_USSR_01/Pants_Pilot_USSR_01_tucked.et"
+     }
+    }
+    CRF_Clothing "{691AD02AE845F1BF}" {
+     m_iClothingType HEADGEAR
+     m_ClothingPrefabs {
+      "{E49D9EE7E2B3016C}Prefabs/Characters/HeadGear/Helmet_ZSh5_01/Helmet_ZSh5_01.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE845F1BE}" {
+   m_Role CREW_CHIEF
+   m_Clothing {
+    CRF_Clothing "{691AD02AE845F1B0}" {
+     m_iClothingType SHIRT
+     m_ClothingPrefabs {
+      "{6835DAF42A09E23C}Prefabs/Characters/Uniforms/Jacket_Pilot_USSR_01/Jacket_Pilot_USSR_01.et"
+     }
+    }
+    CRF_Clothing "{691AD02AE845F1B3}" {
+     m_iClothingType PANTS
+     m_ClothingPrefabs {
+      "{83DFA8F68CA40B10}Prefabs/Characters/Uniforms/Pants_Pilot_USSR_01/Pants_Pilot_USSR_01.et"
+      "{6B7F32F1F8A191B0}Prefabs/Characters/Uniforms/Pants_Pilot_USSR_01/Pants_Pilot_USSR_01_tucked.et"
+     }
+    }
+    CRF_Clothing "{691AD02AE845F1B2}" {
+     m_iClothingType HEADGEAR
+     m_ClothingPrefabs {
+      "{E49D9EE7E2B3016C}Prefabs/Characters/HeadGear/Helmet_ZSh5_01/Helmet_ZSh5_01.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE8457824}" {
+   m_Role LOGI_RUNNER
+   m_Clothing {
+    CRF_Clothing "{691AD02AE8457823}" {
+     m_iClothingType BACKPACK
+     m_ClothingPrefabs {
+      "{41A9C55B61F375F0}Prefabs/Items/Equipment/Backpacks/Backpack_Kolobok.et"
+     }
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE8457822}" {
+   m_Role RIFLEMAN_DEMO
+   m_AdditionalInventoryItems {
+    CRF_Inventory_Item "{691AD02AE8457821}" {
+     m_sItemPrefab "{73F69547963CAEE0}PrefabsEditable/Explosives/E_DemoBlock_TSh400g.et"
+     m_iItemCount 2
+    }
+    CRF_Inventory_Item "{691AD02AE8457807}" {
+     m_sItemPrefab "{90976DC90A223095}Prefabs/Items/Equipment/Detonators/BlastingMachine_KPM_3U1/BlastingMachine_KPM_3U1.et"
+     m_iItemCount 1
+    }
+    CRF_Inventory_Item "{691AD02AE8457806}" {
+     m_sItemPrefab "{2E5BFBBBC0AD79CE}Prefabs/Weapons/Explosives/Explosive_Satchels/OPFOR_Satchel.et"
+     m_iItemCount 1
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE8457805}" {
+   m_Role COMBAT_ENGINEER
+   m_AdditionalInventoryItems {
+    CRF_Inventory_Item "{691AD02AE85A8F07}" {
+     m_sItemPrefab "{73F69547963CAEE0}PrefabsEditable/Explosives/E_DemoBlock_TSh400g.et"
+     m_iItemCount 3
+    }
+    CRF_Inventory_Item "{691AD02AE85A8F06}" {
+     m_sItemPrefab "{90976DC90A223095}Prefabs/Items/Equipment/Detonators/BlastingMachine_KPM_3U1/BlastingMachine_KPM_3U1.et"
+     m_iItemCount 2
+    }
+    CRF_Inventory_Item "{691AD02AE85A8F01}" {
+     m_sItemPrefab "{2E5BFBBBC0AD79CE}Prefabs/Weapons/Explosives/Explosive_Satchels/OPFOR_Satchel.et"
+     m_iItemCount 3
+    }
+   }
+  }
+  CRF_Role_Custom_Gear "{691AD02AE85AD6C1}" {
+   m_Role JTAC
+   m_sRoleName "Senior Rifleman"
+  }
+  CRF_Role_Custom_Gear "{691AD02AE85AD6C0}" {
+   m_Role TEAM_LEAD
+   m_sRoleName "Assistant Squad Lead"
+  }
+  CRF_Role_Custom_Gear "{691AD02AE85AD6C3}" {
+   m_Role FIRST_SERGEANT
+   m_sRoleName "Deputy Company Commander"
+  }
+  CRF_Role_Custom_Gear "{691AD02AE85AD6C2}" {
+   m_Role PLATOON_SERGEANT
+   m_sRoleName "Deputy Platoon Leader"
+  }
+  CRF_Role_Custom_Gear "{691AD02AF76F5F8D}" {
+   m_Role DRONE_OPERATOR
+   m_sRoleName "Runner"
+  }
+  CRF_Role_Custom_Gear "{691AD02C4C7ACC7E}" {
+   m_Role RIFLEMAN
+   m_sRoleName "Assault Rifleman"
+   m_PrimaryWeapon {
+    CRF_Weapon_Class "{691AD02C50EE757E}" {
+     m_Weapon "{41AD4E19A9BDBDCE}Prefabs/Weapons/Rifles/AK47/BC_Rifle_AK47.et"
+     m_MagazineArray {
+      CRF_Magazine_Class "{691AD02CA43ED060}" {
+       m_Magazine "{D66B57C62D7D503C}Prefabs/Weapons/Magazines/AK/BC_Magazine_762x39_AK_30rnd_Last_5Tracer.et"
+       m_MagazineCount 12
+      }
+     }
+    }
+   }
+   m_AdditionalInventoryItems {
+    CRF_Inventory_Item "{691AD02CBC102ABC}" {
+     m_sItemPrefab "{645C73791ECA1698}Prefabs/Weapons/Grenades/Grenade_RGD5.et"
+     m_iItemCount 2
+    }
+    CRF_Inventory_Item "{691AD02C8B4D8AB5}" {
+     m_sItemPrefab "{77EAE5E07DC4678A}Prefabs/Weapons/Grenades/Smoke_RDG2.et"
+     m_iItemCount 2
+    }
+   }
+  }
+ }
+}

--- a/Configs/Gearscripts/Custom/Harry/50s/CRF_GS_USSR50s.conf.meta
+++ b/Configs/Gearscripts/Custom/Harry/50s/CRF_GS_USSR50s.conf.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{C206DF5E4DFEDC63}Configs/Gearscripts/Custom/Salami/Iron Sickle/CRF_GS_USSR50s.conf"
+ Configurations {
+  CONFResourceClass PC {
+  }
+  CONFResourceClass XBOX_ONE : PC {
+  }
+  CONFResourceClass XBOX_SERIES : PC {
+  }
+  CONFResourceClass PS4 : PC {
+  }
+  CONFResourceClass PS5 : PC {
+  }
+  CONFResourceClass HEADLESS : PC {
+  }
+  CONFResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Missions/Yeonpyeong/Harry_0414_RAID93_Counters.conf
+++ b/Missions/Yeonpyeong/Harry_0414_RAID93_Counters.conf
@@ -1,0 +1,15 @@
+SCR_MissionHeader "{3D094352621EA88C}Missions/CRF_BaseMissionConfig.conf" {
+ World "{3F2D287252425401}Worlds/Yeonpyeong/Harry_TVT_Counter.ent"
+ m_sName "CRF RAID93 Counters"
+ m_sAuthor "Harry"
+ m_sDescription "It's not over till it's over"
+ m_sIcon "{B7385DA4504BD4D5}UI/Images/Coalition/crflogo.edds"
+ m_sLoadingScreen "{B7385DA4504BD4D5}UI/Images/Coalition/crflogo.edds"
+ m_sPreviewImage "{B7385DA4504BD4D5}UI/Images/Coalition/crflogo.edds"
+ m_sGameMode "RAID"
+ m_iPlayerCount 128
+ m_iStartingHours 12
+ m_iMapMarkerLimitPerPlayer 256
+ m_sTerrainName "Yeonpyeong"
+ m_sAuthorGUID "2469a01d-de32-4b3c-806b-165cb4e57c4b"
+}

--- a/Missions/Yeonpyeong/Harry_0414_RAID93_Counters.conf.meta
+++ b/Missions/Yeonpyeong/Harry_0414_RAID93_Counters.conf.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{10EF9E7EA6781270}Missions/Yeonpyeong/Harry_0414_RAID93_Counters.conf"
+ Configurations {
+  CONFResourceClass PC {
+  }
+  CONFResourceClass XBOX_ONE : PC {
+  }
+  CONFResourceClass XBOX_SERIES : PC {
+  }
+  CONFResourceClass PS4 : PC {
+  }
+  CONFResourceClass PS5 : PC {
+  }
+  CONFResourceClass HEADLESS : PC {
+  }
+  CONFResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Worlds/Yeonpyeong/Harry_TVT_Counter.ent
+++ b/Worlds/Yeonpyeong/Harry_TVT_Counter.ent
@@ -1,0 +1,3 @@
+SubScene {
+ Parent "{9D726E3A65816832}Yeonpyeong.ent"
+}

--- a/Worlds/Yeonpyeong/Harry_TVT_Counter.ent.meta
+++ b/Worlds/Yeonpyeong/Harry_TVT_Counter.ent.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{3F2D287252425401}Worlds/Yeonpyeong/Harry_TVT_Counter.ent"
+ Configurations {
+  ENTResourceClass PC {
+  }
+  ENTResourceClass XBOX_ONE : PC {
+  }
+  ENTResourceClass XBOX_SERIES : PC {
+  }
+  ENTResourceClass PS4 : PC {
+  }
+  ENTResourceClass PS5 : PC {
+  }
+  ENTResourceClass HEADLESS : PC {
+  }
+  ENTResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Worlds/Yeonpyeong/Harry_TVT_Counter_Layers/MARKERS.layer
+++ b/Worlds/Yeonpyeong/Harry_TVT_Counter_Layers/MARKERS.layer
@@ -1,0 +1,6 @@
+CRF_ManualMarker : "{2C55310F9082A86D}PrefabsMissionMaking/Markers/ObjectiveMarkers/OG/GLOBAL_ObjectiveMarker_et.et" {
+ coords 5297.65 20.318 7845.321
+ angles 0 0 0
+ m_MarkerColor 0.502 0 0 1
+ m_sDescription "OPFOR Retreat"
+}

--- a/Worlds/Yeonpyeong/Harry_TVT_Counter_Layers/OBJECTIVES.layer
+++ b/Worlds/Yeonpyeong/Harry_TVT_Counter_Layers/OBJECTIVES.layer
@@ -1,0 +1,112 @@
+SCR_DestructibleBuildingEntity : "{5CC8525A69118B0C}Prefabs/Structures/Industrial/Containers/FuelTanks/FuelTank_01/FuelTank_01_orange.et" {
+ components {
+  CRF_RaidItemComponent "{691AD02838B65902}" {
+   m_iSupplyValue 30
+   m_sItemName "Orange Fuel Tank"
+  }
+ }
+ coords 4281.396 0 7938.016
+ angles 0 -25.293 0
+}
+$grp GenericEntity : "{6B52C6B5FEC3E369}Prefabs/Destructible/GMFX_Destructible_AmmoDump.et" {
+ {
+  components {
+   CRF_RaidItemComponent "{691AD029A12383C7}" {
+    m_sItemName "Ammo"
+   }
+  }
+  coords 4216.36 41.716 7897.738
+  angles 0 57.673 0
+ }
+ {
+  components {
+   CRF_RaidItemComponent "{691AD029A12383C7}" {
+    m_sItemName "Ammo"
+   }
+  }
+  coords 4366.596 43.259 7896.73
+  angles 0 57.673 0
+ }
+ {
+  components {
+   CRF_RaidItemComponent "{691AD029A12383C7}" {
+    m_sItemName "Ammo"
+   }
+  }
+  coords 4201.186 41.719 7901.426
+  angles 0 57.673 0
+ }
+ {
+  components {
+   CRF_RaidItemComponent "{691AD029A12383C7}" {
+    m_sItemName "Ammo"
+   }
+  }
+  coords 4234.613 42.924 7965.838
+  angles 0 57.673 0
+ }
+ {
+  components {
+   CRF_RaidItemComponent "{691AD029A12383C7}" {
+    m_sItemName "Ammo"
+   }
+  }
+  coords 4205.062 41.742 7915.713
+  angles 0 57.673 0
+ }
+ {
+  components {
+   CRF_RaidItemComponent "{691AD029A12383C7}" {
+    m_sItemName "Ammo"
+   }
+  }
+  coords 4379.666 43.259 7895.624
+  angles 0 57.673 0
+ }
+ {
+  components {
+   CRF_RaidItemComponent "{691AD029A12383C7}" {
+    m_sItemName "Ammo"
+   }
+  }
+  coords 4312.978 30.415 7830.382
+  angles 0 57.673 0
+ }
+ {
+  components {
+   CRF_RaidItemComponent "{691AD029A12383C7}" {
+    m_sItemName "Ammo"
+   }
+  }
+  coords 4314.172 30.415 7831.212
+  angles 0 57.673 0
+ }
+ {
+  components {
+   CRF_RaidItemComponent "{691AD029A12383C7}" {
+    m_sItemName "Ammo"
+   }
+  }
+  coords 4435.324 21.034 7783.831
+  angles 0 57.673 0
+ }
+}
+GenericEntity : "{C5341109EB1AB7B5}Prefabs/Destructible/GMFX_Destructible_Radar_RPL5.et" {
+ components {
+  CRF_RaidItemComponent "{691AD029EDF601B1}" {
+   m_iSupplyValue 30
+   m_sItemName "Radar"
+  }
+ }
+ coords 4288.504 48.027 7693.797
+}
+GenericEntity : "{FFCDFB1375A99125}Prefabs/Destructible/GMFX_Destructible_RPL5_01_generator.et" {
+ components {
+  CRF_RaidItemComponent "{691AD029C084043A}" {
+   m_iSupplyValue 30
+   m_sItemName "Generator"
+  }
+ }
+ coords 4243.362 41.594 7966.772
+ angles 0 -117.494 0
+}

--- a/Worlds/Yeonpyeong/Harry_TVT_Counter_Layers/POLYZONES.layer
+++ b/Worlds/Yeonpyeong/Harry_TVT_Counter_Layers/POLYZONES.layer
@@ -1,0 +1,69 @@
+PolylineShapeEntity : "{318DDE6633C34CF1}PrefabsMissionMaking/PolyZone/GameBoundry.et" {
+ coords 4561.301 18.533 7815.146
+ Points {
+  ShapePoint "{691AD024D324C426}" {
+   Position -383.449 0 -266.328
+  }
+  ShapePoint "{691AD024D12D7BFC}" {
+   Position -405.702 0 264.762
+  }
+  ShapePoint "{691AD024D6B46EBD}" {
+   Position 859.365 0 313.231
+  }
+  ShapePoint "{691AD024D51035C3}" {
+   Position 798.904 0 -420.131
+  }
+ }
+}
+PolylineShapeEntity : "{93BA83DF484DB512}PrefabsMissionMaking/PolyZone/ForwardDeploy/BLUFOR_ForwardDeployZone.et" {
+ coords 4217.247 78.648 8094.714
+ Points {
+  ShapePoint "{691AD03014FDE58D}" {
+   Position 18.183 0 38.085
+  }
+  ShapePoint "{691AD0301BA8BCC3}" {
+   Position 35.495 0 -28.108
+  }
+  ShapePoint "{691AD0301960DFF9}" {
+   Position 80.1 0 -107.95
+  }
+  ShapePoint "{691AD03019911997}" {
+   Position 121.261 0 -158.227
+  }
+  ShapePoint "{691AD03019CD29B5}" {
+   Position 150.858 0 -203.582
+  }
+  ShapePoint "{691AD0301E882469}" {
+   Position 215.842 0 -321.577
+  }
+  ShapePoint "{691AD0301D1CF026}" {
+   Position 60.911 0 -420.086
+  }
+  ShapePoint "{691AD03062B55062}" {
+   Position 4.562 0 -325.88
+  }
+  ShapePoint "{691AD03060792B7F}" {
+   Position -51.176 0 -153.477
+  }
+  ShapePoint "{691AD03066456633}" {
+   Position -44.401 0 15.861
+  }
+ }
+}
+PolylineShapeEntity : "{D8E7812AC12E29EB}PrefabsMissionMaking/PolyZone/Safestart/OPFOR_SafestartBoundry.et" {
+ coords 5265.382 9.771 7791.64
+ Points {
+  ShapePoint "{691AD0390B742582}" {
+   Position -135.785 0 -6.8
+  }
+  ShapePoint "{691AD0390B92358C}" {
+   Position -74.151 0 113.664
+  }
+  ShapePoint "{691AD0390A2D676D}" {
+   Position 81.542 0 25.908
+  }
+  ShapePoint "{691AD0390AF82C2E}" {
+   Position 29.788 0 -85.086
+  }
+ }
+}

--- a/Worlds/Yeonpyeong/Harry_TVT_Counter_Layers/PROPS.layer
+++ b/Worlds/Yeonpyeong/Harry_TVT_Counter_Layers/PROPS.layer
@@ -1,0 +1,130 @@
+$grp SCR_DestructibleEntity : "{027CEF1B935A4D42}Prefabs/Structures/Walls/Concrete/ConcreteWall_01/ConcreteWall_01_Base.et" {
+ {
+  coords 4232.482 -0 8107.435
+  angles 0 71.944 0
+ }
+ {
+  coords 4234.281 0 8101.911
+  angles 0 71.944 0
+ }
+ {
+  coords 4233.368 -0.001 8104.714
+  angles 0 71.944 0
+ }
+ {
+  coords 4235.19 -0.001 8099.122
+  angles 0 71.944 0
+ }
+ {
+  coords 4228.864 -0 8118.534
+  angles 0 71.944 0
+ }
+ {
+  coords 4230.663 -0 8113.01
+  angles 0 71.944 0
+ }
+ {
+  coords 4229.75 0 8115.813
+  angles 0 71.944 0
+ }
+ {
+  coords 4231.572 -0 8110.221
+  angles 0 71.944 0
+ }
+ {
+  coords 4223.372 -0 8116.443
+  angles 0 -19.34 0
+ }
+ {
+  coords 4220.59 -0.001 8115.469
+  angles 0 -19.34 0
+ }
+ {
+  coords 4226.14 -0.001 8117.417
+  angles 0 -19.34 0
+ }
+ {
+  coords 4206.875 -0 8110.658
+  angles 0 -19.34 0
+ }
+ {
+  coords 4212.357 -0 8112.579
+  angles 0 -19.34 0
+ }
+ {
+  coords 4209.575 0 8111.604
+  angles 0 -19.34 0
+ }
+ {
+  coords 4215.125 -0.001 8113.551
+  angles 0 -19.34 0
+ }
+ {
+  coords 4217.889 -0 8114.523
+  angles 0 -19.34 0
+ }
+ {
+  coords 4201.351 0 8108.714
+  angles 0 -19.34 0
+ }
+ {
+  coords 4198.569 -0 8107.74
+  angles 0 -19.34 0
+ }
+ {
+  coords 4204.121 0 8109.688
+  angles 0 -19.34 0
+ }
+ {
+  coords 4184.855 -0 8102.929
+  angles 0 -19.34 0
+ }
+ {
+  coords 4190.337 -0 8104.851
+  angles 0 -19.34 0
+ }
+ {
+  coords 4187.556 -0.001 8103.876
+  angles 0 -19.34 0
+ }
+ {
+  coords 4193.104 -0 8105.823
+  angles 0 -19.34 0
+ }
+ {
+  coords 4195.869 0 8106.794
+  angles 0 -19.34 0
+ }
+ {
+  coords 4189.337 0 8092.083
+  angles 0 -111.729 0
+ }
+ {
+  coords 4187.187 0 8097.479
+  angles 0 -111.729 0
+ }
+ {
+  coords 4191.509 0 8086.637
+  angles 0 -111.729 0
+ }
+ {
+  coords 4188.278 0 8094.741
+  angles 0 -111.729 0
+ }
+ {
+  coords 4190.423 0.001 8089.36
+  angles 0 -111.729 0
+ }
+ {
+  coords 4186.102 -0 8100.205
+  angles 0 -111.729 0
+ }
+ {
+  coords 4192.6 0.807 8083.897
+  angles 0 -111.729 0
+ }
+ {
+  coords 4193.658 0 8081.237
+  angles 0 -111.729 0
+ }
+}

--- a/Worlds/Yeonpyeong/Harry_TVT_Counter_Layers/SPAWNPOINTS.layer
+++ b/Worlds/Yeonpyeong/Harry_TVT_Counter_Layers/SPAWNPOINTS.layer
@@ -1,0 +1,6 @@
+CRF_StaticSpawnPoint : "{0B3312C6940005B9}PrefabsMissionMaking/Systems/SpawnPoints/OPFOR_Spawn.et" {
+ coords 5252.67 9.719 7792.269
+}
+CRF_StaticSpawnPoint : "{62865C82AB534D91}PrefabsMissionMaking/Systems/SpawnPoints/BLUFOR_Spawn.et" {
+ coords 4213.237 78.472 8090.378
+}

--- a/Worlds/Yeonpyeong/Harry_TVT_Counter_Layers/VEHICLES.layer
+++ b/Worlds/Yeonpyeong/Harry_TVT_Counter_Layers/VEHICLES.layer
@@ -1,0 +1,14 @@
+$grp CRF_VehicleSpawner {
+ {
+  coords 5242.093 9.719 7767.252
+  angles 0 26.782 0
+  m_rVehicle "{8759EDBCF78920B7}Prefabs/Vehicles/Wheeled/Ural4320/OPFOR/OPFOR_AMMO.et"
+  m_sFactionKey "OPFOR"
+ }
+ {
+  coords 5238.068 9.719 7769.075
+  angles 0 26.782 0
+  m_rVehicle "{43C4AF1EEBD001CE}Prefabs/Vehicles/Wheeled/UAZ452/UAZ452_ambulance.et"
+  m_sFactionKey "OPFOR"
+ }
+}

--- a/Worlds/Yeonpyeong/Harry_TVT_Counter_Layers/_INIT.layer
+++ b/Worlds/Yeonpyeong/Harry_TVT_Counter_Layers/_INIT.layer
@@ -1,0 +1,313 @@
+SCR_AIWorld : "{E0A05C76552E7F58}Prefabs/AI/SCR_AIWorld.et" {
+ coords 6517.027 0 7732.549
+}
+CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et" {
+ components {
+  CRF_RaidGamemodeComponent "{691AD0270E3CBF37}" {
+   m_sAttackingSide "OPFOR"
+   m_sDefendingSide "BLUFOR"
+  }
+  SCR_TimeAndWeatherHandlerComponent "{64427EEC304DD9A0}" {
+   m_bRandomStartingWeather 0
+   m_aStartingWeatherAndTime {
+    SCR_TimeAndWeatherState "{66EE8AEC3605B974}" {
+     m_sWeatherPresetName "Clear"
+     m_iStartingHour 12
+     m_iStartingMinutes 0
+    }
+   }
+   m_bRandomWeatherChanges 0
+  }
+ }
+ coords 0 0 0
+ m_bRespawnEnabled 0
+ m_bWaveRespawn 0
+ m_bRallyPointsEnabled 0
+ m_iTimeToRespawn 60
+ m_iRespawnCutoffMinutes 0
+ m_iTimeLimitMinutes 45
+ m_bLockUnusedSlots 1
+ m_bUseSafestartTimeLimit 1
+ m_iSafestartTimeLimit 15
+ m_aMissionDescriptors {
+  CRF_MissionDescriptor "{644250503DF684C0}" {
+   m_sTitle "Mission: Situation"
+   m_sTextData "Russian backed Korean forces are conducting a raid on a blufor staging areas. They need to destroy 50% of the available materiel, and then hold out at the marked retreat spot. "\
+   ""\
+   "BLUFOR Composition: Inf"\
+   "BLUFOR Assets: HMG"\
+   ""\
+   "OPFOR Composition: Inf"\
+   "OPFOR Assets: Combat engineers, MG teams"\
+   ""\
+   "Time: 45 min"\
+   "Weather: Day clear"
+   m_aFactionKeys {
+   }
+   m_bShowForAnyFaction 1
+  }
+  CRF_MissionDescriptor "{64425051F2E00216}" {
+   m_sTitle "BLUFOR Objectives"
+   m_sTextData "Prevent the enemy from destroying 50% of the available materiel. If they do manage to destroy it, there will be a respawn wave. Chase down the enemy, and destroy them on the way or at the marked retreat path. "
+   m_aFactionKeys +{
+   }
+   m_bShowForAnyFaction 0
+  }
+  CRF_MissionDescriptor "{64425051B9B5AF67}" {
+   m_sTitle "OPFOR Objectives"
+   m_sTextData "Destroy at least 50% of the marked materiel. After the raid is finished, there will be a respawn wave for both teams. Extract your forces, and hold out against the counter attack at the marked retreat area. "
+   m_aFactionKeys +{
+   }
+   m_bShowForAnyFaction 0
+  }
+  CRF_MissionDescriptor "{644250519BE30999}" {
+   m_sTitle "INDFOR Objectives"
+   m_sTextData "If INDFOR is playable, add mission objectives in bullet point list. Add details for each if you feel necessary, but keep it concise."
+   m_aFactionKeys +{
+   }
+   m_bShowForAnyFaction 0
+  }
+  CRF_MissionDescriptor "{6442505149CF6C93}" {
+   m_sTitle "Administration"
+   m_sTextData "Place any meta or technical information that players should know here. Otherwise, leave empty."
+   m_aFactionKeys +{
+   }
+   m_bShowForAnyFaction 0
+  }
+ }
+ m_iFactionOneRatio 3
+ m_iFactionTwoRatio 2
+ m_sFactionOneKey "OPF"
+ m_sFactionTwoKey "BLU"
+ m_BluforSlots {
+  CRF_SlottingGroup "{691CE0AEB2B552D3}" {
+   m_sCallsign "1PLT"
+   m_FlagType SIGNAL
+   m_aSlots {
+    PLATOON_LEADER
+    PLATOON_SERGEANT
+    DRONE_OPERATOR
+    DRONE_OPERATOR
+   }
+  }
+  CRF_SlottingGroup "{691CE0AEB2B55193}" {
+   m_sCallsign "Able"
+   m_FlagType INFANTRY
+   m_aSlots {
+    SQUAD_LEAD
+    MEDIC
+    TEAM_LEAD
+    DRONE_OPERATOR
+    AUTOMATIC_RIFLEMAN
+    ASSISTANT_AUTOMATIC_RIFLEMAN
+    TEAM_LEAD
+    RIFLEMAN
+    RIFLEMAN
+    RIFLEMAN
+   }
+  }
+  CRF_SlottingGroup "{691CE0AEB2B550F0}" {
+   m_sCallsign "Bravo"
+   m_FlagType INFANTRY
+   m_aSlots {
+    SQUAD_LEAD
+    MEDIC
+    TEAM_LEAD
+    DRONE_OPERATOR
+    AUTOMATIC_RIFLEMAN
+    ASSISTANT_AUTOMATIC_RIFLEMAN
+    TEAM_LEAD
+    RIFLEMAN
+    RIFLEMAN
+    RIFLEMAN
+   }
+  }
+  CRF_SlottingGroup "{691CE0AEB2B55011}" {
+   m_sCallsign "Charlie"
+   m_FlagType INFANTRY
+   m_aSlots {
+    SQUAD_LEAD
+    MEDIC
+    TEAM_LEAD
+    DRONE_OPERATOR
+    AUTOMATIC_RIFLEMAN
+    ASSISTANT_AUTOMATIC_RIFLEMAN
+    TEAM_LEAD
+    RIFLEMAN
+    RIFLEMAN
+    RIFLEMAN
+   }
+  }
+  CRF_SlottingGroup "{691CE0AEB2B557B9}" {
+   m_sCallsign "HMG"
+   m_FlagType MACHINEGUN
+   m_aSlots {
+    SQUAD_LEAD
+    MEDIC
+    DRONE_OPERATOR
+    HEAVY_MACHINEGUN
+    ASSISTANT_HEAVY_MACHINEGUN
+    JTAC
+   }
+  }
+ }
+ m_OpforSlots {
+  CRF_SlottingGroup "{691CE0AEB2B55618}" {
+   m_sCallsign "1PLT"
+   m_FlagType SIGNAL
+   m_aSlots {
+    PLATOON_LEADER
+    PLATOON_SERGEANT
+    DRONE_OPERATOR
+    DRONE_OPERATOR
+   }
+  }
+  CRF_SlottingGroup "{691CE0AEB2B555B1}" {
+   m_sCallsign "Assault 1"
+   m_FlagType INFANTRY
+   m_aSlots {
+    SQUAD_LEAD
+    MEDIC
+    TEAM_LEAD
+    DRONE_OPERATOR
+    RIFLEMAN
+    RIFLEMAN
+    RIFLEMAN
+    RIFLEMAN
+    COMBAT_ENGINEER
+   }
+  }
+  CRF_SlottingGroup "{691CE0AEB2B554D2}" {
+   m_sCallsign "MG 1"
+   m_FlagType MACHINEGUN
+   m_aSlots {
+    SQUAD_LEAD
+    MEDIC
+    DRONE_OPERATOR
+    AUTOMATIC_RIFLEMAN
+    ASSISTANT_AUTOMATIC_RIFLEMAN
+    AUTOMATIC_RIFLEMAN
+    ASSISTANT_AUTOMATIC_RIFLEMAN
+   }
+  }
+  CRF_SlottingGroup "{691CE0AEB2B5546A}" {
+   m_sCallsign "Assault 2"
+   m_FlagType INFANTRY
+   m_aSlots {
+    SQUAD_LEAD
+    MEDIC
+    TEAM_LEAD
+    DRONE_OPERATOR
+    RIFLEMAN
+    RIFLEMAN
+    RIFLEMAN
+    RIFLEMAN
+    COMBAT_ENGINEER
+   }
+  }
+  CRF_SlottingGroup "{691CE0AEB2B54B97}" {
+   m_sCallsign "MG 2"
+   m_FlagType MACHINEGUN
+   m_aSlots {
+    SQUAD_LEAD
+    MEDIC
+    DRONE_OPERATOR
+    AUTOMATIC_RIFLEMAN
+    ASSISTANT_AUTOMATIC_RIFLEMAN
+    AUTOMATIC_RIFLEMAN
+    ASSISTANT_AUTOMATIC_RIFLEMAN
+   }
+  }
+  CRF_SlottingGroup "{691CE0AEB2B54B37}" {
+   m_sCallsign "Assault 3"
+   m_FlagType INFANTRY
+   m_aSlots {
+    SQUAD_LEAD
+    MEDIC
+    TEAM_LEAD
+    DRONE_OPERATOR
+    RIFLEMAN
+    RIFLEMAN
+    RIFLEMAN
+    RIFLEMAN
+    RIFLEMAN
+    COMBAT_ENGINEER
+   }
+  }
+  CRF_SlottingGroup "{691CE0AEB2B54A52}" {
+   m_sCallsign "MG 3"
+   m_FlagType MACHINEGUN
+   m_aSlots {
+    SQUAD_LEAD
+    MEDIC
+    DRONE_OPERATOR
+    AUTOMATIC_RIFLEMAN
+    ASSISTANT_AUTOMATIC_RIFLEMAN
+    AUTOMATIC_RIFLEMAN
+    ASSISTANT_AUTOMATIC_RIFLEMAN
+   }
+  }
+ }
+ m_iBLUFORTickets 0
+ m_iOPFORTickets 0
+ m_iINDFORTickets 0
+ m_iCIVTickets 0
+ m_BLUFORGearScriptSettings CRF_GearScriptContainer "{64570ACB9B419A7B}" {
+  m_rGearScript "{3E938198ACC1942D}Configs/Gearscripts/Custom/Harry/50s/CRF_GS_US50s.conf"
+  m_bEnableShareableMarkers 0
+  m_bEnableBFT 1
+  m_bEnableLeadershipRadios 1
+  m_bEnableGIRadios 1
+  m_bEnableRTORadios 1
+ }
+ m_OPFORGearScriptSettings CRF_GearScriptContainer "{64570ACB9B11EAAD}" {
+  m_rGearScript "{C206DF5E4DFEDC63}Configs/Gearscripts/Custom/Harry/50s/CRF_GS_USSR50s.conf"
+  m_bEnableShareableMarkers 0
+  m_bEnableBFT 1
+  m_bEnableLeadershipRadios 1
+  m_bEnableGIRadios 1
+  m_bEnableRTORadios 1
+ }
+ m_INDFORGearScriptSettings CRF_GearScriptContainer "{64570ACB9AE1C9ED}" {
+  m_rGearScript "{9F4A0C3FCDF3F6DE}Configs/Gearscripts/Standard/80s/CRF_GS_FIA.conf"
+  m_bEnableShareableMarkers 0
+  m_bEnableBFT 1
+  m_bEnableLeadershipRadios 1
+  m_bEnableGIRadios 1
+  m_bEnableRTORadios 1
+ }
+ m_CIVILIANGearScriptSettings CRF_GearScriptContainer "{64570ACB9A9C5C52}" {
+  m_rGearScript "{6FFD426FE0C1079B}Configs/Gearscripts/Standard/80s/CRF_GS_CIV.conf"
+  m_bEnableShareableMarkers 0
+  m_bEnableBFT 1
+  m_bEnableLeadershipRadios 0
+  m_bEnableGIRadios 0
+  m_bEnableRTORadios 0
+ }
+ {
+  SCR_FactionManager "691C06E13D2B489F" {
+   ID "632A77473B3CC3A8"
+   Factions {
+    SCR_Faction "{607AA5C7A94496DA}" {
+     m_aFriendlyFactionsIds {
+      "BLUFOR"
+      "OPFOR"
+      "INDFOR"
+     }
+    }
+    SCR_Faction "{628B22E9B4056C88}" {
+     m_aFriendlyFactionsIds {
+     }
+    }
+    SCR_Faction "{628C2D2BFC8C6447}" {
+     m_aFriendlyFactionsIds {
+     }
+    }
+    SCR_Faction "{628CDE9209CA3FF9}" {
+     m_aFriendlyFactionsIds {
+     }
+    }
+   }
+  }
+ }
+}

--- a/Worlds/Yeonpyeong/Harry_TVT_Counter_Layers/_INIT.layer
+++ b/Worlds/Yeonpyeong/Harry_TVT_Counter_Layers/_INIT.layer
@@ -80,7 +80,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
  m_sFactionOneKey "OPF"
  m_sFactionTwoKey "BLU"
  m_BluforSlots {
-  CRF_SlottingGroup "{691CE0AEB2B552D3}" {
+  CRF_SlottingGroup "{692133169ADF19FE}" {
    m_sCallsign "1PLT"
    m_FlagType SIGNAL
    m_aSlots {
@@ -90,7 +90,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
     DRONE_OPERATOR
    }
   }
-  CRF_SlottingGroup "{691CE0AEB2B55193}" {
+  CRF_SlottingGroup "{692133169ADF1103}" {
    m_sCallsign "Able"
    m_FlagType INFANTRY
    m_aSlots {
@@ -106,7 +106,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
     RIFLEMAN
    }
   }
-  CRF_SlottingGroup "{691CE0AEB2B550F0}" {
+  CRF_SlottingGroup "{692133169ADF1062}" {
    m_sCallsign "Bravo"
    m_FlagType INFANTRY
    m_aSlots {
@@ -122,7 +122,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
     RIFLEMAN
    }
   }
-  CRF_SlottingGroup "{691CE0AEB2B55011}" {
+  CRF_SlottingGroup "{692133169ADF179C}" {
    m_sCallsign "Charlie"
    m_FlagType INFANTRY
    m_aSlots {
@@ -138,7 +138,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
     RIFLEMAN
    }
   }
-  CRF_SlottingGroup "{691CE0AEB2B557B9}" {
+  CRF_SlottingGroup "{692133169ADF16CF}" {
    m_sCallsign "HMG"
    m_FlagType MACHINEGUN
    m_aSlots {
@@ -152,7 +152,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
   }
  }
  m_OpforSlots {
-  CRF_SlottingGroup "{691CE0AEB2B55618}" {
+  CRF_SlottingGroup "{692133169ADF1552}" {
    m_sCallsign "1PLT"
    m_FlagType SIGNAL
    m_aSlots {
@@ -162,7 +162,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
     DRONE_OPERATOR
    }
   }
-  CRF_SlottingGroup "{691CE0AEB2B555B1}" {
+  CRF_SlottingGroup "{692133169ADF14F8}" {
    m_sCallsign "Assault 1"
    m_FlagType INFANTRY
    m_aSlots {
@@ -170,14 +170,14 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
     MEDIC
     TEAM_LEAD
     DRONE_OPERATOR
-    RIFLEMAN
+    ASSISTANT_RIFLEMAN_ANTITANK
     RIFLEMAN
     RIFLEMAN
     RIFLEMAN
     COMBAT_ENGINEER
    }
   }
-  CRF_SlottingGroup "{691CE0AEB2B554D2}" {
+  CRF_SlottingGroup "{692133169ADF142D}" {
    m_sCallsign "MG 1"
    m_FlagType MACHINEGUN
    m_aSlots {
@@ -190,7 +190,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
     ASSISTANT_AUTOMATIC_RIFLEMAN
    }
   }
-  CRF_SlottingGroup "{691CE0AEB2B5546A}" {
+  CRF_SlottingGroup "{692133169ADF0B46}" {
    m_sCallsign "Assault 2"
    m_FlagType INFANTRY
    m_aSlots {
@@ -198,14 +198,14 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
     MEDIC
     TEAM_LEAD
     DRONE_OPERATOR
-    RIFLEMAN
+    ASSISTANT_RIFLEMAN_ANTITANK
     RIFLEMAN
     RIFLEMAN
     RIFLEMAN
     COMBAT_ENGINEER
    }
   }
-  CRF_SlottingGroup "{691CE0AEB2B54B97}" {
+  CRF_SlottingGroup "{692133169ADF0AE2}" {
    m_sCallsign "MG 2"
    m_FlagType MACHINEGUN
    m_aSlots {
@@ -218,7 +218,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
     ASSISTANT_AUTOMATIC_RIFLEMAN
    }
   }
-  CRF_SlottingGroup "{691CE0AEB2B54B37}" {
+  CRF_SlottingGroup "{692133169ADF0A00}" {
    m_sCallsign "Assault 3"
    m_FlagType INFANTRY
    m_aSlots {
@@ -226,15 +226,14 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
     MEDIC
     TEAM_LEAD
     DRONE_OPERATOR
-    RIFLEMAN
-    RIFLEMAN
+    ASSISTANT_RIFLEMAN_ANTITANK
     RIFLEMAN
     RIFLEMAN
     RIFLEMAN
     COMBAT_ENGINEER
    }
   }
-  CRF_SlottingGroup "{691CE0AEB2B54A52}" {
+  CRF_SlottingGroup "{692133169ADF09A0}" {
    m_sCallsign "MG 3"
    m_FlagType MACHINEGUN
    m_aSlots {


### PR DESCRIPTION
This Pull Request will:

Add the mission Counters made by Harry to the repository.

**Mission Creation Checklist:**
- [x] Mission File
- [x] Gearscripts Tested
- [x] Ingame Play Area Markers
- [x] Ingame Briefings to all players
- [x] Side-based briefings  
- [x] Mission .conf file
- [x] PR Contains enough information for an [AAR Post](https://discord.com/channels/237991125523103747/1489488919081779240/1489489341305847890)

**Terrain:**

Yeonpyeong

**GameMode**

Raid

**Slotting Ratio:**

OPFOR 3:2 BLUFOR

**Slot Count**

93

**Time limit:**

45 min

**Faction(s):**

BLUFOR - US 50's defending
BLUFOR Comp: Inf
BLUFOR Assets: HMG

OPFOR - USSR/Korean 50's attacking
OPFOR Comp: Inf
OPFOR Assets: Combat engineers, MG teams

**Objectives/Win Conditions:**

Opfor must attack and destroy at least 50% of the available materiel. Then, they must retreat to the marked area and weather the counter attack from blufor. 

**Short mission description:**

USSR backed Korean forces are conducting a raid on BLUFOR staging areas. 

**Mission Briefing Screenshot:**

<img width="1268" height="739" alt="image" src="https://github.com/user-attachments/assets/bc3539f9-c557-440e-b53c-f548e4b4c4d5" />

**Any Technical testing needed? Triggers? Scripts?:**

Some new gearscripts

**Links to Added Mods**

N/A

**Design concept/thoughts:**

Continuing to test the Raid gamemode, and I was in the mood for a 50's mission. 

**Other Notes:**

The respawn wave will need to be manually triggered after the gamemode is complete.

