### PR TITLE
Replay Tweaks Harry HVT94 Decisions

### DIFF
--- a/Configs/Gearscripts/Custom/Harry/GWOT/CRF_GS_2000sUS_DCU_PGM.conf
+++ b/Configs/Gearscripts/Custom/Harry/GWOT/CRF_GS_2000sUS_DCU_PGM.conf
@@ -136,13 +136,10 @@ CRF_GearScriptConfig {
   }
  }
  m_SNIPER CRF_Weapon_Class "{690D10FB94E8BF1B}" {
-  m_Weapon "{6325E78EE0925A4A}Prefabs/Weapons/Rifles/SCARH/Rifle_SCARH_FDE_plain.et"
-  m_Attachments {
-   "{30B41A4172CBD098}Prefabs/Weapons/Attachments/Optics/ta31rco/Optic_TA31RCO_ARD_army.et"
-  }
+  m_Weapon "{56CE827F9AD5880E}Prefabs/Weapons/Rifles/M40/Rifle_M40A5_Optic_PEQ.et"
   m_MagazineArray {
    CRF_Magazine_Class "{690D10FB94E8BF1C}" {
-    m_Magazine "{562CF0BA933D781A}Prefabs/Weapons/Magazines/762x51_SCARH_FDE_20rnd/Magazine_762x51_SCARH_FDE_20rnd_4AP_1Tracer_M993_M62.et"
+    m_Magazine "{925F3A6F7FE0DE64}Prefabs/Weapons/Magazines/Magazine_762x51_M40_5rnd_M61AP.et"
     m_MagazineCount 8
    }
   }

--- a/Scripts/Game/GameMode/High Value Target/CRF_HighValueTarget_Game.c
+++ b/Scripts/Game/GameMode/High Value Target/CRF_HighValueTarget_Game.c
@@ -125,6 +125,9 @@ class CRF_HighValueTargetGamemodeManager: SCR_BaseGameModeComponent
 	
 	[Attribute("true", "auto", "Set AI HVTs to unconscious state on spawn.", category: "AI HVT Settings")]
 	bool m_setUnconcious;
+
+	[Attribute("false", "auto", "Send the defenders a message when the transponder updates", category: "AI HVT Settings")]
+	bool m_updateDefender;
 	
 	//------------------------------------------------------------------------------------------------
 	// HVT ENTRIES
@@ -535,13 +538,16 @@ class CRF_HighValueTargetGamemodeManager: SCR_BaseGameModeComponent
 		for (int i = 0; i < entryCount; i++)
 		{
 			vector pos = vector.Zero;
-			
+						
 			// O(1) lookup using reverse map
 			if (m_mEntryToHVT.Contains(i))
 			{
 				IEntity hvtEntity = m_mEntryToHVT.Get(i);
+				
 				if (hvtEntity && IsHVTAlive(hvtEntity))
+				{
 					pos = hvtEntity.GetOrigin();
+				}
 			}
 			
 			m_aHvtPositions.Insert(pos);
@@ -624,6 +630,21 @@ class CRF_HighValueTargetGamemodeManager: SCR_BaseGameModeComponent
 				continue;
 			
 			transponder.SetOrigin(newPos);
+		}
+
+		if (m_updateDefender)
+		{
+			foreach (int index, CRF_HVTEntry entry : m_aHVTEntries)
+			{
+				if (!entry || !m_mEntryToHVT.Contains(index))
+					continue;
+				
+				IEntity hvtEntity = m_mEntryToHVT.Get(index);
+				if (hvtEntity && IsHVTAlive(hvtEntity))
+				{
+					CRF_PlayerRplToAuthorityManager.GetInstance().SendHint("The HVT/VIP marker is updating", -1, entry.GetFactionKey());
+				}
+			}
 		}
 	}
 	

--- a/Worlds/Fallujah/Harry_TVT_Decisions_Layers/POLYZONES.layer
+++ b/Worlds/Fallujah/Harry_TVT_Decisions_Layers/POLYZONES.layer
@@ -25,6 +25,41 @@ PolylineShapeEntity : "{2150339CD6D25BF2}PrefabsMissionMaking/PolyZone/Safestart
   }
  }
 }
