### PR TITLE
Make CVON killable

### DIFF
--- a/Scripts/Game/Systems/Core/Entities/CRF_Gamemode.c
+++ b/Scripts/Game/Systems/Core/Entities/CRF_Gamemode.c
@@ -59,6 +59,9 @@ class CRF_Gamemode : SCR_BaseGameMode
 	
 	[Attribute("0", UIWidgets.Hidden)]
 	int m_iSafestartTimeLimit;
+
+	[Attribute("true", UIWidgets.Hidden)]
+	bool m_bUseCVON;
 	
 	[Attribute("", UIWidgets.Hidden)]
 	ref	array<ref CRF_MissionDescriptor> m_aMissionDescriptors;

--- a/Scripts/Game/Systems/ModdedOverrides/CRF_CVON_GamemodeOverride.c
+++ b/Scripts/Game/Systems/ModdedOverrides/CRF_CVON_GamemodeOverride.c
@@ -1,0 +1,25 @@
+// CRF_CVON_GamemodeOverride.c
+// Disables the Coalition VON (CVON) system when the mission designer has unchecked "Use CVON"
+// on the CRF_Lobby entity. When CVON is disabled, the vanilla Arma Reforger in-game VON is
+// restored automatically because CVON_SCR_VONController.ActivateVON() and Init() both guard
+// against a null CVON_VONGameModeComponent instance.
+
+modded class CVON_VONGameModeComponent
+{
+	//------------------------------------------------------------------------------------------------
+	//! After base init runs (and sets m_Instance = this in the constructor), check whether the
+	//! CRF_Gamemode that owns this component has elected to use CVON. If not, clear the static
+	//! instance pointer so every downstream CVON system treats CVON as absent and falls through
+	//! to vanilla VON behaviour.
+	override void OnPostInit(IEntity owner)
+	{
+		super.OnPostInit(owner);
+
+		CRF_Gamemode gamemode = CRF_Gamemode.Cast(owner);
+		if (!gamemode)
+			return;
+
+		if (!gamemode.m_bUseCVON)
+			m_Instance = null;
+	}
+}

