### PR TITLE
Update Solstice

### DIFF
--- a/Worlds/Yeonpyeong/Harry_COOP_Solstice_Layers/MARKERS.layer
+++ b/Worlds/Yeonpyeong/Harry_COOP_Solstice_Layers/MARKERS.layer
@@ -4,209 +4,209 @@ $grp CRF_ManualMarker : "{2C55310F9082A86D}PrefabsMissionMaking/Markers/Objectiv
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 4434.653 88.178 8248.125
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 4434.817 89.211 8196.05
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 4464.738 83.095 8162.582
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 4473.845 86.464 8109.354
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 4494.561 86.374 8069.024
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 4538.352 81.076 8039.178
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 4575.561 81.212 8009.652
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 4798.564 71.855 7940.581
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 4814.261 70.212 7916.882
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 4818.572 69.224 7887.897
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 4843.493 69.649 7853.812
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 4842.07 63.849 7805.924
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 4876.492 51.581 7749.372
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 4356.21 86.949 8208.255
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 4275.424 77.115 8186.404
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 4225.423 72.233 8176.494
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 4194.754 55.626 8217.458
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 4107.712 73.096 8250.632
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 4002.049 81.216 8252.381
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 3917.368 91.413 8255.636
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 3861.625 93.352 8287.771
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 3827.644 87.995 8331.063
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 3773.128 87.984 8365.438
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 3753.379 87.373 8402.685
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 3621.899 78.934 8462.095
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 3587.457 109.71 8430.444
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 3503.833 93.79 8480.724
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 3472.913 92.876 8538.904
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
  {
   coords 3441.752 84.049 8571.311
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sQuadName "dot"
-  m_sDescription "Enemy Entrenchment"
+  m_sDescription "OPFOR Entrenchment"
  }
 }

--- a/Worlds/Yeonpyeong/Harry_COOP_Solstice_Layers/OBJECTIVES.layer
+++ b/Worlds/Yeonpyeong/Harry_COOP_Solstice_Layers/OBJECTIVES.layer
@@ -1,49 +1,3 @@
-$grp CRF_VehicleSpawner {
- {
-  coords 4569.792 22.001 8490.737
-  angles 0 138.879 0
-  m_rVehicle "{753091E32C4E2EE3}Prefabs/Vehicles/Wheeled/Ural_4320_Grad/BM 21-1_9M22.et"
-  m_sFactionKey "BLUFOR"
-  m_aAdditionalVehicleItems {
-   CRF_VehicleGearScriptAdditionalItem "{69AA317B85FC3D9C}" {
-    m_Prefab "{48C72125A134E975}Prefabs/Items/Equipment/BallisticTable/TF_BallisticTable_BM-21.et"
-   }
-  }
- }
- {
-  coords 4728.451 14.692 8582.257
-  angles 0 138.879 0
-  m_rVehicle "{753091E32C4E2EE3}Prefabs/Vehicles/Wheeled/Ural_4320_Grad/BM 21-1_9M22.et"
-  m_sFactionKey "BLUFOR"
-  m_aAdditionalVehicleItems {
-   CRF_VehicleGearScriptAdditionalItem "{69AA317B9279E4E5}" {
-    m_Prefab "{48C72125A134E975}Prefabs/Items/Equipment/BallisticTable/TF_BallisticTable_BM-21.et"
-   }
-  }
- }
- {
-  coords 4656.808 14.473 8580.005
-  angles 0 138.879 0
-  m_rVehicle "{753091E32C4E2EE3}Prefabs/Vehicles/Wheeled/Ural_4320_Grad/BM 21-1_9M22.et"
-  m_sFactionKey "BLUFOR"
-  m_aAdditionalVehicleItems {
-   CRF_VehicleGearScriptAdditionalItem "{69AA317B9279E4E5}" {
-    m_Prefab "{48C72125A134E975}Prefabs/Items/Equipment/BallisticTable/TF_BallisticTable_BM-21.et"
-   }
-  }
- }
- {
-  coords 4501.167 23.105 8490.657
-  angles 0 138.879 0
-  m_rVehicle "{753091E32C4E2EE3}Prefabs/Vehicles/Wheeled/Ural_4320_Grad/BM 21-1_9M22.et"
-  m_sFactionKey "BLUFOR"
-  m_aAdditionalVehicleItems {
-   CRF_VehicleGearScriptAdditionalItem "{69AA3178222EBBBA}" {
-    m_Prefab "{48C72125A134E975}Prefabs/Items/Equipment/BallisticTable/TF_BallisticTable_BM-21.et"
-   }
-  }
- }
-}
 $grp CRF_ManualMarker : "{2C55310F9082A86D}PrefabsMissionMaking/Markers/ObjectiveMarkers/OG/GLOBAL_ObjectiveMarker_et.et" {
  {
   coords 4409.553 90.906 8215.602
@@ -62,23 +16,5 @@ $grp CRF_ManualMarker : "{2C55310F9082A86D}PrefabsMissionMaking/Markers/Objectiv
   angles 0 0 0
   m_MarkerColor 0 0.125 0.502 1
   m_sDescription "HMG"
- }
-}
-$grp CRF_ManualMarker : "{BA688A2E51546A69}PrefabsMissionMaking/Markers/ObjectiveMarkers/OG/OPFOR_ObjectiveMarker.et" {
- {
-  coords 4503.313 23.105 8486.117
-  m_sDescription "Grad"
- }
- {
-  coords 4572.519 22.001 8487.029
-  m_sDescription "Grad"
- }
- {
-  coords 4659.25 14.473 8575.979
-  m_sDescription "Grad"
- }
- {
-  coords 4730.628 14.692 8579.397
-  m_sDescription "Grad"
  }
 }