+PolylineShapeEntity : "{318DDE6633C34CF1}PrefabsMissionMaking/PolyZone/GameBoundry.et" {
+ coords 4888.367 312.841 6522.623
+ Points {
+  ShapePoint "{693701E984986D22}" {
+   Position -2238.498 0 -726.712
+  }
+  ShapePoint "{693701E98ABC04FD}" {
+   Position -2354.646 0 -120.836
+  }
+  ShapePoint "{693701E98E94C015}" {
+   Position -2373.946 0 297.261
+  }
+  ShapePoint "{693701E993AEC3D5}" {
+   Position -1980.501 0 327.739
+  }
+  ShapePoint "{693701E9943D6B1D}" {
+   Position -1684.832 0 457.995
+  }
+  ShapePoint "{693701E99B93C019}" {
+   Position -1328.488 0 739.648
+  }
+  ShapePoint "{693701E99E0BACC6}" {
+   Position -1220.795 0 818.8
+  }
+  ShapePoint "{693701E99C3FEBB7}" {
+   Position 229.531 0 716.748
+  }
+  ShapePoint "{693701E9E341335F}" {
+   Position 158.808 0 -910.181
+  }
+  ShapePoint "{693701E9F12767C9}" {
+   Position -1651.494 0 -787.317
+  }
+ }
+}
 PolylineShapeEntity : "{36DDFCD0D6C43000}PrefabsMissionMaking/PolyZone/Safestart/INDFOR_SafestartBoundry.et" {
  coords 3244.448 175.207 6691.403
  Points {

--- a/Worlds/Fallujah/Harry_TVT_Decisions_Layers/_INIT.layer
+++ b/Worlds/Fallujah/Harry_TVT_Decisions_Layers/_INIT.layer
@@ -10,6 +10,8 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
  components {
   CRF_HighValueTargetGamemodeManager "{690CF7883A29767A}" {
    m_timeBetweenPings 420
+   m_bInitialPing 1
+   m_updateDefender 1
    m_aHVTEntries {
     CRF_HVTEntry "{690CF7881BA4266E}" {
      m_hvtPrefab "{13FA9557610A1B68}Prefabs/Characters/Factions/IND/MEC/Character_MEC_Civil01.et"
@@ -22,13 +24,15 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
    m_CallInSupportsConfig SCR_CallInSupportContainerConfig "{621B2B44550E77F5}" {
     m_aCallIns {
      SCR_CallInSupportContainer "{613B10C78ECB03E7}" {
-      m_iRequestUsageLimit 3
+      m_iRequestUsageLimit 1
       m_iRequestCooldown 0
       m_iRequestCost 0
       m_eRequiredRank RENEGADE
       m_aAvialableForFactions {
        "BLUFOR"
       }
+      m_iMinSpawnDelay 55
+      m_iMaxSpawnDelay 90
       m_bMustBeSquadLeader 0
       m_iMinNumberOfSquadMembers 0
       m_aRequiredGadgets {
@@ -67,7 +71,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
    m_sTextData "BLUFOR have located an HVT in the marked region of Fallujah. "\
    ""\
    "BLUFOR Composition: Moto Inf"\
-   "BLUFOR Assets: LAVs, Mortars w/ PGMs, Limited Air Strikes, Recon"\
+   "BLUFOR Assets: LAVs, Mortars w/ PGMs, 1 Air Strike, Recon"\
    ""\
    "OPFOR Composition:  Inf"\
    "OPFOR Assets: Unknown"\
@@ -83,7 +87,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
    m_sTextData "Find and eliminate the HVT.  The HVT marker will update every 7 minutes. When the HVT is eliminated, both sides will receive a respawn wave. Blufor is to withdraw troops to the marked FOB, and weather the attack. "\
    ""\
    "Mission Maker Notes"\
-   "Indfor is not allowed to attack the FOB before the HVT dies, unless the enemy is firing mortars from it. Be warned that the enemy has IEDs, and may have concealed them among debris in the AO. "
+   "Indfor is not allowed to attack the FOB before the HVT dies, unless the enemy is firing mortars from it. Be warned that the enemy has IEDs, and may have concealed them among debris in the AO. Understand that the 1 airstrike is an implied threat to strong pointing, and you lose leverage after using it."
    m_aFactionKeys +{
    }
    m_bShowForAnyFaction 0
@@ -97,10 +101,10 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
   }
   CRF_MissionDescriptor "{644250519BE30999}" {
    m_sTitle "INDFOR Objectives"
-   m_sTextData "Protect the HVT. The HVT marker will update every 7 minutes. When the HVT is eliminated, both sides will receive a respawn wave. After respawn, attack and destroy BLUFOR on their way back to the FOB. "\
+   m_sTextData "Protect the HVT. The HVT marker will update every 7 minutes. When the HVT is eliminated, both sides will receive a respawn wave. After respawn, attack and destroy BLUFOR on their way back to the FOB. Indfor is not allowed to attack the FOB before the HVT dies, unless the enemy is firing mortars from it. "\
    ""\
    "Mission Maker Notes"\
-   "Indfor is not allowed to attack the FOB before the HVT dies, unless the enemy is firing mortars from it. "
+   "The enemy has an airstrike that they can use to effectively destroy one strongpoint. It takes a range of 55-90 seconds to arrive after call in, giving you plenty of opportunity to move the HVT in between the marker updating every 7 minutes and the airstrike arriving. Keep the target moving on each update to prevent being airstruck."
    m_aFactionKeys +{
    }
    m_bShowForAnyFaction 0
@@ -118,7 +122,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
  m_sFactionOneKey "BLU"
  m_sFactionTwoKey "IND"
  m_BluforSlots {
-  CRF_SlottingGroup "{691173B27F82421A}" {
+  CRF_SlottingGroup "{693701E94926F20F}" {
    m_sCallsign "1PLT"
    m_FlagType SIGNAL
    m_aSlots {
@@ -128,7 +132,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
     COMBAT_ENGINEER
    }
   }
-  CRF_SlottingGroup "{691173B27F824083}" {
+  CRF_SlottingGroup "{693701E94926F0A2}" {
    m_sCallsign "Recon"
    m_FlagType SNIPER
    m_aSlots {
@@ -136,7 +140,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
     SPOTTER
    }
   }
-  CRF_SlottingGroup "{691173B27F824027}" {
+  CRF_SlottingGroup "{693701E94926F7CC}" {
    m_sCallsign "1-1"
    m_FlagType INFANTRY
    m_aSlots {
@@ -151,7 +155,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
     GRENADIER
    }
   }
-  CRF_SlottingGroup "{691173B27F82475F}" {
+  CRF_SlottingGroup "{693701E94926F5D8}" {
    m_sCallsign "1-2"
    m_FlagType INFANTRY
    m_aSlots {
@@ -166,7 +170,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
     GRENADIER
    }
   }
-  CRF_SlottingGroup "{691173B27F8246F7}" {
+  CRF_SlottingGroup "{693701E94926F502}" {
    m_sCallsign "1-3"
    m_FlagType INFANTRY
    m_aSlots {
@@ -181,7 +185,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
     GRENADIER
    }
   }
-  CRF_SlottingGroup "{691173B27F824613}" {
+  CRF_SlottingGroup "{693701E94926F4B3}" {
    m_sCallsign "1-4"
    m_FlagType INFANTRY
    m_aSlots {
@@ -196,7 +200,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
     GRENADIER
    }
   }
-  CRF_SlottingGroup "{691173B27F8245BB}" {
+  CRF_SlottingGroup "{693701E94926EBD6}" {
    m_sCallsign "1-5"
    m_FlagType INFANTRY
    m_aSlots {
@@ -211,7 +215,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
     GRENADIER
    }
   }
-  CRF_SlottingGroup "{691173B27F8244E6}" {
+  CRF_SlottingGroup "{693701E94926EB78}" {
    m_sCallsign "MTR"
    m_FlagType MORTAR
    m_aSlots {
@@ -224,7 +228,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
   }
  }
  m_IndforSlots {
-  CRF_SlottingGroup "{691173B27F823BB9}" {
+  CRF_SlottingGroup "{693701E94926E9B4}" {
    m_sCallsign "Cell Lead"
    m_FlagType SIGNAL
    m_aSlots {
@@ -232,7 +236,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
     PLATOON_SERGEANT
    }
   }
-  CRF_SlottingGroup "{691173B27F823ADD}" {
+  CRF_SlottingGroup "{693701E94926E8EF}" {
    m_sCallsign "Cell 1"
    m_FlagType INFANTRY
    m_aSlots {
@@ -247,7 +251,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
     RIFLEMAN
    }
   }
-  CRF_SlottingGroup "{691173B27F823A06}" {
+  CRF_SlottingGroup "{693701E94926E806}" {
    m_sCallsign "Cell 2"
    m_FlagType INFANTRY
    m_aSlots {
@@ -262,7 +266,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
     RIFLEMAN
    }
   }
-  CRF_SlottingGroup "{691173B27F8239AD}" {
+  CRF_SlottingGroup "{693701E94926EF9C}" {
    m_sCallsign "Cell 3"
    m_FlagType INFANTRY
    m_aSlots {
@@ -277,16 +281,16 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
     RIFLEMAN
    }
   }
-  CRF_SlottingGroup "{691173B27F8238D3}" {
+  CRF_SlottingGroup "{693701E94926EF37}" {
    m_sCallsign "Suicide Squad"
    m_FlagType MAINTENANCE
    m_aSlots {
     JTAC
-    COMBAT_ENGINEER
-    COMBAT_ENGINEER
+    RIFLEMAN_DEMO
+    RIFLEMAN_DEMO
    }
   }
-  CRF_SlottingGroup "{691173B27F82385A}" {
+  CRF_SlottingGroup "{693701E94926EEBA}" {
    m_sCallsign "Gun Truck 1"
    m_FlagType ARMORED
    m_aSlots {
@@ -295,7 +299,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
     VEHICLE_DRIVER
    }
   }
-  CRF_SlottingGroup "{691173B27F823FF4}" {
+  CRF_SlottingGroup "{693701E94926EE3A}" {
    m_sCallsign "Gun Truck 2"
    m_FlagType ARMORED
    m_aSlots {


### PR DESCRIPTION
This is tweaking a current mission, Decisions, for a replay. When we played it last, Indfor didn't understand the gamemode and it cut short what could have been a cool mission. I think it's worth a second try. 

Changes
 - I've changed the RHS call ins to be limited to 1. It's the inherent threat that keeps indfor moving, and doesn't just devolve into sieging a building. I've also adjusted each side briefing to more directly tell them that. If they want more precision strikes, they'll have to have mortars use PGMs. 
 - changed indfor combat engineers to rifleman demo
 - changed scar to the m40
 - added a game border to prevent super flanks from wasting time
 - added functionality to the HVT game mode with a toggle that updates defenders with a ping when the transponder is updating.

**Terrain:**

Fallujah

**GameMode**

HVT

**Slotting Ratio:**
Blufor 4: Indfor 3

**Slot Count**

94

**Time limit:**

60

**Faction(s):**

BLUFOR - GWOT US Attacking
BLUFOR Comp: Moto Inf
BLUFOR Assets: LAVs, Mortars w/ PGMs, 1 Air strike, Recon

INDFOR - Insurgents Defending
INDFOR Comp: Inf
INDFOR Assets: Unknown


**Objectives/Win Conditions:**

Blufor must kill the HVT, and then retreat to their FOB and survive. 

Indfor must protect the HVT, and then attack Blufor as they retreat. 

**Short mission description:**

Blufor have located an HVT in the marked region of Fallujah. 

**Mission Briefing Screenshot:**

<img width="1361" height="647" alt="image" src="https://github.com/user-attachments/assets/e15b3243-38ca-4072-a749-ca575e402794" />


**Any Technical testing needed? Triggers? Scripts?:**

Added functionality to the HVT gamemode that could use testing.

**Links to Added Mods**

N/A

**Design concept/thoughts:**

N/A

**Other Notes:**

N/A


