### PR TITLE
Fixes VONData not resetting on crashing

### DIFF
--- a/Scripts/Game/Systems/ModdedOverrides/CVON/CRF_CVON_VONController.c
+++ b/Scripts/Game/Systems/ModdedOverrides/CVON/CRF_CVON_VONController.c
@@ -274,6 +274,12 @@ modded class SCR_VONController
 		if (!m_Camera)
 			return;
 		
+		if (!m_bFirstConnect)
+		{
+			WriteJSON(true, true);
+			m_bFirstConnect = true;
+		}
+		
 		m_PlayerIdTemp.Clear();
 		m_PlayerManager.GetPlayers(m_PlayerIdTemp);
 		


### PR DESCRIPTION
Fixes an issue we've been having where if you crash and reconnect with no one around you, your VONData.JSON never writes again until you get closer to another player.