### PR TITLE
Smoke component change

### DIFF
--- a/Prefabs/Weapons/Ammo/SOV_Ammo_Smoke_Green.et
+++ b/Prefabs/Weapons/Ammo/SOV_Ammo_Smoke_Green.et
@@ -2,6 +2,7 @@ Projectile : "{D40A105437369C1D}Prefabs/Weapons/Core/Ammo_GrenadeLauncher_Base.e
  ID "50C6F965BA00F9FA"
  components {
   TimerTriggerComponent "{61CAF43DD5E4450F}" {
+   Enabled 0
    PROJECTILE_EFFECTS {
     ExplosionEffect "{61CAF43DD5E44501}" {
      EffectPrefab "{19A70761A19A91AA}PrefabsEditable/EffectsModules/Smoke/EffectModule_Smoke_Green.et"
@@ -22,16 +23,15 @@ Projectile : "{D40A105437369C1D}Prefabs/Weapons/Core/Ammo_GrenadeLauncher_Base.e
    Enabled 0
   }
   CollisionTriggerComponent "{61CAF43DD5E44531}" {
-   Enabled 0
+   Enabled 1
    PROJECTILE_EFFECTS {
     ExplosionEffect "{61CAF43DD5E44533}" {
-     EffectPrefab "{729D7EE679AD97E7}Prefabs/Weapons/Warheads/Warhead_Grenade_HE_VOG25.et"
-     ParticleEffect "{728768DE31C8D1DE}Particles/Weapon/Explosion_VOG25.ptc"
-     SoundEvent "SOUND_EXPLOSION"
+     EffectPrefab "{19A70761A19A91AA}PrefabsEditable/EffectsModules/Smoke/EffectModule_Smoke_Green.et"
+     ParticleEffect "{D1C900C94DD3D4B2}Particles/Weapon/Smoke_grenade_M18_Green.ptc"
+     SoundEvent "SOUND_DEPLOY"
     }
    }
    ArmingTime 0
-   SafetyDistance 10
   }
   InventoryItemComponent "{52627A12350994B6}" {
    Attributes SCR_ItemAttributeCollection "{52627A1234AD20A4}" {

--- a/Prefabs/Weapons/Ammo/SOV_Ammo_Smoke_Purple.et
+++ b/Prefabs/Weapons/Ammo/SOV_Ammo_Smoke_Purple.et
@@ -2,6 +2,7 @@ Projectile : "{D40A105437369C1D}Prefabs/Weapons/Core/Ammo_GrenadeLauncher_Base.e
  ID "50C6F965BA00F9FA"
  components {
   TimerTriggerComponent "{61CAF43DCEC63CB3}" {
+   Enabled 0
    PROJECTILE_EFFECTS {
     ExplosionEffect "{61CAF43DCEC63CA6}" {
      EffectPrefab "{1BBEB0BB59A93FFE}PrefabsEditable/EffectsModules/Smoke/EffectModule_Smoke_Purple.et"
@@ -22,16 +23,15 @@ Projectile : "{D40A105437369C1D}Prefabs/Weapons/Core/Ammo_GrenadeLauncher_Base.e
    Enabled 0
   }
   CollisionTriggerComponent "{61CAF43DCEC63D54}" {
-   Enabled 0
+   Enabled 1
    PROJECTILE_EFFECTS {
     ExplosionEffect "{61CAF43DCEC63D57}" {
-     EffectPrefab "{729D7EE679AD97E7}Prefabs/Weapons/Warheads/Warhead_Grenade_HE_VOG25.et"
-     ParticleEffect "{728768DE31C8D1DE}Particles/Weapon/Explosion_VOG25.ptc"
-     SoundEvent "SOUND_EXPLOSION"
+     EffectPrefab "{1BBEB0BB59A93FFE}PrefabsEditable/EffectsModules/Smoke/EffectModule_Smoke_Purple.et"
+     ParticleEffect "{47CA9C7F1E75DBE3}Particles/Weapon/Smoke_grenade_M18_Purple.ptc"
+     SoundEvent "SOUND_DEPLOY"
     }
    }
    ArmingTime 0
-   SafetyDistance 10
   }
   InventoryItemComponent "{52627A12350994B6}" {
    Attributes SCR_ItemAttributeCollection "{52627A1234AD20A4}" {

--- a/Prefabs/Weapons/Ammo/SOV_Ammo_Smoke_Red.et
+++ b/Prefabs/Weapons/Ammo/SOV_Ammo_Smoke_Red.et
@@ -2,6 +2,7 @@ Projectile : "{D40A105437369C1D}Prefabs/Weapons/Core/Ammo_GrenadeLauncher_Base.e
  ID "50C6F965BA00F9FA"
  components {
   TimerTriggerComponent "{61CAF43DD8873B56}" {
+   Enabled 0
    PROJECTILE_EFFECTS {
     ExplosionEffect "{61CAF43DD8873B49}" {
      EffectPrefab "{1F7300EC0835D898}PrefabsEditable/EffectsModules/Smoke/EffectModule_Smoke_Red.et"
@@ -22,16 +23,15 @@ Projectile : "{D40A105437369C1D}Prefabs/Weapons/Core/Ammo_GrenadeLauncher_Base.e
    Enabled 0
   }
   CollisionTriggerComponent "{61CAF43DD8873B7A}" {
-   Enabled 0
+   Enabled 1
    PROJECTILE_EFFECTS {
     ExplosionEffect "{61CAF43DD8873B75}" {
-     EffectPrefab "{729D7EE679AD97E7}Prefabs/Weapons/Warheads/Warhead_Grenade_HE_VOG25.et"
-     ParticleEffect "{728768DE31C8D1DE}Particles/Weapon/Explosion_VOG25.ptc"
-     SoundEvent "SOUND_EXPLOSION"
+     EffectPrefab "{1F7300EC0835D898}PrefabsEditable/EffectsModules/Smoke/EffectModule_Smoke_Red.et"
+     ParticleEffect "{94CAB105E065775C}Particles/Weapon/Smoke_grenade_M18_Red.ptc"
+     SoundEvent "SOUND_DEPLOY"
     }
    }
    ArmingTime 0
-   SafetyDistance 10
   }
   InventoryItemComponent "{52627A12350994B6}" {
    Attributes SCR_ItemAttributeCollection "{52627A1234AD20A4}" {

--- a/Prefabs/Weapons/Ammo/SOV_Ammo_Smoke_White.et
+++ b/Prefabs/Weapons/Ammo/SOV_Ammo_Smoke_White.et
@@ -2,6 +2,7 @@ Projectile : "{D40A105437369C1D}Prefabs/Weapons/Core/Ammo_GrenadeLauncher_Base.e
  ID "50C6F965BA00F9FA"
  components {
   TimerTriggerComponent "{61CAF43E6D135013}" {
+   Enabled 0
    PROJECTILE_EFFECTS {
     ExplosionEffect "{69A51A553DB1C454}" {
      EffectPrefab "{86BF42335C64B008}PrefabsEditable/EffectsModules/Smoke/EffectModule_Smoke_White.et"
@@ -21,16 +22,15 @@ Projectile : "{D40A105437369C1D}Prefabs/Weapons/Core/Ammo_GrenadeLauncher_Base.e
    Enabled 0
   }
   CollisionTriggerComponent "{61CAF43E6D135033}" {
-   Enabled 0
+   Enabled 1
    PROJECTILE_EFFECTS {
     ExplosionEffect "{61CAF43E6D13502D}" {
-     EffectPrefab "{729D7EE679AD97E7}Prefabs/Weapons/Warheads/Warhead_Grenade_HE_VOG25.et"
-     ParticleEffect "{728768DE31C8D1DE}Particles/Weapon/Explosion_VOG25.ptc"
-     SoundEvent "SOUND_EXPLOSION"
+     EffectPrefab "{86BF42335C64B008}PrefabsEditable/EffectsModules/Smoke/EffectModule_Smoke_White.et"
+     ParticleEffect "{273A8DD1950A31DA}Particles/Weapon/Smoke_Mortar_Shell.ptc"
+     SoundEvent "SOUND_DEPLOY"
     }
    }
    ArmingTime 0
-   SafetyDistance 10
   }
   InventoryItemComponent "{52627A12350994B6}" {
    Attributes SCR_ItemAttributeCollection "{52627A1234AD20A4}" {

--- a/Prefabs/Weapons/Ammo/SOV_Ammo_Smoke_Yellow.et
+++ b/Prefabs/Weapons/Ammo/SOV_Ammo_Smoke_Yellow.et
@@ -2,6 +2,7 @@ Projectile : "{D40A105437369C1D}Prefabs/Weapons/Core/Ammo_GrenadeLauncher_Base.e
  ID "50C6F965BA00F9FA"
  components {
   TimerTriggerComponent "{61CAF43DD26C9404}" {
+   Enabled 0
    PROJECTILE_EFFECTS {
     ExplosionEffect "{61CAF43DD26C943E}" {
      EffectPrefab "{94C2FE6E02662E76}PrefabsEditable/EffectsModules/Smoke/EffectModule_Smoke_Yellow.et"
@@ -22,16 +23,15 @@ Projectile : "{D40A105437369C1D}Prefabs/Weapons/Core/Ammo_GrenadeLauncher_Base.e
    Enabled 0
   }
   CollisionTriggerComponent "{61CAF43DD26C942E}" {
-   Enabled 0
+   Enabled 1
    PROJECTILE_EFFECTS {
     ExplosionEffect "{61CAF43DD26C9429}" {
-     EffectPrefab "{729D7EE679AD97E7}Prefabs/Weapons/Warheads/Warhead_Grenade_HE_VOG25.et"
-     ParticleEffect "{728768DE31C8D1DE}Particles/Weapon/Explosion_VOG25.ptc"
-     SoundEvent "SOUND_EXPLOSION"
+     EffectPrefab "{94C2FE6E02662E76}PrefabsEditable/EffectsModules/Smoke/EffectModule_Smoke_Yellow.et"
+     ParticleEffect "{E1E084593B8A05D2}Particles/Weapon/Smoke_grenade_M18_Yellow.ptc"
+     SoundEvent "SOUND_DEPLOY"
     }
    }
    ArmingTime 0
-   SafetyDistance 10
   }
   InventoryItemComponent "{52627A12350994B6}" {
    Attributes SCR_ItemAttributeCollection "{52627A1234AD20A4}" {

--- a/Prefabs/Weapons/Ammo/US_Ammo_Smoke_Green.et
+++ b/Prefabs/Weapons/Ammo/US_Ammo_Smoke_Green.et
@@ -2,6 +2,7 @@ Projectile : "{D40A105437369C1D}Prefabs/Weapons/Core/Ammo_GrenadeLauncher_Base.e
  ID "50C6F965BA00F9FA"
  components {
   TimerTriggerComponent "{61CAE284EB59D20F}" {
+   Enabled 0
    PROJECTILE_EFFECTS {
     ExplosionEffect "{61CAE284EB59D202}" {
      EffectPrefab "{19A70761A19A91AA}PrefabsEditable/EffectsModules/Smoke/EffectModule_Smoke_Green.et"
@@ -22,16 +23,15 @@ Projectile : "{D40A105437369C1D}Prefabs/Weapons/Core/Ammo_GrenadeLauncher_Base.e
    Enabled 0
   }
   CollisionTriggerComponent "{61CAE284EB59D231}" {
-   Enabled 0
+   Enabled 1
    PROJECTILE_EFFECTS {
     ExplosionEffect "{61CAE284EB59D233}" {
-     EffectPrefab "{729D7EE679AD97E7}Prefabs/Weapons/Warheads/Warhead_Grenade_HE_VOG25.et"
-     ParticleEffect "{728768DE31C8D1DE}Particles/Weapon/Explosion_VOG25.ptc"
-     SoundEvent "SOUND_EXPLOSION"
+     EffectPrefab "{19A70761A19A91AA}PrefabsEditable/EffectsModules/Smoke/EffectModule_Smoke_Green.et"
+     ParticleEffect "{D1C900C94DD3D4B2}Particles/Weapon/Smoke_grenade_M18_Green.ptc"
+     SoundEvent "SOUND_DEPLOY"
     }
    }
    ArmingTime 0
-   SafetyDistance 10
   }
   InventoryItemComponent "{52627A12350994B6}" {
    Attributes SCR_ItemAttributeCollection "{52627A1234AD20A4}" {

--- a/Prefabs/Weapons/Ammo/US_Ammo_Smoke_Purple.et
+++ b/Prefabs/Weapons/Ammo/US_Ammo_Smoke_Purple.et
@@ -2,6 +2,7 @@ Projectile : "{D40A105437369C1D}Prefabs/Weapons/Core/Ammo_GrenadeLauncher_Base.e
  ID "50C6F965BA00F9FA"
  components {
   TimerTriggerComponent "{61CAF43AAFBA1073}" {
+   Enabled 0
    PROJECTILE_EFFECTS {
     ExplosionEffect "{61CAF43AAFBA1062}" {
      EffectPrefab "{1BBEB0BB59A93FFE}PrefabsEditable/EffectsModules/Smoke/EffectModule_Smoke_Purple.et"
@@ -22,16 +23,15 @@ Projectile : "{D40A105437369C1D}Prefabs/Weapons/Core/Ammo_GrenadeLauncher_Base.e
    Enabled 0
   }
   CollisionTriggerComponent "{61CAF43AAFBA1013}" {
-   Enabled 0
+   Enabled 1
    PROJECTILE_EFFECTS {
     ExplosionEffect "{61CAF43AAFBA100D}" {
-     EffectPrefab "{729D7EE679AD97E7}Prefabs/Weapons/Warheads/Warhead_Grenade_HE_VOG25.et"
-     ParticleEffect "{728768DE31C8D1DE}Particles/Weapon/Explosion_VOG25.ptc"
-     SoundEvent "SOUND_EXPLOSION"
+     EffectPrefab "{1BBEB0BB59A93FFE}PrefabsEditable/EffectsModules/Smoke/EffectModule_Smoke_Purple.et"
+     ParticleEffect "{47CA9C7F1E75DBE3}Particles/Weapon/Smoke_grenade_M18_Purple.ptc"
+     SoundEvent "SOUND_DEPLOY"
     }
    }
    ArmingTime 0
-   SafetyDistance 10
   }
   InventoryItemComponent "{52627A12350994B6}" {
    Attributes SCR_ItemAttributeCollection "{52627A1234AD20A4}" {

--- a/Prefabs/Weapons/Ammo/US_Ammo_Smoke_Red.et
+++ b/Prefabs/Weapons/Ammo/US_Ammo_Smoke_Red.et
@@ -2,6 +2,7 @@ Projectile : "{D40A105437369C1D}Prefabs/Weapons/Core/Ammo_GrenadeLauncher_Base.e
  ID "50C6F965BA00F9FA"
  components {
   TimerTriggerComponent "{61CAF436738B31DA}" {
+   Enabled 0
    PROJECTILE_EFFECTS {
     ExplosionEffect "{61CAF436738B31CF}" {
      EffectPrefab "{1F7300EC0835D898}PrefabsEditable/EffectsModules/Smoke/EffectModule_Smoke_Red.et"
@@ -22,16 +23,15 @@ Projectile : "{D40A105437369C1D}Prefabs/Weapons/Core/Ammo_GrenadeLauncher_Base.e
    Enabled 0
   }
   CollisionTriggerComponent "{61CAF436738B31F9}" {
-   Enabled 0
+   Enabled 1
    PROJECTILE_EFFECTS {
     ExplosionEffect "{61CAF436738B31F4}" {
-     EffectPrefab "{729D7EE679AD97E7}Prefabs/Weapons/Warheads/Warhead_Grenade_HE_VOG25.et"
-     ParticleEffect "{728768DE31C8D1DE}Particles/Weapon/Explosion_VOG25.ptc"
-     SoundEvent "SOUND_EXPLOSION"
+     EffectPrefab "{1F7300EC0835D898}PrefabsEditable/EffectsModules/Smoke/EffectModule_Smoke_Red.et"
+     ParticleEffect "{94CAB105E065775C}Particles/Weapon/Smoke_grenade_M18_Red.ptc"
+     SoundEvent "SOUND_DEPLOY"
     }
    }
    ArmingTime 0
-   SafetyDistance 10
   }
   InventoryItemComponent "{52627A12350994B6}" {
    Attributes SCR_ItemAttributeCollection "{52627A1234AD20A4}" {

--- a/Prefabs/Weapons/Ammo/US_Ammo_Smoke_White.et
+++ b/Prefabs/Weapons/Ammo/US_Ammo_Smoke_White.et
@@ -2,6 +2,7 @@ Projectile : "{D40A105437369C1D}Prefabs/Weapons/Core/Ammo_GrenadeLauncher_Base.e
  ID "50C6F965BA00F9FA"
  components {
   TimerTriggerComponent "{61CAF435739E1D40}" {
+   Enabled 0
    PROJECTILE_EFFECTS {
     ExplosionEffect "{69A51A54C324FB24}" {
      EffectPrefab "{86BF42335C64B008}PrefabsEditable/EffectsModules/Smoke/EffectModule_Smoke_White.et"
@@ -21,16 +22,15 @@ Projectile : "{D40A105437369C1D}Prefabs/Weapons/Core/Ammo_GrenadeLauncher_Base.e
    Enabled 0
   }
   CollisionTriggerComponent "{61CAF435739E1D65}" {
-   Enabled 0
+   Enabled 1
    PROJECTILE_EFFECTS {
     ExplosionEffect "{61CAF435739E1D67}" {
-     EffectPrefab "{729D7EE679AD97E7}Prefabs/Weapons/Warheads/Warhead_Grenade_HE_VOG25.et"
-     ParticleEffect "{728768DE31C8D1DE}Particles/Weapon/Explosion_VOG25.ptc"
-     SoundEvent "SOUND_EXPLOSION"
+     EffectPrefab "{86BF42335C64B008}PrefabsEditable/EffectsModules/Smoke/EffectModule_Smoke_White.et"
+     ParticleEffect "{273A8DD1950A31DA}Particles/Weapon/Smoke_Mortar_Shell.ptc"
+     SoundEvent "SOUND_DEPLOY"
     }
    }
    ArmingTime 0
-   SafetyDistance 10
   }
   InventoryItemComponent "{52627A12350994B6}" {
    Attributes SCR_ItemAttributeCollection "{52627A1234AD20A4}" {

--- a/Prefabs/Weapons/Ammo/US_Ammo_Smoke_Yellow.et
+++ b/Prefabs/Weapons/Ammo/US_Ammo_Smoke_Yellow.et
@@ -2,6 +2,7 @@ Projectile : "{D40A105437369C1D}Prefabs/Weapons/Core/Ammo_GrenadeLauncher_Base.e
  ID "50C6F965BA00F9FA"
  components {
   TimerTriggerComponent "{61CAF43AA77C2508}" {
+   Enabled 0
    PROJECTILE_EFFECTS {
     ExplosionEffect "{61CAF43AA77C2503}" {
      EffectPrefab "{94C2FE6E02662E76}PrefabsEditable/EffectsModules/Smoke/EffectModule_Smoke_Yellow.et"
@@ -22,16 +23,15 @@ Projectile : "{D40A105437369C1D}Prefabs/Weapons/Core/Ammo_GrenadeLauncher_Base.e
    Enabled 0
   }
   CollisionTriggerComponent "{61CAF43AA77C2532}" {
-   Enabled 0
+   Enabled 1
    PROJECTILE_EFFECTS {
     ExplosionEffect "{61CAF43AA77C252D}" {
-     EffectPrefab "{729D7EE679AD97E7}Prefabs/Weapons/Warheads/Warhead_Grenade_HE_VOG25.et"
-     ParticleEffect "{728768DE31C8D1DE}Particles/Weapon/Explosion_VOG25.ptc"
-     SoundEvent "SOUND_EXPLOSION"
+     EffectPrefab "{94C2FE6E02662E76}PrefabsEditable/EffectsModules/Smoke/EffectModule_Smoke_Yellow.et"
+     ParticleEffect "{E1E084593B8A05D2}Particles/Weapon/Smoke_grenade_M18_Yellow.ptc"
+     SoundEvent "SOUND_DEPLOY"
     }
    }
    ArmingTime 0
-   SafetyDistance 10
   }
   InventoryItemComponent "{52627A12350994B6}" {
    Attributes SCR_ItemAttributeCollection "{52627A1234AD20A4}" {


### PR DESCRIPTION
Moves the 40mm smoke grenade from a timer trigger to a collision trigger. You may lose the canister bouncing, or rolling, but the effect should more reliably deploy which is more important. 