--- a/Worlds/Yeonpyeong/Harry_COOP_Solstice_Layers/_INIT.layer
+++ b/Worlds/Yeonpyeong/Harry_COOP_Solstice_Layers/_INIT.layer
@@ -20,7 +20,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
  m_bRallyPointsEnabled 1
  m_iTimeToRespawn 360
  m_iRespawnCutoffMinutes 0
- m_iTimeLimitMinutes 90
+ m_iTimeLimitMinutes 110
  m_bLockUnusedSlots 0
  m_bUseSafestartTimeLimit 0
  m_iSafestartTimeLimit 0
@@ -43,33 +43,43 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
    m_bShowForAnyFaction 1
   }
   CRF_MissionDescriptor "{64425051F2E00216}" {
-   m_sTitle "BLUFOR Objectives"
-   m_sTextData "You are here to help push the 1-41 infantry battallion through the heavily defended Yeonpyeong island, and sieze the harbour for our ships. Engineering forces have established a beachhead where we are deploying forces, but it's critical we move quickly to the interior of the island. Be warned that the berms our EVs made are just barely sufficient cover from enemy fire, so keep your head down. The enemy defensive line is marked, with two HMG positions we've identified so far. We're unaware of what other threats are on the island. Find, or make holes in the enemy defenses and help the GI get in. "
+   m_sTitle "Intent- PL Talk to your COY"
+   m_sTextData "BLUFOR PL is intended to communicate regularly with their Zeus, who is playing the role of COY. The players are playing the role of a highly experienced assault group being supported in a company sized fight."
    m_aFactionKeys +{
    }
    m_bShowForAnyFaction 0
   }
   CRF_MissionDescriptor "{64425051B9B5AF67}" {
-   m_sTitle "OPFOR Objectives"
-   m_sTextData "US Forces have landed, and are attempting to sieze the island. While you generally want to push back the invader, you have some specific tasks that will help. "\
-   ""\
-   "- We were pushed back from a vehicle storage prematurely. There are grads left at the marked location. Retrieve as many as you can. "\
-   "- Your forces will need resupply if they are to continue to fight. Ensure that the marked depots are kept full, so that troops stay in fighting condition."
-   m_aFactionKeys +{
+   m_sTitle "BLUFOR Objectives"
+   m_sTextData "You are here to help push the 1-41 infantry battallion through the heavily defended Yeonpyeong island, and sieze the harbour for our ships. Engineering forces have established a beachhead where we are deploying forces, but it's critical we move quickly to the interior of the island. Be warned that the berms our EVs made are just barely sufficient cover from enemy fire, so keep your head down. The enemy defensive line is marked, with two HMG positions we've identified so far. We're unaware of what other threats are on the island. Find, or make holes in the enemy defenses and help the GI get in. "
+   m_aFactionKeys {
+    "BLUFOR"
    }
    m_bShowForAnyFaction 0
   }
   CRF_MissionDescriptor "{644250519BE30999}" {
-   m_sTitle "INDFOR Objectives"
-   m_sTextData "If INDFOR is playable, add mission objectives in bullet point list. Add details for each if you feel necessary, but keep it concise."
-   m_aFactionKeys +{
+   m_sTitle "OPFOR Objectives"
+   m_sTextData "US Forces have landed, and are attempting to sieze the island. While you generally want to push back the invader, you will receive specific taskings from the Zeus who is acting as COY. "
+   m_aFactionKeys {
+    "OPFOR"
    }
    m_bShowForAnyFaction 0
   }
   CRF_MissionDescriptor "{6442505149CF6C93}" {
-   m_sTitle "Administration"
-   m_sTextData "Place any meta or technical information that players should know here. Otherwise, leave empty."
-   m_aFactionKeys +{
+   m_sTitle "INDFOR Objectives"
+   m_sTextData "If INDFOR is playable, add mission objectives in bullet point list. Add details for each if you feel necessary, but keep it concise."
+   m_aFactionKeys {
+    "INDFOR"
+   }
+   m_bShowForAnyFaction 0
+  }
+  CRF_MissionDescriptor "{69B91DF721F93973}" {
+   m_sTitle "Dynamic Taskings"
+   m_sTextData "You may be asked to handle emergent situations by your relevant COY (Zeus). Any global markers added will be explicitly for BLUFOR. OPFOR will receive their taskings over radio."
+   m_aFactionKeys {
+    "BLUFOR"
+    "OPFOR"
+    "INDFOR"
    }
    m_bShowForAnyFaction 0
   }
@@ -207,6 +217,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
  m_iOPFORTickets 4
  m_iINDFORTickets 0
  m_iCIVTickets 0
+ m_bSafestartEnabledOnMissionStart 0
  m_BLUFORGearScriptSettings CRF_GearScriptContainer "{64570ACB9B419A7B}" {
   m_rGearScript "{52AFB3AF94AE003E}Configs/Gearscripts/Standard/Modern/CRF_GS_RHSUSMC_2008.conf"
   m_bEnableShareableMarkers 1


### PR DESCRIPTION
- Removes the BM-21 since it crashed last time
- Replaces OPFOR objectives with dynamic Zeus tasking
- Removes safestart, and adds 20 minutes to timer, to make the time spent on the beach head more immersive
- Adds clarification over intent, dynamic taskings to briefings
- Clarifies entrenchment markings