### PR TITLE
Lottery Deslot Fix

### DIFF
--- a/scripts/Game/Systems/Components/Lottery/CRF_SlotLottery.c
+++ b/scripts/Game/Systems/Components/Lottery/CRF_SlotLottery.c
@@ -467,7 +467,7 @@ class CRF_SlotLottery : SCR_BaseGameModeComponent
 
 					int currentSlotId = sm.GetPlayerSlotID(entry.m_iPlayerId);
 					if (currentSlotId > 0)
-						sm.UpdateSlotPlayerID(currentSlotId, -1);
+						sm.UpdateSlotPlayerID(currentSlotId, 0);
 
 					int randomIdx = Math.RandomInt(0, squadSlots.Count());
 					int slotId    = squadSlots[randomIdx];
@@ -505,7 +505,7 @@ class CRF_SlotLottery : SCR_BaseGameModeComponent
 
 				int currentSlotId = sm.GetPlayerSlotID(entry.m_iPlayerId);
 				if (currentSlotId > 0)
-					sm.UpdateSlotPlayerID(currentSlotId, -1);
+					sm.UpdateSlotPlayerID(currentSlotId, 0);
 
 				int randomIdx = Math.RandomInt(0, allAvailableSlots.Count());
 				int slotId    = allAvailableSlots[randomIdx];


### PR DESCRIPTION
Fix for the deslotting bug where a slot emptied by the lottery component wasn't selectable. It was because the playerID for that slot was being set to -1 instead of 0, and when a player tries to select the slot it gets evaluated against if playerID != 0. 