### PR TITLE
Shieldwall2 Spawn Fix

### DIFF
--- a/Prefabs/Weapons/Grenades/MagicGrenades/GrenadeAOEs/Damage_PoisonArea.et
+++ b/Prefabs/Weapons/Grenades/MagicGrenades/GrenadeAOEs/Damage_PoisonArea.et
@@ -5,13 +5,14 @@ GenericEntity : "{A19A22F731C8C3E6}Prefabs/Systems/DamageAreas/DamageArea_Kolguy
    DamageAreas {
     SCR_DotDamageArea "{6646DB3FF2DCC4EC}" {
      "Area shape" DamageAreaShapeSphere "{68C9569BF41138E4}" {
-      Radius 6.5
+      Radius 5.5
      }
      m_eDamageType FIRE
      m_bRemoveEffectWhenLeavingTheArea 1
      m_eHitZoneSelectionMode RANDOM_PHYSICAL
-     m_fDotDamage 1.25
-     m_fEffectDuration 2
+     m_fDotDamage 1
+     m_fEffectDuration 1.25
+     m_bAddDurationOnExit 0
      m_eDotDamageType FIRE
     }
    }

--- a/Worlds/Mogadishu/Trist_SPCL_Shieldwall2_Layers/_INIT.layer
+++ b/Worlds/Mogadishu/Trist_SPCL_Shieldwall2_Layers/_INIT.layer
@@ -16,6 +16,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
       }
       CRF_Rush_RespawnPointEntry "{69EF59A752797A40}" {
        m_sMarkerEntityName "spawnopf_2"
+       m_eFaction "OPFOR"
       }
      }
     }
@@ -27,6 +28,7 @@ CRF_Gamemode CRF_Lobby : "{6A996BBFCEB37E78}Prefabs/Systems/!Lobby/CRF_Lobby.et"
       }
       CRF_Rush_RespawnPointEntry "{69EF59A744A5A3A2}" {
        m_sMarkerEntityName "spawnopf_3"
+       m_eFaction "OPFOR"
       }
      }
     }


### PR DESCRIPTION
The spawns hadnt saved correctly when played and kinda flubbed up the melee SPCL, this fixes it. On a side note, WB certainly sometimes just decides not to save property changes of components within the layer files some reason.