### PR TITLE
Fixes reconnecting during respawn mission

### DIFF
--- a/Scripts/Game/Systems/Core/Managers/Gamemode/CRF_GamemodeManager.c
+++ b/Scripts/Game/Systems/Core/Managers/Gamemode/CRF_GamemodeManager.c
@@ -106,6 +106,12 @@ class CRF_GamemodeManager : SCR_BaseGameModeComponent
 						dataCollector.NotifyPlayerSpawned(playerId, playerCharacter);
 				}
 			}
+			else
+			{
+				//Sends the player the respawn screen if they reconnect while dead
+				if (m_SlottingManager.IsPlayerInASlot(playerId) && m_SlottingManager.IsPlayerConsideredDead(playerId))
+					m_RplBroadcastManager.SendRespawnScreen(playerId);
+			}
 
 			m_RplBroadcastManager.InitilizePlayerBroadcast(playerId, playerRplComp.Id());
 		};


### PR DESCRIPTION
fixes https://github.com/CoalitionArma/Coalition-Reforger-Framework/issues/1382

Potential fix for this, unfortunately cannot test due to dedi tools not keeping your playerId consistent when reconnecting DESPITE BI saying this was fucking fixed in 1.6.

Will need live server testing to truly see if it fixed the issue but it seems we just never checked for respawn conditions when a player inits.