--- a/Scripts/Game/Systems/ModdedOverrides/CVON/CRF_CVON_GroupsManagerComponent.c
+++ b/Scripts/Game/Systems/ModdedOverrides/CVON/CRF_CVON_GroupsManagerComponent.c
@@ -1,9 +1,25 @@
 modded class SCR_GroupsManagerComponent
 {
+	// Guard AnyPlayerFrequencies against a null CVON instance (e.g. when m_bUseCVON is false)
+	//==========================================================================================================================================================================
+	override bool AnyPlayerFrequencies(int playerId)
+	{
+		if (!CVON_VONGameModeComponent.GetInstance())
+			return false;
+		return super.AnyPlayerFrequencies(playerId);
+	}
+
 	//Needed so we wait for the group to initialize
 	//==========================================================================================================================================================================
 	override void TuneFreqDelayWithPresets(int playerId, IEntity player)
 	{
+		// If CVON is disabled fall back to vanilla frequency tuning
+		if (!CVON_VONGameModeComponent.GetInstance())
+		{
+			TunePlayersFrequency(playerId, player);
+			return;
+		}
+
 		if (!player)
 			return;
 		

--- a/Scripts/Game/Systems/UI/Menus/Spectator/CRF_SpectatorMenu.c
+++ b/Scripts/Game/Systems/UI/Menus/Spectator/CRF_SpectatorMenu.c
@@ -410,7 +410,41 @@ class CRF_SpectatorMenu: ChimeraMenuBase
 		
 		// Handle spectator camera
 		UpdateSpectatorCamera(tDelta);
-		
+
+		// When CVON is disabled, teleport the spectator entity to follow the camera so that
+		// the entity's SCR_VoNComponent picks up direct voice from nearby alive players.
+		// Uses the same pattern as SCR_Global.TeleportPlayer:
+		//   1. GetWorldTransform (world-space, not local) from the camera
+		//   2. BaseGameEntity.Teleport — updates both physics body and scene-graph, and replicates
+		//      the position to the server for the player-owned character (unlike SetTransform alone)
+		//   3. Zero velocities to prevent any residual physics drift
+		if (!CVON_VONGameModeComponent.GetInstance())
+		{
+			IEntity specEntity = SCR_PlayerController.GetLocalMainEntity();
+			if (specEntity && CRF_EntityHelper.IsSpectator(specEntity))
+			{
+				CameraBase camera = GetGame().GetCameraManager().CurrentCamera();
+				if (camera)
+				{
+					vector mat[4];
+					camera.GetWorldTransform(mat);
+
+					BaseGameEntity bgEntity = BaseGameEntity.Cast(specEntity);
+					if (bgEntity)
+						bgEntity.Teleport(mat);
+					else
+						specEntity.SetWorldTransform(mat);
+
+					Physics phys = specEntity.GetPhysics();
+					if (phys)
+					{
+						phys.SetVelocity(vector.Zero);
+						phys.SetAngularVelocity(vector.Zero);
+					}
+				}
+			}
+		}
+
 		// Update follow-mode HUD overlay
 		m_EntityInfoDisplay.UpdateEntityInfoDisplay(m_eSpecEntity);
 		

--- a/Scripts/Game/Systems/UI/Menus/Spectator/CRF_SpectatorMenu.c
+++ b/Scripts/Game/Systems/UI/Menus/Spectator/CRF_SpectatorMenu.c
@@ -411,13 +411,12 @@ class CRF_SpectatorMenu: ChimeraMenuBase
 		// Handle spectator camera
 		UpdateSpectatorCamera(tDelta);
 
-		// When CVON is disabled, teleport the spectator entity to follow the camera so that
-		// the entity's SCR_VoNComponent picks up direct voice from nearby alive players.
-		// Uses the same pattern as SCR_Global.TeleportPlayer:
-		//   1. GetWorldTransform (world-space, not local) from the camera
-		//   2. BaseGameEntity.Teleport — updates both physics body and scene-graph, and replicates
-		//      the position to the server for the player-owned character (unlike SetTransform alone)
-		//   3. Zero velocities to prevent any residual physics drift
+		// When CVON is disabled, keep the spectator entity's world position in sync with the
+		// camera every frame so vanilla VON proximity checks (server-side) route alive players'
+		// direct speech to the spectator. The camera is a local-only entity with no RplComponent,
+		// so we cannot parent the spectator character to it — we must replicate position explicitly.
+		// BaseGameEntity.Teleport updates the physics body and flushes a position update through
+		// the character replication path, matching the pattern used by PS_PlayableControllerComponent.
 		if (!CVON_VONGameModeComponent.GetInstance())
 		{
 			IEntity specEntity = SCR_PlayerController.GetLocalMainEntity();
@@ -426,21 +425,16 @@ class CRF_SpectatorMenu: ChimeraMenuBase
 				CameraBase camera = GetGame().GetCameraManager().CurrentCamera();
 				if (camera)
 				{
+					// Preserve entity orientation; only update world-space position
 					vector mat[4];
-					camera.GetWorldTransform(mat);
+					specEntity.GetWorldTransform(mat);
+					mat[3] = camera.GetOrigin();
 
 					BaseGameEntity bgEntity = BaseGameEntity.Cast(specEntity);
 					if (bgEntity)
 						bgEntity.Teleport(mat);
 					else
 						specEntity.SetWorldTransform(mat);
-
-					Physics phys = specEntity.GetPhysics();
-					if (phys)
-					{
-						phys.SetVelocity(vector.Zero);
-						phys.SetAngularVelocity(vector.Zero);
-					}
 				}
 			}
 		}

--- a/Scripts/WorkbenchGame/MissionPlugins/CRF_MissionGamemodePlugin.c
+++ b/Scripts/WorkbenchGame/MissionPlugins/CRF_MissionGamemodePlugin.c
@@ -50,6 +50,9 @@ class CRF_MissionGamemodePlugin : WorkbenchPlugin
 	
 	[Attribute("0", desc: "Weather can change during gameplay", category: "CRF Mission Settings - Weather & Time")]
 	protected bool m_bRandomWeatherChanges;
+
+	[Attribute("true", desc: "Use Coalition VON (CVON) for voice communication via TeamSpeak. Uncheck to use the default Arma Reforger in-game VON instead.", category: "CRF Mission Settings - VON")]
+	protected bool m_bUseCVON;
 	
 	//------------------------------------------------------------------------------------------------
 	override void Run()
@@ -76,6 +79,7 @@ class CRF_MissionGamemodePlugin : WorkbenchPlugin
 		m_iRespawnCutoffMinutes = gamemode.m_iRespawnCutoffMinutes;
 		m_bUseSafestartTimeLimit = gamemode.m_bUseSafestartTimeLimit;
 		m_iSafestartTimeLimit = gamemode.m_iSafestartTimeLimit;
+		m_bUseCVON = gamemode.m_bUseCVON;
 		
 		// Weather
 		SCR_TimeAndWeatherHandlerComponent timeAndWeatherComp = SCR_TimeAndWeatherHandlerComponent.Cast(gamemode.FindComponent(SCR_TimeAndWeatherHandlerComponent));
@@ -134,7 +138,8 @@ class CRF_MissionGamemodePlugin : WorkbenchPlugin
 		api.SetVariableValue(entitySource, null, "m_iTimeToRespawn", m_iTimeToRespawn.ToString());
 		api.SetVariableValue(entitySource, null, "m_iRespawnCutoffMinutes", m_iRespawnCutoffMinutes.ToString());
 		api.SetVariableValue(entitySource, null, "m_bUseSafestartTimeLimit", m_bUseSafestartTimeLimit.ToString());
-		api.SetVariableValue(entitySource, null, "m_iSafestartTimeLimit", m_iSafestartTimeLimit.ToString());	
+		api.SetVariableValue(entitySource, null, "m_iSafestartTimeLimit", m_iSafestartTimeLimit.ToString());
+		api.SetVariableValue(entitySource, null, "m_bUseCVON", m_bUseCVON.ToString());	
 		
 		// Weather
 		int componentIndex = SCR_BaseContainerTools.FindComponentIndex(entitySource, SCR_TimeAndWeatherHandlerComponent);

--- a/Worlds/Arland/CRF_LobbyTestWorld_Layers/AAINT.layer
+++ b/Worlds/Arland/CRF_LobbyTestWorld_Layers/AAINT.layer
@@ -37,12 +37,14 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
  coords 1228.604 37.813 2845.828
  m_bRespawnEnabled 0
  m_bWaveRespawn 0
+ m_bRallyPointsEnabled 0
  m_iTimeToRespawn 60
  m_iRespawnCutoffMinutes 0
  m_iTimeLimitMinutes 45
  m_bLockUnusedSlots 1
  m_bUseSafestartTimeLimit 0
  m_iSafestartTimeLimit 15
+ m_bUseCVON 0
  m_iFactionOneRatio 1
  m_iFactionTwoRatio 2
  m_sFactionOneKey "BLU"


### PR DESCRIPTION
Enables the killing of cvon which defaults the game back to in-game von systems. Verified all working to include spectators hearing alive players.